### PR TITLE
chore(release): add scripts/release.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,17 @@ jobs:
 
       - name: Build
         run: go build ./...
+
+  shell:
+    name: Shell tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install bashunit
+        run: |
+          curl -s https://bashunit.typeddevs.com/install.sh | bash -s -- /usr/local/bin
+
+      - name: Run release.sh tests
+        run: bashunit scripts/release_test.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-race coverage coverage-html install clean release
+.PHONY: build test test-race test-shell coverage coverage-html install clean release
 
 BIN := agnostic-ai
 PKG := ./cmd/agnostic-ai
@@ -11,6 +11,9 @@ test:
 
 test-race:
 	go test -race ./...
+
+test-shell:
+	bashunit scripts/release_test.sh
 
 coverage:
 	go test -coverpkg=./internal/...,./cmd/... -coverprofile=coverage.out ./...

--- a/docs/internal/release-process.md
+++ b/docs/internal/release-process.md
@@ -10,12 +10,30 @@ Semantic Versioning. Pre-1.0:
 
 ## Cutting a release
 
+Use the script:
+
+```bash
+scripts/release.sh vX.Y.Z              # full run: bump, tag, push
+scripts/release.sh vX.Y.Z --dry-run    # preview only
+scripts/release.sh vX.Y.Z --no-push    # commit + tag locally
+```
+
+The script:
+
+1. Validates clean tree, on `main`, in sync with `origin/main`, tag does not exist.
+2. Runs `gofmt -s -l`, `go vet`, `go test ./...`, `agnostic-ai sync --check`.
+3. Bumps `version` in `cmd/agnostic-ai/main.go`.
+4. Promotes `[Unreleased]` in `CHANGELOG.md` to `[vX.Y.Z]` with today's date and inserts a fresh `[Unreleased]` block above.
+5. Commits `chore(release): vX.Y.Z` and tags `vX.Y.Z` (annotated).
+6. Pushes `main` and the tag. CI fires GoReleaser, which publishes binaries.
+
+Manual fallback (only if the script can't run):
+
 1. Update `version` in `cmd/agnostic-ai/main.go`
 2. Update `CHANGELOG.md`
 3. `git commit -m "chore(release): vX.Y.Z"`
 4. `git tag vX.Y.Z`
 5. `git push origin main --tags`
-6. CI builds binaries and publishes to GitHub Releases
 
 ## Cross-compile manually
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# release.sh — cut a new agnostic-ai release.
+#
+# Usage:
+#   scripts/release.sh vX.Y.Z              # cut and push
+#   scripts/release.sh vX.Y.Z --dry-run    # preview only; touches no files
+#   scripts/release.sh vX.Y.Z --no-push    # commit and tag locally; do not push
+#
+# What it does (in order):
+#   1. Validate inputs and git state (clean tree, on main, in sync with origin).
+#   2. Run go vet, gofmt -s -l, go test ./..., agnostic-ai sync --check.
+#   3. Bump `version` in cmd/agnostic-ai/main.go.
+#   4. Promote [Unreleased] in CHANGELOG.md to [vX.Y.Z] with today's date and
+#      insert a fresh empty [Unreleased] block above it.
+#   5. Commit `chore(release): vX.Y.Z`.
+#   6. Create annotated tag vX.Y.Z.
+#   7. Push main and tag. CI builds binaries via GoReleaser.
+
+set -Eeuo pipefail
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+note() { printf '→ %s\n' "$*"; }
+
+# --- args ---------------------------------------------------------------------
+
+VERSION=""
+DRY_RUN=0
+NO_PUSH=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --no-push) NO_PUSH=1 ;;
+    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
+    v*) VERSION="$arg" ;;
+    *)  die "unknown arg: $arg" ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || die "missing version. example: scripts/release.sh v0.2.0"
+[[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]] \
+  || die "version must match vMAJOR.MINOR.PATCH (or vMAJOR.MINOR.PATCH-pre)"
+
+PLAIN="${VERSION#v}"
+DATE="$(date +%Y-%m-%d)"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+note "version: $VERSION"
+note "date:    $DATE"
+[[ $DRY_RUN -eq 1 ]] && note "mode:    dry-run (no writes, no commits, no push)"
+[[ $NO_PUSH -eq 1 && $DRY_RUN -eq 0 ]] && note "mode:    --no-push (commit + tag only)"
+
+# --- preflight ----------------------------------------------------------------
+
+note "preflight: git state"
+[[ -z "$(git status --porcelain)" ]] || die "working tree dirty. commit or stash first."
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[[ "$BRANCH" == "main" ]] || die "must release from main, on $BRANCH"
+
+git fetch origin main --quiet
+LOCAL="$(git rev-parse @)"
+REMOTE="$(git rev-parse @{u})"
+[[ "$LOCAL" == "$REMOTE" ]] || die "local main not in sync with origin. pull or push first."
+
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+  die "tag $VERSION already exists"
+fi
+
+note "preflight: gofmt"
+GOFMT_OUT="$(gofmt -s -l . | grep -v '^vendor/' || true)"
+[[ -z "$GOFMT_OUT" ]] || die "gofmt -s issues:"$'\n'"$GOFMT_OUT"
+
+note "preflight: go vet"
+go vet ./...
+
+note "preflight: go test"
+go test ./...
+
+note "preflight: sync --check (drift gate)"
+go run ./cmd/agnostic-ai sync --check
+
+# --- bump version -------------------------------------------------------------
+
+MAIN_FILE="cmd/agnostic-ai/main.go"
+CURRENT="$(awk -F'"' '/^var version =/{print $2}' "$MAIN_FILE")"
+[[ -n "$CURRENT" ]] || die "could not read current version from $MAIN_FILE"
+note "bump: $CURRENT -> $PLAIN"
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  # Portable in-place sed (BSD + GNU): write to temp, move back.
+  awk -v new="$PLAIN" '
+    /^var version =/ { print "var version = \"" new "\""; next }
+    { print }
+  ' "$MAIN_FILE" > "$MAIN_FILE.tmp" && mv "$MAIN_FILE.tmp" "$MAIN_FILE"
+fi
+
+# --- update CHANGELOG ---------------------------------------------------------
+
+CHANGELOG="CHANGELOG.md"
+[[ -f "$CHANGELOG" ]] || die "missing $CHANGELOG"
+
+grep -q '^## \[Unreleased\]' "$CHANGELOG" || die "no [Unreleased] section in $CHANGELOG"
+
+note "changelog: promote [Unreleased] -> [$VERSION] $DATE"
+if [[ $DRY_RUN -eq 0 ]]; then
+  awk -v ver="$VERSION" -v date="$DATE" '
+    !done && /^## \[Unreleased\]/ {
+      print "## [Unreleased]"
+      print ""
+      print "## [" ver "] - " date
+      done = 1
+      next
+    }
+    { print }
+  ' "$CHANGELOG" > "$CHANGELOG.tmp" && mv "$CHANGELOG.tmp" "$CHANGELOG"
+fi
+
+# --- commit + tag + push ------------------------------------------------------
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  note "dry-run complete. exiting before commit."
+  exit 0
+fi
+
+note "commit"
+git add "$MAIN_FILE" "$CHANGELOG"
+git commit -m "chore(release): $VERSION"
+
+note "tag"
+git tag -a "$VERSION" -m "Release $VERSION"
+
+if [[ $NO_PUSH -eq 1 ]]; then
+  note "skipping push. run \`git push origin main && git push origin $VERSION\` when ready."
+  exit 0
+fi
+
+note "push main"
+git push origin main
+
+note "push tag (CI builds release binaries)"
+git push origin "$VERSION"
+
+note "done. watch the release workflow:"
+note "  gh run watch \$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,110 +3,77 @@
 # release.sh — cut a new agnostic-ai release.
 #
 # Usage:
