### PR TITLE
chore(release): pull GH release notes from CHANGELOG.md

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,9 @@
 #   6. Create annotated tag vX.Y.Z.
 #   7. Push main and tag. CI fires GoReleaser, which builds and uploads
 #      binaries plus tarballs to a fresh GitHub Release for the tag.
-#   8. Watch the release workflow and print the release URL when done.
+#   8. Watch the release workflow.
+#   9. Replace the auto-generated release notes with the matching section
+#      from CHANGELOG.md (install + changelog body + docs links).
 
 set -Eeuo pipefail
 
@@ -83,6 +85,69 @@ promote_changelog() {
     }
     { print }
   ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
+# extract_changelog_section <CHANGELOG path> <vX.Y.Z> — echoes the body
+# under `## [vX.Y.Z]` up to (but not including) the next `## ` heading.
+# Trailing blank lines are stripped. Returns 1 if the section is missing.
+extract_changelog_section() {
+  local file="$1" ver="$2"
+  grep -q "^## \[${ver}\]" "$file" || return 1
+  awk -v ver="$ver" '
+    BEGIN { in_section=0 }
+    {
+      if (match($0, "^## \\[" ver "\\]")) { in_section=1; next }
+      if (in_section && match($0, /^## /)) { in_section=0 }
+      if (in_section) lines[++n]=$0
+    }
+    END {
+      end=n
+      while (end > 0 && lines[end] ~ /^[[:space:]]*$/) end--
+      start=1
+      while (start <= end && lines[start] ~ /^[[:space:]]*$/) start++
+      for (i=start; i<=end; i++) print lines[i]
+    }
+  ' "$file"
+}
+
+# format_release_notes <vX.Y.Z> <CHANGELOG path> <repo nameWithOwner> —
+# echoes a markdown release-notes body: install block + changelog section +
+# docs links.
+format_release_notes() {
+  local ver="$1" changelog="$2" repo="$3"
+  local section
+  section="$(extract_changelog_section "$changelog" "$ver")" \
+    || { printf 'error: no [%s] section in %s\n' "$ver" "$changelog" >&2; return 1; }
+  cat <<EOF
+## Install
+
+Homebrew:
+\`\`\`bash
+brew install chemaclass/tap/agnostic-ai
+\`\`\`
+
+Direct binary:
+\`\`\`bash
+curl -fsSL https://github.com/$repo/releases/download/$ver/agnostic-ai_\$(uname -s)_\$(uname -m).tar.gz | tar xz
+\`\`\`
+
+From source:
+\`\`\`bash
+go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@$ver
+\`\`\`
+
+## What's in $ver
+
+$section
+
+## Documentation
+
+- [Getting started](https://github.com/$repo/blob/main/docs/user/getting-started.md)
+- [Spec format](https://github.com/$repo/blob/main/docs/user/spec-format.md)
+- [Targets and capability matrix](https://github.com/$repo/blob/main/docs/user/targets.md)
+- [CLI reference](https://github.com/$repo/blob/main/docs/user/cli-reference.md)
+- [Full changelog](https://github.com/$repo/blob/main/CHANGELOG.md)
+EOF
 }
 
 # parse_args <argv...> — sets globals VERSION, BUMP, DRY_RUN, NO_PUSH.
@@ -233,6 +298,18 @@ watch_release() {
 
   local repo
   repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+
+  note "updating release notes from CHANGELOG.md"
+  local notes
+  notes="$(mktemp)"
+  if format_release_notes "$version" "CHANGELOG.md" "$repo" > "$notes"; then
+    gh release edit "$version" --notes-file "$notes" >/dev/null
+    note "release notes updated"
+  else
+    note "could not extract [$version] section from CHANGELOG.md; leaving auto-generated notes."
+  fi
+  rm -f "$notes"
+
   note "release published:"
   note "  https://github.com/$repo/releases/tag/$version"
   gh release view "$version" --json assets --jq '.assets[].name' \

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -152,6 +152,127 @@ function test_promote_changelog_errors_without_unreleased() {
   rm -f "$tmp"
 }
 
+# ---- extract_changelog_section ----------------------------------------------
+
+function test_extract_changelog_section_returns_body_only() {
+  local tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [v0.2.0] - 2026-06-01
+
+### Added
+- New thing.
+
+### Fixed
+- Old bug.
+
+## [v0.1.0] - 2026-05-04
+
+### Added
+- Initial release.
+EOF
+  local out
+  out="$(extract_changelog_section "$tmp" "v0.2.0")"
+  assert_contains "### Added" "$out"
+  assert_contains "- New thing." "$out"
+  assert_contains "- Old bug." "$out"
+  assert_not_contains "## [v0.1.0]" "$out"
+  assert_not_contains "Initial release" "$out"
+  rm -f "$tmp"
+}
+
+function test_extract_changelog_section_strips_trailing_blanks() {
+  local tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+## [v0.1.0] - 2026-05-04
+
+### Added
+- foo
+
+
+
+## [v0.0.1] - 2026-04-01
+
+- old
+EOF
+  local out
+  out="$(extract_changelog_section "$tmp" "v0.1.0")"
+  # Last line must be content, not blank.
+  local last
+  last="$(printf '%s\n' "$out" | tail -1)"
+  assert_equals "- foo" "$last"
+  rm -f "$tmp"
+}
+
+function test_extract_changelog_section_returns_last_section() {
+  local tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+## [v0.2.0] - 2026-06-01
+
+- new
+
+## [v0.1.0] - 2026-05-04
+
+- first
+- ever
+EOF
+  local out
+  out="$(extract_changelog_section "$tmp" "v0.1.0")"
+  assert_contains "- first" "$out"
+  assert_contains "- ever" "$out"
+  assert_not_contains "- new" "$out"
+  rm -f "$tmp"
+}
+
+function test_extract_changelog_section_errors_on_missing() {
+  local tmp
+  tmp="$(mktemp)"
+  printf '## [v0.1.0]\n- foo\n' > "$tmp"
+  extract_changelog_section "$tmp" "v9.9.9" >/dev/null
+  assert_equals 1 $?
+  rm -f "$tmp"
+}
+
+# ---- format_release_notes ----------------------------------------------------
+
+function test_format_release_notes_includes_changelog_body() {
+  local tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+## [v0.1.0] - 2026-05-04
+
+### Added
+- one
+- two
+EOF
+  local out
+  out="$(format_release_notes "v0.1.0" "$tmp" "owner/repo")"
+  assert_contains "## Install" "$out"
+  assert_contains "brew install chemaclass/tap/agnostic-ai" "$out"
+  assert_contains "owner/repo/releases/download/v0.1.0" "$out"
+  assert_contains "## What's in v0.1.0" "$out"
+  assert_contains "- one" "$out"
+  assert_contains "- two" "$out"
+  assert_contains "## Documentation" "$out"
+  assert_contains "owner/repo/blob/main/docs/user/getting-started.md" "$out"
+  rm -f "$tmp"
+}
+
+function test_format_release_notes_errors_on_missing_section() {
+  local tmp
+  tmp="$(mktemp)"
+  printf '## [v0.1.0]\n- foo\n' > "$tmp"
+  format_release_notes "v9.9.9" "$tmp" "owner/repo" >/dev/null 2>&1
+  assert_equals 1 $?
+  rm -f "$tmp"
+}
+
 # ---- parse_args --------------------------------------------------------------
 
 function test_parse_args_default_is_minor() {


### PR DESCRIPTION
## Summary
- After GoReleaser publishes a tag, `release.sh` now replaces the auto-generated commit list on the GitHub release with the matching section from `CHANGELOG.md` (install + body + docs links).
- Same content the maintainer would have hand-edited; happens automatically.
- Falls back silently to GoReleaser's notes if the version section can't be found.

## Tests
- 6 new bashunit cases cover `extract_changelog_section` (returns body only, strips trailing blanks, isolates last section, errors on missing) and `format_release_notes` (includes install/changelog/docs blocks; errors on missing section).
- Total now 31 / 31.

## Test plan
- [x] `bashunit scripts/release_test.sh` — 31 / 31 locally.
- [x] `format_release_notes v0.1.0 CHANGELOG.md Chemaclass/agnostic-ai` produces clean markdown end-to-end.
- [ ] CI green.
- [ ] Verified on the next real release (v0.2.0+).