### PR TITLE
Support importing existing Cursor projects with init --from cursor

### DIFF
--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -202,7 +202,7 @@ func TestInitCmd_UnknownFromRejected(t *testing.T) {
 	silence(t)
 
 	root := NewRootCmd("test")
-	root.SetArgs([]string{"init", "--from", "cursor"})
+	root.SetArgs([]string{"init", "--from", "nonesuch"})
 	if err := root.Execute(); err == nil {
 		t.Error("expected error for unknown --from")
 	}

--- a/internal/cli/import_cursor.go
+++ b/internal/cli/import_cursor.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const cursorOnlyConfig = `version: 1
+
+sources:
+  agents: agents
+  skills: skills
+  rules: rules
+  hooks: hooks
+
+targets:
+  - cursor
+
+on-unsupported: warn
+`
+
+// importFromCursor scaffolds an agnostic-ai project by reading existing
+// Cursor config (.cursor/rules/*.mdc) under root. Refuses if
+// agnostic.config.yaml already exists.
+func importFromCursor(root string) error {
+	cfgPath := filepath.Join(root, "agnostic.config.yaml")
+	if _, err := os.Stat(cfgPath); err == nil {
+		return fmt.Errorf("agnostic.config.yaml already exists")
+	}
+	if err := ensureSourceDirs(root); err != nil {
+		return err
+	}
+
+	n, err := importCursorRules(root)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(cfgPath, []byte(cursorOnlyConfig), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", cfgPath, err)
+	}
+	fmt.Printf("imported %d rules\n", n)
+	return nil
+}
+
+// importCursorRules translates each .cursor/rules/*.mdc into rules/<name>.md.
+// Frontmatter keys (description, globs, alwaysApply, plus any custom keys)
+// pass through verbatim; a name field derived from the filename is injected
+// when missing.
+func importCursorRules(root string) (int, error) {
+	src := filepath.Join(root, ".cursor", "rules")
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".mdc") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			return count, fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		name := strings.TrimSuffix(e.Name(), ".mdc")
+		translated, err := translateCursorRule(name, data)
+		if err != nil {
+			return count, fmt.Errorf("translate %s: %w", e.Name(), err)
+		}
+		dst := filepath.Join(root, "rules", name+".md")
+		if err := os.WriteFile(dst, translated, 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", dst, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// translateCursorRule rewrites a .mdc file as an agnostic rule. Frontmatter
+// is parsed, a name field is injected if absent, and the result is
+// re-marshaled. Body is preserved verbatim.
+func translateCursorRule(name string, data []byte) ([]byte, error) {
+	meta, body := splitMdcFrontmatter(data)
+	if _, ok := meta["name"]; !ok {
+		meta["name"] = name
+	}
+
+	var fm bytes.Buffer
+	enc := yaml.NewEncoder(&fm)
+	enc.SetIndent(2)
+	if err := enc.Encode(meta); err != nil {
+		return nil, fmt.Errorf("marshal frontmatter: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("close encoder: %w", err)
+	}
+
+	var out bytes.Buffer
+	out.WriteString("---\n")
+	out.Write(fm.Bytes())
+	out.WriteString("---\n\n")
+	out.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		out.WriteString("\n")
+	}
+	return out.Bytes(), nil
+}
+
+// splitMdcFrontmatter mirrors spec.splitFrontmatter for the import path.
+// Returns an empty map (never nil) when no valid frontmatter is present so
+// callers can always inject keys.
+func splitMdcFrontmatter(data []byte) (map[string]any, string) {
+	const delim = "---"
+	empty := map[string]any{}
+
+	if !bytes.HasPrefix(data, []byte(delim)) {
+		return empty, string(data)
+	}
+	rest := data[len(delim):]
+	idx := bytes.Index(rest, []byte("\n"+delim))
+	if idx < 0 {
+		return empty, string(data)
+	}
+	yamlPart := rest[:idx]
+	body := bytes.TrimLeft(rest[idx+len("\n"+delim):], "\n")
+
+	var meta map[string]any
+	if err := yaml.Unmarshal(yamlPart, &meta); err != nil {
+		return empty, string(data)
+	}
+	if meta == nil {
+		meta = empty
+	}
+	return meta, string(body)
+}

--- a/internal/cli/import_cursor_test.go
+++ b/internal/cli/import_cursor_test.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func TestImportFromCursor_RefusesIfConfigExists(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "agnostic.config.yaml"), "version: 1\n")
+	if err := importFromCursor(dir); err == nil {
+		t.Error("expected error when config already exists")
+	}
+}
+
+func TestImportFromCursor_TranslatesRules(t *testing.T) {
+	dir := t.TempDir()
+	mdc := `---
+description: Always use Conventional Commits.
+globs: "**/*"
+alwaysApply: true
+---
+
+Use ` + "`feat:`" + `, ` + "`fix:`" + `, etc.
+`
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "conventional-commits.mdc"), mdc)
+
+	if err := importFromCursor(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "rules", "conventional-commits.md"))
+	if err != nil {
+		t.Fatalf("missing rules/conventional-commits.md: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"name: conventional-commits",
+		"description: Always use Conventional Commits.",
+		"alwaysApply: true",
+		"Use `feat:`, `fix:`, etc.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestImportFromCursor_NoFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "loose.mdc"), "Just plain body.\n")
+
+	if err := importFromCursor(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "rules", "loose.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "name: loose") {
+		t.Errorf("expected name: loose in frontmatter, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Just plain body.") {
+		t.Errorf("expected body preserved, got:\n%s", got)
+	}
+}
+
+func TestImportFromCursor_PreservesUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	mdc := `---
+description: scoped
+globs: "src/**/*.ts"
+alwaysApply: false
+customKey: keep-me
+---
+
+body
+`
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "scoped.mdc"), mdc)
+
+	if err := importFromCursor(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, "rules", "scoped.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"globs: src/**/*.ts",
+		"customKey: keep-me",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestImportFromCursor_NoCursorDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromCursor(dir); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(dir, "rules"))
+	if len(entries) != 0 {
+		t.Errorf("expected empty rules/, got %d entries", len(entries))
+	}
+}
+
+func TestImportFromCursor_WritesCursorOnlyConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromCursor(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "- cursor") {
+		t.Errorf("expected cursor target, got %s", data)
+	}
+	if strings.Contains(string(data), "- claude") {
+		t.Errorf("expected only cursor target, got %s", data)
+	}
+}
+
+func TestImportFromCursor_SkipsNonMdc(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "keep.mdc"), "body\n")
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "ignore.txt"), "ignored\n")
+
+	if err := importFromCursor(dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "keep.md")); err != nil {
+		t.Errorf("expected keep.md, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "ignore.md")); err == nil {
+		t.Error("did not expect ignore.md")
+	}
+}
+
+func TestInitCmd_FromCursorRoutes(t *testing.T) {
+	dir := t.TempDir()
+	mdc := `---
+description: routed
+---
+
+body
+`
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "routed.mdc"), mdc)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"init", "--from", "cursor"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "routed.md")); err != nil {
+		t.Error("expected rules/routed.md after init --from cursor")
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -19,12 +19,14 @@ func newInitCmd() *cobra.Command {
 				return scaffold(".")
 			case "claude":
 				return importFromClaude(".")
+			case "cursor":
+				return importFromCursor(".")
 			default:
-				return fmt.Errorf("unknown source for --from: %q (supported: claude)", from)
+				return fmt.Errorf("unknown source for --from: %q (supported: claude, cursor)", from)
 			}
 		},
 	}