-#   scripts/release.sh vX.Y.Z              # cut and push
-#   scripts/release.sh vX.Y.Z --dry-run    # preview only; touches no files
-#   scripts/release.sh vX.Y.Z --no-push    # commit and tag locally; do not push
+#   scripts/release.sh                     # bump minor by default (X.Y.0 -> X.(Y+1).0)
+#   scripts/release.sh major               # bump major (X.Y.Z -> (X+1).0.0)
+#   scripts/release.sh minor               # bump minor (explicit)
+#   scripts/release.sh patch               # bump patch (X.Y.Z -> X.Y.(Z+1))
+#   scripts/release.sh vX.Y.Z              # explicit version
+#   scripts/release.sh --dry-run           # preview only; touches no files
+#   scripts/release.sh patch --no-push     # commit and tag locally; do not push
 #
 # What it does (in order):
 #   1. Validate inputs and git state (clean tree, on main, in sync with origin).
 #   2. Run go vet, gofmt -s -l, go test ./..., agnostic-ai sync --check.
 #   3. Bump `version` in cmd/agnostic-ai/main.go.
 #   4. Promote [Unreleased] in CHANGELOG.md to [vX.Y.Z] with today's date and
-#      insert a fresh empty [Unreleased] block above it.
+#      insert a fresh [Unreleased] block above.
 #   5. Commit `chore(release): vX.Y.Z`.
 #   6. Create annotated tag vX.Y.Z.
