### PR TITLE
chore(release): trim release notes to changelog body only

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -111,42 +111,20 @@ extract_changelog_section() {
 }
 
 # format_release_notes <vX.Y.Z> <CHANGELOG path> <repo nameWithOwner> —
-# echoes a markdown release-notes body: install block + changelog section +
-# docs links.
+# echoes the changelog section for ver plus a single link to the full
+# changelog. Install instructions and docs live in README; not duplicated
+# here.
 format_release_notes() {
   local ver="$1" changelog="$2" repo="$3"
   local section
   section="$(extract_changelog_section "$changelog" "$ver")" \
     || { printf 'error: no [%s] section in %s\n' "$ver" "$changelog" >&2; return 1; }
   cat <<EOF
-## Install
-
-Homebrew:
-\`\`\`bash
-brew install chemaclass/tap/agnostic-ai
-\`\`\`
-
-Direct binary:
-\`\`\`bash
-curl -fsSL https://github.com/$repo/releases/download/$ver/agnostic-ai_\$(uname -s)_\$(uname -m).tar.gz | tar xz
-\`\`\`
-
-From source:
-\`\`\`bash
-go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@$ver
-\`\`\`
-
-## What's in $ver
-
 $section
 
-## Documentation
+---
 
-- [Getting started](https://github.com/$repo/blob/main/docs/user/getting-started.md)
-- [Spec format](https://github.com/$repo/blob/main/docs/user/spec-format.md)
-- [Targets and capability matrix](https://github.com/$repo/blob/main/docs/user/targets.md)
-- [CLI reference](https://github.com/$repo/blob/main/docs/user/cli-reference.md)
-- [Full changelog](https://github.com/$repo/blob/main/CHANGELOG.md)
+[Full changelog](https://github.com/$repo/blob/main/CHANGELOG.md) · [README](https://github.com/$repo#readme)
 EOF
 }
 

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -253,14 +253,24 @@ function test_format_release_notes_includes_changelog_body() {
 EOF
   local out
   out="$(format_release_notes "v0.1.0" "$tmp" "owner/repo")"
-  assert_contains "## Install" "$out"
-  assert_contains "brew install chemaclass/tap/agnostic-ai" "$out"
-  assert_contains "owner/repo/releases/download/v0.1.0" "$out"
-  assert_contains "## What's in v0.1.0" "$out"
+  assert_contains "### Added" "$out"
   assert_contains "- one" "$out"
   assert_contains "- two" "$out"
-  assert_contains "## Documentation" "$out"
-  assert_contains "owner/repo/blob/main/docs/user/getting-started.md" "$out"
+  assert_contains "owner/repo/blob/main/CHANGELOG.md" "$out"
+  assert_contains "owner/repo#readme" "$out"
+  rm -f "$tmp"
+}
+
+function test_format_release_notes_omits_install_and_docs_blocks() {
+  local tmp
+  tmp="$(mktemp)"
+  printf '## [v0.1.0]\n\n- foo\n' > "$tmp"
+  local out
+  out="$(format_release_notes "v0.1.0" "$tmp" "owner/repo")"
+  assert_not_contains "## Install" "$out"
+  assert_not_contains "brew install" "$out"
+  assert_not_contains "## Documentation" "$out"
+  assert_not_contains "/docs/user/getting-started.md" "$out"
   rm -f "$tmp"
 }
 


### PR DESCRIPTION
## Summary
- Drop install + docs blocks from GH release notes. README owns those; release notes should answer 'what changed'.
- Notes now: changelog section for the version + single footer linking to CHANGELOG and README.
- Avoids drift (release notes captured at tag time vs README updated continuously).