### PR TITLE
feat(cli): add init --from claude to import existing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+- `agnostic-ai init --from claude`: import existing `CLAUDE.md`, `.claude/agents/`, `.claude/skills/`, and `.claude/settings.json` into agnostic source specs. Lowers adoption friction for users with populated Claude Code configs.
+- `agnostic-ai sync --check` and `agnostic-ai doctor`: detect drift between source specs and emitted target files. Use as CI gate.
+- `x-<target>` frontmatter namespace: per-adapter extensions (e.g. `x-claude:`, `x-cursor:`) flatten for the matching target and are stripped for others.
 - Initial Go scaffold.
 - Adapters for Claude Code, Codex, Gemini CLI, Cursor, GitHub Copilot, Aider, Cline, Windsurf, Continue.
 - Commands: `init`, `sync`, `validate`, `list`.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -16,8 +16,25 @@ agnostic-ai [command] [flags]
 Scaffold a project: `agnostic.config.yaml` plus empty `agents/`, `skills/`, `rules/`, `hooks/`. Errors if `agnostic.config.yaml` exists.
 
 ```bash
-agnostic-ai init
+agnostic-ai init                  # empty scaffold
+agnostic-ai init --from claude    # import existing Claude Code config
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--from <source>` | Import existing config from a source. Supported: `claude`. |
+
+`--from claude` reads the current directory:
+
+| Source | Becomes |
+|--------|---------|
+| `CLAUDE.md` (split on `## headings`) | `rules/<slug>.md` per section |
+| `CLAUDE.md` (no headings) | single `rules/<projectname>.md` |
+| `.claude/agents/*.md` | `agents/<name>.md` (byte-identical copy) |
+| `.claude/skills/<name>/SKILL.md` | `skills/<name>/SKILL.md` |
+| `.claude/settings.json` hooks | `hooks/<event>-<group>-<index>.yaml` |
+
+Writes `targets: [claude]` only. Add other targets to the config and run `agnostic-ai sync`.
 
 ## validate
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -33,6 +33,14 @@ agnostic-ai init
 └── hooks/
 ```
 
+### Already on Claude Code?
+
+```bash
+agnostic-ai init --from claude
+```
+
+Reads `CLAUDE.md` and `.claude/` from the current directory, writes equivalent agnostic specs and a `targets: [claude]` config. Add more targets to the config and run `agnostic-ai sync`.
+
 ## First rule
 
 `rules/conventional-commits.md`:

--- a/internal/adapters/internal/emit/meta.go
+++ b/internal/adapters/internal/emit/meta.go
@@ -12,9 +12,10 @@ const XPrefix = "x-"
 // for the named target and `x-*` keys for other targets dropped.
 //
 // Example: meta = {name: r1, x-claude: {allowed-tools: [Read]}, x-cursor: {globs: "src/**"}}
-//   ResolveMeta(meta, "claude") -> {name: r1, allowed-tools: [Read]}
-//   ResolveMeta(meta, "cursor") -> {name: r1, globs: "src/**"}
-//   ResolveMeta(meta, "gemini") -> {name: r1}
+//
+//	ResolveMeta(meta, "claude") -> {name: r1, allowed-tools: [Read]}
+//	ResolveMeta(meta, "cursor") -> {name: r1, globs: "src/**"}
+//	ResolveMeta(meta, "gemini") -> {name: r1}
 //
 // Adapter-owned keys overwrite top-level keys with the same name.
 func ResolveMeta(meta map[string]any, target string) map[string]any {

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -1,0 +1,308 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const claudeOnlyConfig = `version: 1
+
+sources:
+  agents: agents
+  skills: skills
+  rules: rules
+  hooks: hooks
+
+targets:
+  - claude
+
+on-unsupported: warn
+`
+
+type importCounts struct{ rules, agents, skills, hooks int }
+
+// importFromClaude scaffolds an agnostic-ai project by reading existing
+// Claude Code config (CLAUDE.md and .claude/) under root. Refuses if
+// agnostic.config.yaml already exists.
+func importFromClaude(root string) error {
+	cfgPath := filepath.Join(root, "agnostic.config.yaml")
+	if _, err := os.Stat(cfgPath); err == nil {
+		return fmt.Errorf("agnostic.config.yaml already exists")
+	}
+	if err := ensureSourceDirs(root); err != nil {
+		return err
+	}
+
+	c := importCounts{}
+	var err error
+	if c.rules, err = importClaudeRules(root); err != nil {
+		return err
+	}
+	if c.agents, err = importClaudeAgents(root); err != nil {
+		return err
+	}
+	if c.skills, err = importClaudeSkills(root); err != nil {
+		return err
+	}
+	if c.hooks, err = importClaudeHooks(root); err != nil {
+		return err
+	}
+	if err := os.WriteFile(cfgPath, []byte(claudeOnlyConfig), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", cfgPath, err)
+	}
+	fmt.Printf("imported %d rules, %d agents, %d skills, %d hooks\n",
+		c.rules, c.agents, c.skills, c.hooks)
+	return nil
+}
+
+func ensureSourceDirs(root string) error {
+	for _, d := range []string{"agents", "skills", "rules", "hooks"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", d, err)
+		}
+	}
+	return nil
+}
+
+// importClaudeRules splits CLAUDE.md on `## ` headings into one rule file
+// per section. Without headings it writes a single rule named after the
+// project directory.
+func importClaudeRules(root string) (int, error) {
+	src := filepath.Join(root, "CLAUDE.md")
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+
+	sections := splitH2Sections(string(data))
+	if len(sections) == 0 {
+		body := strings.TrimSpace(string(data))
+		if body == "" {
+			return 0, nil
+		}
+		name := projectSlug(root)
+		path := filepath.Join(root, "rules", name+".md")
+		if err := writeRule(path, name, body); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+	for _, s := range sections {
+		path := filepath.Join(root, "rules", s.slug+".md")
+		if err := writeRule(path, s.slug, s.body); err != nil {
+			return 0, err
+		}
+	}
+	return len(sections), nil
+}
+
+type h2Section struct{ slug, body string }
+
+var h2HeadingRE = regexp.MustCompile(`(?m)^##[ \t]+(.+?)[ \t]*$`)
+
+// splitH2Sections returns one section per `## heading`. Slug collisions
+// are deduplicated with -2, -3 suffixes. Content before the first heading
+// is discarded.
+func splitH2Sections(s string) []h2Section {
+	idx := h2HeadingRE.FindAllStringSubmatchIndex(s, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	out := make([]h2Section, 0, len(idx))
+	used := map[string]int{}
+	for i, m := range idx {
+		title := s[m[2]:m[3]]
+		base := slugify(title)
+		if base == "" {
+			base = fmt.Sprintf("section-%d", i+1)
+		}
+		slug := base
+		if n, exists := used[base]; exists {
+			used[base] = n + 1
+			slug = fmt.Sprintf("%s-%d", base, n+1)
+		} else {
+			used[base] = 1
+		}
+		bodyStart := m[1]
+		bodyEnd := len(s)
+		if i+1 < len(idx) {
+			bodyEnd = idx[i+1][0]
+		}
+		body := strings.TrimSpace(s[bodyStart:bodyEnd])
+		out = append(out, h2Section{slug: slug, body: body})
+	}
+	return out
+}
+
+var nonAlphaNumRE = regexp.MustCompile(`[^a-z0-9]+`)
+
+// slugify lowercases and collapses non-alphanumeric runs into single
+// hyphens. Leading/trailing hyphens trimmed.
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	s = nonAlphaNumRE.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+// projectSlug returns the basename of root, slugified. Falls back to
+// "project" for unresolvable paths.
+func projectSlug(root string) string {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "project"
+	}
+	s := slugify(filepath.Base(abs))
+	if s == "" {
+		return "project"
+	}
+	return s
+}
+
+func writeRule(path, name, body string) error {
+	fm := fmt.Sprintf("---\nname: %s\n---\n\n", name)
+	if err := os.WriteFile(path, []byte(fm+body+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// importClaudeAgents copies .claude/agents/*.md byte-for-byte to agents/.
+func importClaudeAgents(root string) (int, error) {
+	src := filepath.Join(root, ".claude", "agents")
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			return count, fmt.Errorf("read agent %s: %w", e.Name(), err)
+		}
+		dst := filepath.Join(root, "agents", e.Name())
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", dst, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// importClaudeSkills copies each .claude/skills/<name>/SKILL.md to
+// skills/<name>/SKILL.md. Other files inside the skill dir are ignored.
+func importClaudeSkills(root string) (int, error) {
+	src := filepath.Join(root, ".claude", "skills")
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		skillPath := filepath.Join(src, e.Name(), "SKILL.md")
+		data, err := os.ReadFile(skillPath)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return count, fmt.Errorf("read skill %s: %w", e.Name(), err)
+		}
+		dstDir := filepath.Join(root, "skills", e.Name())
+		if err := os.MkdirAll(dstDir, 0o755); err != nil {
+			return count, fmt.Errorf("mkdir %s: %w", dstDir, err)
+		}
+		dst := filepath.Join(dstDir, "SKILL.md")
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", dst, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+type claudeHookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+type claudeHookGroup struct {
+	Matcher string              `json:"matcher"`
+	Hooks   []claudeHookCommand `json:"hooks"`
+}
+
+type claudeSettings struct {
+	Hooks map[string][]claudeHookGroup `json:"hooks"`
+}
+
+// importClaudeHooks reads .claude/settings.json and writes one yaml per
+// hook command into hooks/<event>-<group>-<index>.yaml.
+func importClaudeHooks(root string) (int, error) {
+	src := filepath.Join(root, ".claude", "settings.json")
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	var s claudeSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return 0, fmt.Errorf("parse %s: %w", src, err)
+	}
+	if len(s.Hooks) == 0 {
+		return 0, nil
+	}
+	events := make([]string, 0, len(s.Hooks))
+	for e := range s.Hooks {
+		events = append(events, e)
+	}
+	sort.Strings(events)
+
+	count := 0
+	for _, event := range events {
+		for gi, g := range s.Hooks[event] {
+			for hi, h := range g.Hooks {
+				name := fmt.Sprintf("%s-%d-%d", strings.ToLower(event), gi+1, hi+1)
+				doc := map[string]any{
+					"name":    name,
+					"event":   event,
+					"matcher": g.Matcher,
+					"command": h.Command,
+				}
+				raw, err := yaml.Marshal(doc)
+				if err != nil {
+					return count, fmt.Errorf("marshal hook %s: %w", name, err)
+				}
+				path := filepath.Join(root, "hooks", name+".yaml")
+				if err := os.WriteFile(path, raw, 0o644); err != nil {
+					return count, fmt.Errorf("write %s: %w", path, err)
+				}
+				count++
+			}
+		}
+	}
+	return count, nil
+}

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestImportFromClaude_RefusesIfConfigExists(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "agnostic.config.yaml"), "version: 1\n")
+	if err := importFromClaude(dir); err == nil {
+		t.Error("expected error when config already exists")
+	}
+}
+
+func TestImportFromClaude_SplitsRulesByH2(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), `# Project
+
+## conventional-commits
+
+Use feat:, fix:, etc.
+
+## go-style
+
+gofmt clean.
+`)
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"conventional-commits", "go-style"} {
+		path := filepath.Join(dir, "rules", name+".md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("missing %s: %v", path, err)
+		}
+		if !strings.Contains(string(data), "name: "+name) {
+			t.Errorf("expected frontmatter name: %s in %s", name, data)
+		}
+	}
+}
+
+func TestImportFromClaude_MonolithicRules(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "Just a flat doc with no headings.\n")
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, "rules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(entries))
+	}
+}
+
+func TestImportFromClaude_NoClaudeMd(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(dir, "rules"))
+	if len(entries) != 0 {
+		t.Errorf("expected empty rules/, got %d entries", len(entries))
+	}
+}
+
+func TestImportFromClaude_CopiesAgents(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nname: reviewer\nmodel: sonnet\n---\nReview diffs.\n"
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "reviewer.md"), body)
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "agents", "reviewer.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Errorf("agent not byte-identical. got %q", got)
+	}
+}
+
+func TestImportFromClaude_CopiesSkills(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nname: validator\n---\nValidate yaml.\n"
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "validator", "SKILL.md"), body)
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "skills", "validator", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Errorf("skill not byte-identical. got %q", got)
+	}
+}
+
+func TestImportFromClaude_ImportsHooks(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "hooks": {
+    "PostToolUse": [
+      {"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "fmt"}]}
+    ]
+  }
+}`
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), settings)
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "hooks", "posttooluse-1-1.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("missing %s: %v", path, err)
+	}
+	for _, want := range []string{"event: PostToolUse", "matcher: Edit|Write", "command: fmt"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("expected %q in %s", want, data)
+		}
+	}
+}
+
+func TestImportFromClaude_MultipleHookCommandsPerGroup(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "hooks": {
+    "PostToolUse": [
+      {"matcher": "Edit", "hooks": [
+        {"type": "command", "command": "fmt"},
+        {"type": "command", "command": "lint"}
+      ]}
+    ]
+  }
+}`
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), settings)
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"posttooluse-1-1.yaml", "posttooluse-1-2.yaml"} {
+		if _, err := os.Stat(filepath.Join(dir, "hooks", name)); err != nil {
+			t.Errorf("missing %s", name)
+		}
+	}
+}
+
+func TestImportFromClaude_MalformedSettings(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), "{not json")
+	if err := importFromClaude(dir); err == nil {
+		t.Error("expected parse error on malformed settings.json")
+	}
+}
+
+func TestImportFromClaude_WritesClaudeOnlyConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromClaude(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "- claude") {
+		t.Errorf("expected claude target, got %s", data)
+	}
+	if strings.Contains(string(data), "- cursor") {
+		t.Errorf("expected only claude target, got %s", data)
+	}
+}
+
+func TestSlugify_Collisions(t *testing.T) {
+	in := "## Go Style\n\nfoo\n\n## go-style\n\nbar\n"
+	got := splitH2Sections(in)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(got))
+	}
+	if got[0].slug != "go-style" || got[1].slug != "go-style-2" {
+		t.Errorf("expected go-style, go-style-2; got %s, %s", got[0].slug, got[1].slug)
+	}
+}
+
+func TestInitCmd_UnknownFromRejected(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"init", "--from", "cursor"})
+	if err := root.Execute(); err == nil {
+		t.Error("expected error for unknown --from")
+	}
+}
+
+func TestInitCmd_FromClaudeRoutes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "## r1\n\nbody\n")
+	chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"init", "--from", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "r1.md")); err != nil {
+		t.Error("expected rules/r1.md after init --from claude")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -109,13 +109,23 @@ func newListCmd() *cobra.Command {
 }
 
 func newInitCmd() *cobra.Command {
-	return &cobra.Command{
+	var from string
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Scaffold an agnostic-ai project in the current directory.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return scaffold(".")
+			switch from {
+			case "":
+				return scaffold(".")
+			case "claude":
+				return importFromClaude(".")
+			default:
+				return fmt.Errorf("unknown source for --from: %q (supported: claude)", from)
+			}
 		},
 	}
+	cmd.Flags().StringVar(&from, "from", "", "Import existing config from a source (supported: claude)")
+	return cmd
 }
 
 // loadProject loads config and bundle from root.