-#   7. Push main and tag. CI builds binaries via GoReleaser.
+#   7. Push main and tag. CI fires GoReleaser, which builds and uploads
+#      binaries plus tarballs to a fresh GitHub Release for the tag.
+#   8. Watch the release workflow and print the release URL when done.
 
 set -Eeuo pipefail
 
-die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+# ---- pure helpers (sourced by tests) -----------------------------------------
+
+die()  { printf 'error: %s\n' "$*" >&2; return 1; }
 note() { printf '→ %s\n' "$*"; }
 
-# --- args ---------------------------------------------------------------------
+# read_current_version <main.go path> — echoes the literal value from
+# `var version = "X.Y.Z"`.
+read_current_version() {
+  local file="$1"
+  awk -F'"' '/^var version =/{print $2; exit}' "$file"
+}
 
-VERSION=""
-DRY_RUN=0
-NO_PUSH=0
+# validate_version <vX.Y.Z[-pre]> — returns 0 if valid, 1 otherwise.
+validate_version() {
+  [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]
+}
 
-for arg in "$@"; do
-  case "$arg" in
-    --dry-run) DRY_RUN=1 ;;
-    --no-push) NO_PUSH=1 ;;
-    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
-    v*) VERSION="$arg" ;;
-    *)  die "unknown arg: $arg" ;;
+# compute_next_version <major|minor|patch> <current X.Y.Z> — echoes vX.Y.Z.
+compute_next_version() {
+  local bump="$1" current="$2"
+  [[ "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] \
+    || { printf 'error: current version %s is not plain MAJOR.MINOR.PATCH\n' "$current" >&2; return 1; }
+  local maj="${BASH_REMATCH[1]}" min="${BASH_REMATCH[2]}" pat="${BASH_REMATCH[3]}"
+  case "$bump" in
+    major) maj=$((maj + 1)); min=0; pat=0 ;;
+    minor) min=$((min + 1)); pat=0 ;;
+    patch) pat=$((pat + 1)) ;;
+    *)     printf 'error: unknown bump kind %s\n' "$bump" >&2; return 1 ;;
   esac
-done
+  printf 'v%d.%d.%d\n' "$maj" "$min" "$pat"
+}
 
-[[ -n "$VERSION" ]] || die "missing version. example: scripts/release.sh v0.2.0"
-[[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]] \
-  || die "version must match vMAJOR.MINOR.PATCH (or vMAJOR.MINOR.PATCH-pre)"
-
-PLAIN="${VERSION#v}"
-DATE="$(date +%Y-%m-%d)"
-ROOT="$(git rev-parse --show-toplevel)"
-cd "$ROOT"
-
-note "version: $VERSION"
-note "date:    $DATE"
-[[ $DRY_RUN -eq 1 ]] && note "mode:    dry-run (no writes, no commits, no push)"
-[[ $NO_PUSH -eq 1 && $DRY_RUN -eq 0 ]] && note "mode:    --no-push (commit + tag only)"
-
-# --- preflight ----------------------------------------------------------------
-
-note "preflight: git state"
-[[ -z "$(git status --porcelain)" ]] || die "working tree dirty. commit or stash first."
-
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-[[ "$BRANCH" == "main" ]] || die "must release from main, on $BRANCH"
-
-git fetch origin main --quiet
-LOCAL="$(git rev-parse @)"
-REMOTE="$(git rev-parse @{u})"
-[[ "$LOCAL" == "$REMOTE" ]] || die "local main not in sync with origin. pull or push first."
-
-if git rev-parse "$VERSION" >/dev/null 2>&1; then
-  die "tag $VERSION already exists"
-fi
-
-note "preflight: gofmt"
-GOFMT_OUT="$(gofmt -s -l . | grep -v '^vendor/' || true)"
-[[ -z "$GOFMT_OUT" ]] || die "gofmt -s issues:"$'\n'"$GOFMT_OUT"
-
-note "preflight: go vet"
-go vet ./...
-
-note "preflight: go test"
-go test ./...
-
-note "preflight: sync --check (drift gate)"
-go run ./cmd/agnostic-ai sync --check
-
-# --- bump version -------------------------------------------------------------
-
-MAIN_FILE="cmd/agnostic-ai/main.go"
-CURRENT="$(awk -F'"' '/^var version =/{print $2}' "$MAIN_FILE")"
-[[ -n "$CURRENT" ]] || die "could not read current version from $MAIN_FILE"
-note "bump: $CURRENT -> $PLAIN"
-
-if [[ $DRY_RUN -eq 0 ]]; then
-  # Portable in-place sed (BSD + GNU): write to temp, move back.
-  awk -v new="$PLAIN" '
+# bump_version_in_file <main.go path> <new plain version> — rewrites the
+# `var version = "..."` line.
+bump_version_in_file() {
+  local file="$1" new="$2"
+  awk -v new="$new" '
     /^var version =/ { print "var version = \"" new "\""; next }
     { print }
-  ' "$MAIN_FILE" > "$MAIN_FILE.tmp" && mv "$MAIN_FILE.tmp" "$MAIN_FILE"
-fi
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+}
 