-	cmd.Flags().StringVar(&from, "from", "", "Import existing config from a source (supported: claude)")
+	cmd.Flags().StringVar(&from, "from", "", "Import existing config from a source (supported: claude, cursor)")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
- Extends `agnostic-ai init` with a new `--from cursor` source so existing Cursor projects can be lifted into the agnostic format in one command.
- Reads `.cursor/rules/*.mdc`, translates each into `rules/<name>.md`, and writes a cursor-only `agnostic.config.yaml`.
- Frontmatter (`description`, `globs`, `alwaysApply`, plus any custom keys) passes through verbatim; `name:` is injected from the filename when missing.
- Round-trips cleanly: `init --from cursor` followed by `sync` regenerates equivalent `.cursor/rules/*.mdc`, then fans the same rules out to Claude, Codex, Gemini, Copilot, Aider, Cline, Windsurf, and Continue.

## Why
Cursor is one of the most widely used AI coding tools, and a lot of teams have already invested real time tuning their `.cursor/rules/`. Without an importer, those teams have to either rewrite rules by hand or stay locked into a single tool. This change turns Cursor into a first-class entry point: open an existing Cursor project, run one command, and immediately get the same rules working in every other supported AI tool — with no manual conversion and no risk of drift between editors.

## Test plan
- [x] `make test` — full suite passes (new `import_cursor_test.go` covers config-exists guard, frontmatter translation, no-frontmatter fallback, unknown-keys passthrough, missing-dir, cursor-only-config, non-`.mdc` skipping, and CLI routing)
- [x] `go vet` clean
- [x] Manual end-to-end: `.cursor/rules/*.mdc` → `init --from cursor` → edit config to add more targets → `sync` → fans out to Claude / Codex / Gemini / Copilot / Aider / etc.

## Notes
- The existing `TestInitCmd_UnknownFromRejected` test used `cursor` as its "unknown source" sentinel; switched it to `nonesuch` since `cursor` is now valid.
- No new dependencies; reuses `gopkg.in/yaml.v3` already in the module.