### PR DESCRIPTION
## Summary
- Reverse-import: scaffold agnostic source specs from an existing Claude Code setup. Reads `CLAUDE.md` plus `.claude/{agents,skills,settings.json}` in cwd.
- `## headings` in `CLAUDE.md` split into one rule per section; monolithic file becomes one rule named after the project dir. Agents and skills copy byte-for-byte. Hooks expand to one yaml per command.
- Writes `targets: [claude]` only; user adds other targets and runs `sync`.
- Lowers the #1 adoption blocker for users who already have a populated Claude config.

## Decisions baked in
- Slug collisions in headings: append `-2`, `-3`. Never refuse importable input.
- Multiple commands per matcher group in `settings.json`: indexed pair filenames (`posttooluse-1-1.yaml`, `posttooluse-1-2.yaml`). No command dropped.
- Re-run guard: relies on existing `agnostic.config.yaml` check.
- Monolithic rule slug: `filepath.Base(absRoot)` slugified.
- Scope: cwd only. Skips `~/.claude/` and `settings.local.json`.

## Test plan
- [x] Unit: hermetic tempdir tests cover refuse-on-existing-config, H2 split, monolithic, missing CLAUDE.md, agent copy, skill copy, hooks (single + multi-command), malformed JSON, claude-only config, slug collisions.
- [x] CLI routing: unknown `--from` rejected; `--from claude` round-trips end-to-end.
- [x] Smoke test against this repo's own `.claude/`: `imported 4 rules, 2 agents, 1 skills, 2 hooks`.
- [ ] CI: `go test ./...`, `go vet`, `gofmt`, golangci-lint green.