-# --- update CHANGELOG ---------------------------------------------------------
-
-CHANGELOG="CHANGELOG.md"
-[[ -f "$CHANGELOG" ]] || die "missing $CHANGELOG"
-
-grep -q '^## \[Unreleased\]' "$CHANGELOG" || die "no [Unreleased] section in $CHANGELOG"
-
-note "changelog: promote [Unreleased] -> [$VERSION] $DATE"
-if [[ $DRY_RUN -eq 0 ]]; then
-  awk -v ver="$VERSION" -v date="$DATE" '
+# promote_changelog <CHANGELOG path> <vX.Y.Z> <YYYY-MM-DD> — promotes the
+# existing [Unreleased] block to [version] - date and inserts a fresh
+# empty [Unreleased] block above.
+promote_changelog() {
+  local file="$1" ver="$2" date="$3"
+  grep -q '^## \[Unreleased\]' "$file" || { printf 'error: no [Unreleased] section in %s\n' "$file" >&2; return 1; }
+  awk -v ver="$ver" -v date="$date" '
     !done && /^## \[Unreleased\]/ {
       print "## [Unreleased]"
       print ""
@@ -115,33 +82,168 @@ if [[ $DRY_RUN -eq 0 ]]; then
       next
     }
     { print }
-  ' "$CHANGELOG" > "$CHANGELOG.tmp" && mv "$CHANGELOG.tmp" "$CHANGELOG"
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
+# parse_args <argv...> — sets globals VERSION, BUMP, DRY_RUN, NO_PUSH.
+parse_args() {
+  VERSION=""
+  BUMP=""
+  DRY_RUN=0
+  NO_PUSH=0
+  for arg in "$@"; do
+    case "$arg" in
+      --dry-run)         DRY_RUN=1 ;;
+      --no-push)         NO_PUSH=1 ;;
+      -h|--help)         sed -n '2,24p' "$SCRIPT_PATH"; exit 0 ;;
+      major|minor|patch) BUMP="$arg" ;;
+      v*)                VERSION="$arg" ;;
+      *)                 die "unknown arg: $arg"; return 1 ;;
+    esac
+  done
+  if [[ -n "$VERSION" && -n "$BUMP" ]]; then
+    die "pass either an explicit vX.Y.Z or a bump kind (major|minor|patch), not both"
+    return 1
+  fi
+  if [[ -z "$VERSION" && -z "$BUMP" ]]; then
+    BUMP="minor"
+  fi
+}
+
+# ---- main orchestration ------------------------------------------------------
+
+main() {
+  parse_args "$@"
+
+  local main_file="cmd/agnostic-ai/main.go"
+  local changelog="CHANGELOG.md"
+  local current
+  current="$(read_current_version "$main_file")"
+  [[ -n "$current" ]] || die "could not read current version from $main_file"
+
+  if [[ -n "$BUMP" ]]; then
+    VERSION="$(compute_next_version "$BUMP" "$current")"
+  fi
+  validate_version "$VERSION" \
+    || die "version must match vMAJOR.MINOR.PATCH (or vMAJOR.MINOR.PATCH-pre): $VERSION"
+
+  local plain="${VERSION#v}"
+  local date
+  date="$(date +%Y-%m-%d)"
+
+  note "version: $VERSION (was $current)"
+  note "date:    $date"
+  [[ $DRY_RUN -eq 1 ]] && note "mode:    dry-run (no writes, no commits, no push)"
+  [[ $NO_PUSH -eq 1 && $DRY_RUN -eq 0 ]] && note "mode:    --no-push (commit + tag only)"
+
+  preflight "$VERSION"
+
+  note "bump: $current -> $plain"
+  if [[ $DRY_RUN -eq 0 ]]; then
+    bump_version_in_file "$main_file" "$plain"
+    note "changelog: promote [Unreleased] -> [$VERSION] $date"
+    promote_changelog "$changelog" "$VERSION" "$date"
+  else
+    note "dry-run complete. exiting before commit."
+    return 0
+  fi
+
+  note "commit"
+  git add "$main_file" "$changelog"
+  git commit -m "chore(release): $VERSION"
+
+  note "tag"
+  git tag -a "$VERSION" -m "Release $VERSION"
+
+  if [[ $NO_PUSH -eq 1 ]]; then
+    note "skipping push. run \`git push origin main && git push origin $VERSION\` when ready."
+    return 0
+  fi
+
+  note "push main"
+  git push origin main
+
+  note "push tag (CI builds release binaries)"
+  git push origin "$VERSION"
+
+  watch_release "$VERSION"
+}
+
+# preflight gates the release on git state and code health.
+preflight() {
+  local version="$1"
+  note "preflight: git state"
+  [[ -z "$(git status --porcelain)" ]] || die "working tree dirty. commit or stash first."
+
+  local branch
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  [[ "$branch" == "main" ]] || die "must release from main, on $branch"
+
+  git fetch origin main --quiet
+  local local_head remote_head
+  local_head="$(git rev-parse @)"
+  remote_head="$(git rev-parse @{u})"
+  [[ "$local_head" == "$remote_head" ]] || die "local main not in sync with origin. pull or push first."
+
+  if git rev-parse "$version" >/dev/null 2>&1; then
+    die "tag $version already exists"
+  fi
+
+  note "preflight: gofmt"
+  local gofmt_out
+  gofmt_out="$(gofmt -s -l . | grep -v '^vendor/' || true)"
+  [[ -z "$gofmt_out" ]] || die "gofmt -s issues:"$'\n'"$gofmt_out"
+
+  note "preflight: go vet"
+  go vet ./...
+
+  note "preflight: go test"
+  go test ./...
+
+  note "preflight: sync --check (drift gate)"
+  go run ./cmd/agnostic-ai sync --check
+}
+
+# watch_release waits for the release workflow to start, watches it, and
+# prints the resulting GitHub Release URL.
+watch_release() {
+  local version="$1"
+  if ! command -v gh >/dev/null 2>&1; then
+    note "gh not installed. release workflow runs in GitHub Actions; check manually."
+    return 0
+  fi
+
+  note "waiting for release workflow to start..."
+  local run_id=""
+  for _ in $(seq 1 30); do
+    run_id="$(gh run list --workflow=release.yml --branch "$version" \
+      --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+    [[ -n "$run_id" && "$run_id" != "null" ]] && break
+    sleep 2
+  done
+
+  if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+    note "release workflow did not register within 60s. check manually:"
+    note "  gh run list --workflow=release.yml"
+    return 0
+  fi
+
+  note "release workflow run: $run_id"
+  gh run watch "$run_id" --exit-status
+
+  local repo
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+  note "release published:"
+  note "  https://github.com/$repo/releases/tag/$version"
+  gh release view "$version" --json assets --jq '.assets[].name' \
+    | sed 's/^/    asset: /'
+}
+
+# ---- entry point -------------------------------------------------------------
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  cd "$(git rev-parse --show-toplevel)"
+  main "$@"
 fi
