### PR TITLE
feat(init): scaffold sources under configurable base dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- `agnostic-ai init` (bare, no `--from`) now scaffolds source folders under `.agnostic-ai/` instead of cluttering the project root. New `--dir <path>` flag overrides the base directory; pass `--dir .` to keep the legacy root-level layout. The generated `agnostic.config.yaml` reflects the chosen base via its `sources:` paths. Importers (`init --from ...`) keep the previous root-level layout.
+
 ## [v0.3.0] - 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Changed
-- `agnostic-ai init` (bare, no `--from`) now scaffolds source folders under `.agnostic-ai/` instead of cluttering the project root. New `--dir <path>` flag overrides the base directory; pass `--dir .` to keep the legacy root-level layout. The generated `agnostic.config.yaml` reflects the chosen base via its `sources:` paths. Importers (`init --from ...`) keep the previous root-level layout.
+- `agnostic-ai init` scaffolds source folders under `.agnostic-ai/` by default (was project root).
+- `agnostic-ai init --dir <path>`: choose the base directory. Use `--dir .` for the legacy root-level layout.
 
 ## [v0.3.0] - 2026-05-04
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -46,11 +46,11 @@ func newInitCmd() *cobra.Command {
 const defaultConfig = `version: 1
 
 sources:
-  agents: agents
-  skills: skills
-  rules: rules
-  hooks: hooks
-  mcps: mcps
+  agents: .agnostic-ai/agents
+  skills: .agnostic-ai/skills
+  rules: .agnostic-ai/rules
+  hooks: .agnostic-ai/hooks
+  mcps: .agnostic-ai/mcps
 
 targets:
   - claude
@@ -75,7 +75,13 @@ func scaffold(root string) error {
 	if _, err := os.Stat(cfgPath); err == nil {
 		return fmt.Errorf("agnostic.config.yaml already exists")
 	}
-	dirs := []string{"agents", "skills", "rules", "hooks", "mcps"}
+	dirs := []string{
+		filepath.Join(".agnostic-ai", "agents"),
+		filepath.Join(".agnostic-ai", "skills"),
+		filepath.Join(".agnostic-ai", "rules"),
+		filepath.Join(".agnostic-ai", "hooks"),
+		filepath.Join(".agnostic-ai", "mcps"),
+	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
 			return err
@@ -84,6 +90,6 @@ func scaffold(root string) error {
 	if err := os.WriteFile(cfgPath, []byte(defaultConfig), 0o644); err != nil {
 		return err
 	}
-	fmt.Println("scaffold complete. edit agents/, skills/, rules/, hooks/, mcps/ then run `agnostic-ai sync`.")
+	fmt.Println("scaffold complete. edit .agnostic-ai/{agents,skills,rules,hooks,mcps}/ then run `agnostic-ai sync`.")
 	return nil
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -4,9 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+// defaultBaseDir is the default parent directory for scaffolded source
+// folders (agents, skills, rules, hooks, mcps).
+const defaultBaseDir = ".agnostic-ai"
 
 // rulesDirImporters maps a --from source name to the rules directory the
 // importer walks. Claude, Codex, and Cursor have richer importers and
@@ -19,13 +24,14 @@ var rulesDirImporters = map[string]string{
 
 func newInitCmd() *cobra.Command {
 	var from string
+	var dir string
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Scaffold an agnostic-ai project in the current directory.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch from {
 			case "":
-				return scaffold(".")
+				return scaffold(".", dir)
 			case "claude":
 				return importFromClaude(".")
 			case "codex":
@@ -40,17 +46,25 @@ func newInitCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&from, "from", "", "Import existing config from a source (supported: claude, codex, cursor, cline, windsurf, continue)")
+	cmd.Flags().StringVar(&dir, "dir", defaultBaseDir, "Base directory for scaffolded source folders. Use \".\" to write at project root.")
 	return cmd
 }
 
-const defaultConfig = `version: 1
+// renderDefaultConfig builds agnostic.config.yaml with source paths nested
+// under base. base="." writes paths at the project root.
+func renderDefaultConfig(base string) string {
+	prefix := ""
+	if base != "" && base != "." {
+		prefix = filepath.ToSlash(base) + "/"
+	}
+	return fmt.Sprintf(`version: 1
 
 sources:
-  agents: .agnostic-ai/agents
-  skills: .agnostic-ai/skills
-  rules: .agnostic-ai/rules
-  hooks: .agnostic-ai/hooks
-  mcps: .agnostic-ai/mcps
+  agents: %sagents
+  skills: %sskills
+  rules: %srules
+  hooks: %shooks
+  mcps: %smcps
 
 targets:
   - claude
@@ -68,28 +82,34 @@ targets:
   - opencode
 
 on-unsupported: warn
-`
+`, prefix, prefix, prefix, prefix, prefix)
+}
 
-func scaffold(root string) error {
+func scaffold(root, base string) error {
 	cfgPath := filepath.Join(root, "agnostic.config.yaml")
 	if _, err := os.Stat(cfgPath); err == nil {
 		return fmt.Errorf("agnostic.config.yaml already exists")
 	}
-	dirs := []string{
-		filepath.Join(".agnostic-ai", "agents"),
-		filepath.Join(".agnostic-ai", "skills"),
-		filepath.Join(".agnostic-ai", "rules"),
-		filepath.Join(".agnostic-ai", "hooks"),
-		filepath.Join(".agnostic-ai", "mcps"),
+	if base == "" {
+		base = defaultBaseDir
 	}
-	for _, d := range dirs {
-		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+	kinds := []string{"agents", "skills", "rules", "hooks", "mcps"}
+	for _, k := range kinds {
+		if err := os.MkdirAll(filepath.Join(root, base, k), 0o755); err != nil {
 			return err
 		}
 	}
-	if err := os.WriteFile(cfgPath, []byte(defaultConfig), 0o644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte(renderDefaultConfig(base)), 0o644); err != nil {
 		return err
 	}
-	fmt.Println("scaffold complete. edit .agnostic-ai/{agents,skills,rules,hooks,mcps}/ then run `agnostic-ai sync`.")
+	fmt.Printf("scaffold complete. edit %s then run `agnostic-ai sync`.\n", scaffoldHint(base, kinds))
 	return nil
+}
+
+func scaffoldHint(base string, kinds []string) string {
+	list := strings.Join(kinds, ",")
+	if base == "" || base == "." {
+		return fmt.Sprintf("{%s}/", list)
+	}
+	return fmt.Sprintf("%s/{%s}/", filepath.ToSlash(base), list)
 }

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -12,8 +12,8 @@ func TestScaffold_CreatesLayout(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
-		if _, err := os.Stat(filepath.Join(dir, d)); err != nil {
-			t.Errorf("missing %s", d)
+		if _, err := os.Stat(filepath.Join(dir, ".agnostic-ai", d)); err != nil {
+			t.Errorf("missing .agnostic-ai/%s", d)
 		}
 	}
 	if _, err := os.Stat(filepath.Join(dir, "agnostic.config.yaml")); err != nil {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -3,12 +3,13 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestScaffold_CreatesLayout(t *testing.T) {
+func TestScaffold_DefaultBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir); err != nil {
+	if err := scaffold(dir, ""); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
@@ -16,8 +17,67 @@ func TestScaffold_CreatesLayout(t *testing.T) {
 			t.Errorf("missing .agnostic-ai/%s", d)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(dir, "agnostic.config.yaml")); err != nil {
-		t.Error("missing agnostic.config.yaml")
+	cfg, err := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(cfg), "agents: .agnostic-ai/agents") {
+		t.Errorf("config missing nested agents path:\n%s", cfg)
+	}
+}
+
+func TestScaffold_CustomBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffold(dir, "specs"); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
+		if _, err := os.Stat(filepath.Join(dir, "specs", d)); err != nil {
+			t.Errorf("missing specs/%s", d)
+		}
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(cfg), "agents: specs/agents") {
+		t.Errorf("config missing custom path:\n%s", cfg)
+	}
+}
+
+func TestScaffold_BaseDirDot_WritesAtRoot(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffold(dir, "."); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
+		if _, err := os.Stat(filepath.Join(dir, d)); err != nil {
+			t.Errorf("missing %s at root", d)
+		}
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(cfg), "agents: agents\n") {
+		t.Errorf("config should use bare paths when base is '.':\n%s", cfg)
+	}
+}
+
+func TestScaffold_NestedBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffold(dir, filepath.Join("config", "ai")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config", "ai", "agents")); err != nil {
+		t.Errorf("missing config/ai/agents")
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(cfg), "agents: config/ai/agents") {
+		t.Errorf("config missing nested base path:\n%s", cfg)
 	}
 }
 
@@ -27,7 +87,7 @@ func TestScaffold_RefusesIfConfigExists(t *testing.T) {
 		[]byte("version: 1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir); err == nil {
+	if err := scaffold(dir, ""); err == nil {
 		t.Error("expected error when config already exists")
 	}
 }

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -91,9 +91,9 @@ func TestInit_ScaffoldsLayout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, d := range []string{"agents", "skills", "rules", "hooks"} {
-		if _, err := os.Stat(filepath.Join(dir, d)); err != nil {
-			t.Errorf("expected dir %s to exist", d)
+	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
+		if _, err := os.Stat(filepath.Join(dir, ".agnostic-ai", d)); err != nil {
+			t.Errorf("expected dir .agnostic-ai/%s to exist", d)
 		}
 	}
 	if _, err := os.Stat(filepath.Join(dir, "agnostic.config.yaml")); err != nil {


### PR DESCRIPTION
## Summary
- `init` scaffolds sources under `.agnostic-ai/` by default
- `--dir <path>` overrides the base dir (e.g. `--dir specs`, `--dir .` for legacy root layout)
- Generated `agnostic.config.yaml` reflects the chosen base