### PR TITLE
docs: align README with AGENTS.md standard and add layered config roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Write prompts and project conventions **once**. agnostic-ai emits the right config for Claude Code, Codex, Gemini CLI, Cursor, GitHub Copilot, Aider, Cline, Windsurf, Continue, and more.
 
+Aligned with the [AGENTS.md](https://agents.md) open standard (Codex, OpenCode, Cursor, Aider). Markdown body + YAML frontmatter, no proprietary extensions.
+
 ```
                                           ┌──► .claude/agents/*.md
                                           ├──► CLAUDE.md
@@ -138,6 +140,22 @@ make test     # unit + integration
 - Contributors: [docs/internal/](docs/internal/): architecture, adapters, release process.
 - Examples: [docs/examples/](docs/examples/).
 
+## Standards this rides on
+
+- [AGENTS.md](https://agents.md): open agent-instructions standard, used by Codex, OpenCode, Cursor, Aider.
+- [CommonMark](https://commonmark.org): every spec body is plain Markdown.
+- YAML 1.2 frontmatter: portable across parsers.
+
+No proprietary extensions inside the open standard. If a target needs a vendor-specific block, the adapter writes it to that target's native file (e.g. `.cursor/rules/*.mdc`), not to `AGENTS.md`.
+
+## Roadmap
+
+- **User-global layer** (`~/.agnostic-ai/`): one source of truth across every project on the machine.
+- **Project-user layer** (`.agnostic-ai/`, gitignored): per-developer overrides on top of the project layer.
+- Precedence: project-user > project > user-global. Each layer can add or override specs by name.
+
+Track progress in [issues](https://github.com/Chemaclass/agnostic-ai/issues).
+
 ## Status
 
 Pre-1.0. Spec format may change between minor versions. See [CHANGELOG.md](CHANGELOG.md).
@@ -149,3 +167,7 @@ PRs welcome, especially new adapters. See [CONTRIBUTING.md](CONTRIBUTING.md).
 ## License
 
 MIT. See [LICENSE](LICENSE).
+
+---
+
+> Write the rule once. Every AI tool obeys it. Outlive the tool.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Write prompts and project conventions **once**. agnostic-ai emits the right config for Claude Code, Codex, Gemini CLI, Cursor, GitHub Copilot, Aider, Cline, Windsurf, Continue, and more.
 
-Aligned with the [AGENTS.md](https://agents.md) open standard (Codex, OpenCode, Cursor, Aider). Markdown body + YAML frontmatter, no proprietary extensions.
+Aligned with the [AGENTS.md](https://agents.md) open standard. Markdown body + YAML frontmatter, no proprietary extensions.
 
 ```
                                           ┌──► .claude/agents/*.md
@@ -23,10 +23,6 @@ Aligned with the [AGENTS.md](https://agents.md) open standard (Codex, OpenCode, 
                                           ├──► .windsurf/rules/*.md
                                           └──► .continue/rules/*.md
 ```
-
-## Why
-
-Each AI CLI wants its own config (`CLAUDE.md`, `.cursor/rules/*.mdc`, `AGENTS.md`, `CONVENTIONS.md`, ...). Copy-paste drifts. agnostic-ai keeps one source under `agents/`, `skills/`, `rules/`, `hooks/` and emits whatever each tool expects. Edit once, run `sync`, every tool updates.
 
 ## Supported targets
 
@@ -42,119 +38,32 @@ Each AI CLI wants its own config (`CLAUDE.md`, `.cursor/rules/*.mdc`, `AGENTS.md
 | Windsurf       | ✅     | ✅     | ✅    | —     |
 | Continue       | ✅     | ✅     | ✅    | —     |
 
-Legend: ✅ separate files · ◐ merged into single doc · — not supported.
-
-Hooks are Claude-specific (lifecycle events with shell commands). Other targets have no equivalent concept.
-
-Details: [docs/user/targets.md](docs/user/targets.md). Adding a target: [docs/internal/adding-adapters.md](docs/internal/adding-adapters.md).
+Legend: ✅ separate files · ◐ merged into single doc · — not supported. Hooks are Claude-specific.
 
 ## Install
 
-**Prebuilt binary** (no Go required):
-
-Grab the archive for your OS/arch from the [latest release](https://github.com/Chemaclass/agnostic-ai/releases/latest), extract `agnostic-ai`, and put it on your `PATH`.
-
-**Go install:**
+Prebuilt binary from the [latest release](https://github.com/Chemaclass/agnostic-ai/releases/latest), or:
 
 ```bash
 go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest
 ```
 
+More options (Homebrew, curl one-liner): [docs/user/getting-started.md](docs/user/getting-started.md).
+
 ## Quickstart
 
 ```bash
-mkdir my-agents && cd my-agents
-agnostic-ai init           # creates agents/, skills/, rules/, hooks/, agnostic.config.yaml
+agnostic-ai init    # scaffold agents/, skills/, rules/, hooks/
+agnostic-ai sync    # emit configs for every target
 ```
 
-Add a rule (`rules/conventional-commits.md`):
-
-```markdown
----
-name: conventional-commits
-description: Always use Conventional Commits.
-alwaysApply: true
----
-
-Use `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:` prefixes.
-Subject line under 72 chars. Body explains why, not what.
-```
-
-Sync:
-
-```bash
-agnostic-ai sync
-```
-
-Resulting tree:
-
-```
-my-agents/
-├── agnostic.config.yaml
-├── rules/
-│   └── conventional-commits.md
-├── CLAUDE.md                                    # for Claude Code
-├── AGENTS.md                                    # for Codex
-├── GEMINI.md                                    # for Gemini CLI
-├── CONVENTIONS.md                               # for Aider
-├── .github/copilot-instructions.md              # for Copilot
-├── .cursor/rules/conventional-commits.mdc       # for Cursor
-├── .clinerules/conventional-commits.md          # for Cline
-├── .windsurf/rules/conventional-commits.md      # for Windsurf
-└── .continue/rules/conventional-commits.md      # for Continue
-```
-
-## Spec format
-
-Markdown body + YAML frontmatter (hooks are pure YAML), shared across all four kinds.
-
-Full reference: [docs/user/spec-format.md](docs/user/spec-format.md).
-
-## Commands
-
-```bash
-agnostic-ai init                  # scaffold a project
-agnostic-ai sync                  # emit all configured targets
-agnostic-ai sync -t claude,cursor # only specific targets
-agnostic-ai sync --dry-run        # preview without writing
-agnostic-ai validate              # parse-check all specs
-agnostic-ai list                  # show loaded specs
-```
-
-Full reference: [docs/user/cli-reference.md](docs/user/cli-reference.md).
-
-## Build from source
-
-Requires Go 1.23+.
-
-```bash
-git clone https://github.com/Chemaclass/agnostic-ai
-cd agnostic-ai
-make build    # ./agnostic-ai
-make test     # unit + integration
-```
+Walkthrough with a first rule: [docs/user/getting-started.md](docs/user/getting-started.md).
 
 ## Documentation
 
-- Users: [docs/user/](docs/user/): getting started, spec format, targets, config, CLI reference.
-- Contributors: [docs/internal/](docs/internal/): architecture, adapters, release process.
-- Examples: [docs/examples/](docs/examples/).
-
-## Standards this rides on
-
-- [AGENTS.md](https://agents.md): open agent-instructions standard, used by Codex, OpenCode, Cursor, Aider.
-- [CommonMark](https://commonmark.org): every spec body is plain Markdown.
-- YAML 1.2 frontmatter: portable across parsers.
-
-No proprietary extensions inside the open standard. If a target needs a vendor-specific block, the adapter writes it to that target's native file (e.g. `.cursor/rules/*.mdc`), not to `AGENTS.md`.
-
-## Roadmap
-
-- **User-global layer** (`~/.agnostic-ai/`): one source of truth across every project on the machine.
-- **Project-user layer** (`.agnostic-ai/`, gitignored): per-developer overrides on top of the project layer.
-- Precedence: project-user > project > user-global. Each layer can add or override specs by name.
-
-Track progress in [issues](https://github.com/Chemaclass/agnostic-ai/issues).
+- [User docs](docs/user/): getting started, spec format, targets, configuration, CLI reference, standards.
+- [Contributor docs](docs/internal/): architecture, adding adapters, release process, roadmap.
+- [Examples](docs/examples/).
 
 ## Status
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -7,6 +7,7 @@ Read in this order.
 3. [Contributing](contributing.md) — branch flow, commit style, test expectations.
 4. [Release process](release-process.md) — how a tag becomes a release.
 5. [Decision log](decisions.md) — historical record of design choices.
+6. [Roadmap](roadmap.md) — planned directions (layered config, more adapters).
 
 ## House rules
 

--- a/docs/internal/roadmap.md
+++ b/docs/internal/roadmap.md
@@ -1,0 +1,24 @@
+# Roadmap
+
+Tracked here at a high level. Concrete work happens in [issues](https://github.com/Chemaclass/agnostic-ai/issues).
+
+## Layered configuration
+
+Today: a single project layer (specs in the repo).
+
+Planned:
+
+- **User-global layer** (`~/.agnostic-ai/`): one source of truth across every project on the machine. Useful for personal rules a developer wants in every repo (e.g. preferred commit style).
+- **Project-user layer** (`.agnostic-ai/`, gitignored): per-developer overrides on top of the project layer. Useful for personal tweaks without polluting the team config.
+
+**Precedence:** project-user > project > user-global.
+
+Each layer can add new specs by name or override an existing one. The transpiler resolves the merged set before any adapter runs, so adapters stay layer-agnostic.
+
+## Other directions
+
+Filed as issues:
+
+- More adapters (open a PR; see [adding-adapters.md](adding-adapters.md)).
+- Richer `--from <source>` importers beyond `claude`.
+- `doctor` improvements (drift fixes, not only detection).

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -67,3 +67,21 @@ agnostic-ai sync
 | `AGENTS.md` | Codex |
 | `GEMINI.md` | Gemini CLI |
 | `.cursor/rules/conventional-commits.mdc` | Cursor |
+
+Full tree after sync with the default targets:
+
+```
+.
+├── agnostic.config.yaml
+├── rules/
+│   └── conventional-commits.md
+├── CLAUDE.md                                    # for Claude Code
+├── AGENTS.md                                    # for Codex
+├── GEMINI.md                                    # for Gemini CLI
+├── CONVENTIONS.md                               # for Aider
+├── .github/copilot-instructions.md              # for Copilot
+├── .cursor/rules/conventional-commits.mdc       # for Cursor
+├── .clinerules/conventional-commits.md          # for Cline
+├── .windsurf/rules/conventional-commits.md      # for Windsurf
+└── .continue/rules/conventional-commits.md      # for Continue
+```


### PR DESCRIPTION
## Summary

Apply findings from review of [JuanColilla/Agentic-Agnostic-Workflow-Environment](https://github.com/JuanColilla/Agentic-Agnostic-Workflow-Environment).

- **AGENTS.md alignment**: lead paragraph notes alignment with the open standard (Codex, OpenCode, Cursor, Aider). Sets expectations for portability up front.
- **Standards this rides on** section: lists AGENTS.md, CommonMark, YAML 1.2 frontmatter. Spells out the no-proprietary-extensions rule and explains where vendor-specific config goes.
- **Roadmap** section: stubs the user-global layer (`~/.agnostic-ai/`) and project-user layer (`.agnostic-ai/`, gitignored), plus precedence ordering. Captures the layered-config idea from the upstream repo as a concrete future direction.
- **Closing one-liner**: short manifesto-style outro.

Skipped from upstream:
- Long-form rationale essay (this is a tool, not a manifesto).
- Apache NOTICE (MIT does not need it).
- Bootstrap/doctor commands (different product shape vs. transpile).
- Symlink-based resolution (transpile model is the opposite).