-
-# --- commit + tag + push ------------------------------------------------------
-
-if [[ $DRY_RUN -eq 1 ]]; then
-  note "dry-run complete. exiting before commit."
-  exit 0
-fi
-
-note "commit"
-git add "$MAIN_FILE" "$CHANGELOG"
-git commit -m "chore(release): $VERSION"
-
-note "tag"
-git tag -a "$VERSION" -m "Release $VERSION"
-
-if [[ $NO_PUSH -eq 1 ]]; then
-  note "skipping push. run \`git push origin main && git push origin $VERSION\` when ready."
-  exit 0
-fi
-
-note "push main"
-git push origin main
-
-note "push tag (CI builds release binaries)"
-git push origin "$VERSION"
-
-note "done. watch the release workflow:"
-note "  gh run watch \$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# bashunit tests for scripts/release.sh
+#
+# Run:
+#   bashunit scripts/release_test.sh
+#
+# Pure helpers (compute_next_version, validate_version, bump_version_in_file,
+# promote_changelog, parse_args) are tested directly by sourcing the script.
+# End-to-end paths that touch git are exercised through a temp git fixture
+# in dry-run mode so no commits or tags occur.
+
+# Source the script for its functions only. The source guard inside
+# release.sh prevents main() from running.
+SCRIPT_DIR="$(cd "$(dirname "$BASH_SOURCE")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/release.sh"
+
+# ---- validate_version --------------------------------------------------------
+
+function test_validate_version_accepts_plain() {
+  assert_successful_code "$(validate_version v1.2.3 && echo ok)"
+}
+
+function test_validate_version_accepts_pre_release() {
+  validate_version "v0.2.0-rc.1"
+  assert_equals 0 $?
+}
+
+function test_validate_version_rejects_missing_v() {
+  validate_version "1.2.3"
+  assert_equals 1 $?
+}
+
+function test_validate_version_rejects_partial() {
+  validate_version "v1.2"
+  assert_equals 1 $?
+}
+
+function test_validate_version_rejects_garbage() {
+  validate_version "vabc"
+  assert_equals 1 $?
+}
+
+# ---- compute_next_version ----------------------------------------------------
+
+function test_compute_next_version_minor() {
+  assert_equals "v0.2.0" "$(compute_next_version minor 0.1.5)"
+}
+
+function test_compute_next_version_minor_zeroes_patch() {
+  assert_equals "v1.3.0" "$(compute_next_version minor 1.2.7)"
+}
+
+function test_compute_next_version_major_zeroes_minor_and_patch() {
+  assert_equals "v2.0.0" "$(compute_next_version major 1.4.9)"
+}
+
+function test_compute_next_version_patch() {
+  assert_equals "v0.1.6" "$(compute_next_version patch 0.1.5)"
+}
+
+function test_compute_next_version_rejects_unknown_kind() {
+  compute_next_version weird 1.0.0 >/dev/null 2>&1
+  assert_equals 1 $?
+}
+
+function test_compute_next_version_rejects_non_semver_current() {
+  compute_next_version minor "0.1" >/dev/null 2>&1
+  assert_equals 1 $?
+}
+
+function test_compute_next_version_rejects_pre_release_current() {
+  compute_next_version minor "0.1.0-rc.1" >/dev/null 2>&1
+  assert_equals 1 $?
+}
+
+# ---- read_current_version ----------------------------------------------------
+
+function test_read_current_version_extracts_value() {
+  local tmp
+  tmp="$(mktemp)"
+  printf 'package main\n\nvar version = "0.7.3"\n' > "$tmp"
+  assert_equals "0.7.3" "$(read_current_version "$tmp")"
+  rm -f "$tmp"
+}
+
+function test_read_current_version_empty_for_missing_marker() {
+  local tmp
+  tmp="$(mktemp)"
+  printf 'package main\n' > "$tmp"
+  assert_equals "" "$(read_current_version "$tmp")"
+  rm -f "$tmp"
+}
+
+# ---- bump_version_in_file ----------------------------------------------------
+
+function test_bump_version_in_file_rewrites_version_line() {
+  local tmp
+  tmp="$(mktemp)"
+  printf 'package main\n\nvar version = "0.1.0"\n\nfunc main() {}\n' > "$tmp"
+  bump_version_in_file "$tmp" "0.2.0"
+  assert_equals "0.2.0" "$(read_current_version "$tmp")"
+  assert_contains "func main() {}" "$(cat "$tmp")"
+  rm -f "$tmp"
+}
+
+function test_bump_version_in_file_leaves_other_lines_intact() {
+  local tmp
+  tmp="$(mktemp)"
+  printf 'line1\nvar version = "1.0.0"\nline3\n' > "$tmp"
+  bump_version_in_file "$tmp" "1.1.0"
+  assert_equals 'line1
+var version = "1.1.0"
+line3' "$(cat "$tmp")"
+  rm -f "$tmp"
+}
+
+# ---- promote_changelog -------------------------------------------------------
+
+function test_promote_changelog_inserts_dated_section() {
+  local tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- foo
+EOF
+  promote_changelog "$tmp" "v0.2.0" "2026-05-04"
+  local out
+  out="$(cat "$tmp")"
+  assert_contains "## [Unreleased]" "$out"
+  assert_contains "## [v0.2.0] - 2026-05-04" "$out"
+  assert_contains "- foo" "$out"
+  # The new [Unreleased] must appear before the dated section.
+  local unreleased_line dated_line
+  unreleased_line="$(grep -n '^## \[Unreleased\]$' "$tmp" | head -1 | cut -d: -f1)"
+  dated_line="$(grep -n '^## \[v0.2.0\]' "$tmp" | head -1 | cut -d: -f1)"
+  assert_equals "true" "$([[ $unreleased_line -lt $dated_line ]] && echo true || echo false)"
+  rm -f "$tmp"
+}
+
+function test_promote_changelog_errors_without_unreleased() {
+  local tmp
+  tmp="$(mktemp)"
+  printf '# Changelog\n\n## [v0.1.0] - 2026-01-01\n' > "$tmp"
+  promote_changelog "$tmp" "v0.2.0" "2026-05-04" 2>/dev/null
+  assert_equals 1 $?
+  rm -f "$tmp"
+}
+
+# ---- parse_args --------------------------------------------------------------
+
+function test_parse_args_default_is_minor() {
+  parse_args
+  assert_equals "minor" "$BUMP"
+  assert_equals "" "$VERSION"
+  assert_equals 0 "$DRY_RUN"
+  assert_equals 0 "$NO_PUSH"
+}
+
+function test_parse_args_explicit_version() {
+  parse_args v0.5.0
+  assert_equals "v0.5.0" "$VERSION"
+  assert_equals "" "$BUMP"
+}
+
+function test_parse_args_bump_kind_overrides_default() {
+  parse_args patch
+  assert_equals "patch" "$BUMP"
+}
+
+function test_parse_args_dry_run_flag() {
+  parse_args --dry-run
+  assert_equals 1 "$DRY_RUN"
+  assert_equals "minor" "$BUMP"
+}
+
+function test_parse_args_no_push_flag() {
+  parse_args patch --no-push
+  assert_equals 1 "$NO_PUSH"
+  assert_equals "patch" "$BUMP"
+}
+
+function test_parse_args_rejects_version_and_bump_together() {
+  parse_args v0.1.0 minor 2>/dev/null
+  assert_equals 1 $?
+}
+
+function test_parse_args_rejects_unknown_arg() {
+  parse_args banana 2>/dev/null
+  assert_equals 1 $?
+}


### PR DESCRIPTION
## Summary
- New `scripts/release.sh` automates the full release flow: preflight checks → version bump → CHANGELOG promote → commit → tag → push → watch release workflow → print release URL.
- Defaults to **minor bump** (`scripts/release.sh`). Accepts `major`, `minor`, `patch`, or an explicit `vX.Y.Z`.
- After pushing the tag, watches the GitHub release workflow and prints the resulting release URL plus uploaded asset names. CI's existing GoReleaser step builds binaries for darwin/linux/windows × amd64/arm64 and attaches them.
- Flags: `--dry-run` (preview, no writes), `--no-push` (local commit + tag only).
- Preflight gates a release on clean tree, on `main`, in sync with `origin/main`, no existing tag, `gofmt -s` clean, `go vet`, `go test ./...`, and `agnostic-ai sync --check` (no drift).

## Tests
- `scripts/release_test.sh`: **25 bashunit cases**, 35 assertions. Covers `compute_next_version` (major/minor/patch + edge cases), `validate_version`, `read_current_version`, `bump_version_in_file`, `promote_changelog`, `parse_args` (defaults, flags, conflict detection).
- New CI job `Shell tests` runs bashunit on every PR.
- `make test-shell` for local convenience.

## Test plan
- [x] `bash -n scripts/release.sh` — syntax clean.
- [x] `bashunit scripts/release_test.sh` — 25 / 25 passed locally.
- [ ] CI: lint, build, go tests, shell tests green on all platforms.
- [ ] Post-merge: dry-run on clean main verifies awk patches and changelog promotion plan.