### PR TITLE
feat(codex): emit subagents as .codex/agents/*.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 - `agnostic-ai import <source>`: translate an existing AI CLI configuration into agnostic specs in an already-initialized project. Honors the `sources:` paths from `agnostic.config.yaml`. Sources: `claude`, `codex`, `cursor`, `cline`, `windsurf`, `continue`.
+- Codex subagent emission: each agent now emits to `.codex/agents/<name>.toml` (Codex CLI subagent schema). Override the location with `outputs.codex.agents-dir`. Frontmatter `model`, `model_reasoning_effort`, `sandbox_mode`, `nickname_candidates` (under `x-codex:`) pass through to the TOML.
 
 ### Changed
 - `agnostic-ai init` scaffolds source folders under `.agnostic-ai/` by default (was project root).
 - `agnostic-ai init [dir]` accepts an optional positional argument to override the base directory. Use `agnostic-ai init .` for the legacy root-level layout.
+- Codex `AGENTS.md` `## Agents` section no longer inlines agent bodies. It lists each agent with its description and a pointer to the source TOML, so the body lives in exactly one place.
 
 ### Removed
 - `agnostic-ai init --from <source>` flag. Run `agnostic-ai init` followed by `agnostic-ai import <source>` instead.

--- a/README.md
+++ b/README.md
@@ -12,16 +12,17 @@ Write prompts and project conventions **once**. agnostic-ai emits the right conf
 Aligned with the [AGENTS.md](https://agents.md) open standard. Markdown body + YAML frontmatter, no proprietary extensions.
 
 ```
-                               ┌──► .claude/agents/*.md
-                               ├──► CLAUDE.md
-                               ├──► AGENTS.md          (Codex)
-   agents/                     ├──► GEMINI.md
-   skills/  agnostic-ai sync   ├──► .cursor/rules/*.mdc
-   rules/   ─────────────────► ├──► .github/copilot-instructions.md
-   hooks/                      ├──► CONVENTIONS.md    (Aider)
-                               ├──► .clinerules/*.md
-                               ├──► .windsurf/rules/*.md
-                               └──► .continue/rules/*.md
+                                  ┌──► .claude/agents/*.md
+                                  ├──► CLAUDE.md
+                                  ├──► AGENTS.md            (Codex)
+                                  ├──► .codex/agents/*.toml (Codex subagents)
+   .agnostic-ai/agents/           ├──► GEMINI.md
+   .agnostic-ai/skills/  sync     ├──► .cursor/rules/*.mdc
+   .agnostic-ai/rules/   ───────► ├──► .github/copilot-instructions.md
+   .agnostic-ai/hooks/            ├──► CONVENTIONS.md      (Aider)
+                                  ├──► .clinerules/*.md
+                                  ├──► .windsurf/rules/*.md
+                                  └──► .continue/rules/*.md
 ```
 
 ## Supported targets
@@ -29,7 +30,7 @@ Aligned with the [AGENTS.md](https://agents.md) open standard. Markdown body + Y
 | Target         | Agents | Skills | Rules | Hooks | MCPs |
 |----------------|:------:|:------:|:-----:|:-----:|:----:|
 | Claude Code    |   ✅    |   ✅    |   ✅   |   ✅   |  ✅   |
-| Codex CLI      |   ◐    |   ◐    |   ✅   |   -   |  -   |
+| Codex CLI      |   ✅    |   ◐    |   ✅   |   -   |  -   |
 | Gemini CLI     |   ◐    |   ◐    |   ✅   |   -   |  -   |
 | Cursor         |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
 | GitHub Copilot |   ◐    |   ◐    |   ✅   |   -   |  ✅   |
@@ -57,7 +58,7 @@ More options (Homebrew, curl one-liner): [docs/user/getting-started.md](docs/use
 ## Quickstart
 
 ```bash
-agnostic-ai init    # scaffold agents/, skills/, rules/, hooks/
+agnostic-ai init    # scaffold .agnostic-ai/{agents,skills,rules,hooks,mcps}/
 agnostic-ai sync    # emit configs for every target
 ```
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -93,7 +93,8 @@ Per-target paths. Each target reads only the fields it understands; irrelevant f
 |--------|-------|---------|-------|
 | `claude` | `dir` | `.claude` | Holds `agents/`, `skills/`, `settings.json`. |
 | `claude` | `rules-file` | `CLAUDE.md` | Concatenated rules document. |
-| `codex` | `file` | `AGENTS.md` | Single merged document. |
+| `codex` | `file` | `AGENTS.md` | Single merged document (rules + agent listing + skill listing). Nested `<dir>/AGENTS.md` files share this base. |
+| `codex` | `agents-dir` | `.codex/agents` | One TOML file per agent (Codex subagent schema). |
 | `gemini` | `file` | `GEMINI.md` | Single merged document. |
 | `cursor` | `rules-dir` | `.cursor/rules` | One `.mdc` per rule and per agent. |
 | `copilot` | `file` | `.github/copilot-instructions.md` | Single merged document. |

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -94,6 +94,7 @@ Full tree after sync with the default targets:
 ├── CLAUDE.md                                    # for Claude Code
 ├── AGENT.md                                     # for Amp
 ├── AGENTS.md                                    # for Codex
+├── .codex/agents/<name>.toml                    # for Codex subagents
 ├── GEMINI.md                                    # for Gemini CLI
 ├── WARP.md                                      # for Warp
 ├── CONVENTIONS.md                               # for Aider

--- a/internal/adapters/codex/agent_toml.go
+++ b/internal/adapters/codex/agent_toml.go
@@ -1,0 +1,118 @@
+package codex
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// agentTOML renders a Codex CLI custom-agent TOML document for a single
+// agent spec. The schema follows
+// https://developers.openai.com/codex/subagents:
+//
+//	name                   (required, from spec.Name)
+//	description            (required, from frontmatter; falls back to name)
+//	developer_instructions (required, from spec body; falls back to description)
+//	model                  (optional, from frontmatter or x-codex.model)
+//	model_reasoning_effort (optional, from x-codex)
+//	sandbox_mode           (optional, from x-codex)
+//	nickname_candidates    (optional, []string from x-codex)
+//
+// Other Codex agent fields (mcp_servers, skills.config) are not yet
+// translated; pass them through `x-codex` raw if needed in a follow-up.
+func agentTOML(a spec.Entry) string {
+	meta := emit.ResolveMeta(a.Meta, target)
+
+	description := stringOr(meta, "description", a.Name)
+	instructions := strings.TrimSpace(a.Body)
+	if instructions == "" {
+		instructions = description
+	}
+
+	var sb strings.Builder
+	writeTOMLString(&sb, "name", a.Name)
+	writeTOMLString(&sb, "description", description)
+	writeTOMLMultiline(&sb, "developer_instructions", instructions)
+
+	if v := stringOr(meta, "model", ""); v != "" {
+		writeTOMLString(&sb, "model", v)
+	}
+	if v := stringOr(meta, "model_reasoning_effort", ""); v != "" {
+		writeTOMLString(&sb, "model_reasoning_effort", v)
+	}
+	if v := stringOr(meta, "sandbox_mode", ""); v != "" {
+		writeTOMLString(&sb, "sandbox_mode", v)
+	}
+	if names := stringSlice(meta["nickname_candidates"]); len(names) > 0 {
+		writeTOMLStringArray(&sb, "nickname_candidates", names)
+	}
+	return sb.String()
+}
+
+func stringOr(meta map[string]any, key, fallback string) string {
+	if v, ok := meta[key].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+// stringSlice converts an []any of strings (yaml's default) into []string.
+// Returns nil for any other shape so the caller can skip the field.
+func stringSlice(v any) []string {
+	switch xs := v.(type) {
+	case []string:
+		return xs
+	case []any:
+		out := make([]string, 0, len(xs))
+		for _, x := range xs {
+			s, ok := x.(string)
+			if !ok {
+				return nil
+			}
+			out = append(out, s)
+		}
+		return out
+	}
+	return nil
+}
+
+// writeTOMLString writes `key = "value"` with backslashes and double
+// quotes escaped per the TOML basic-string rules.
+func writeTOMLString(sb *strings.Builder, key, value string) {
+	fmt.Fprintf(sb, "%s = \"%s\"\n", key, escapeTOMLBasic(value))
+}
+
+// writeTOMLMultiline writes `key = """\n<value>\n"""`. Backslashes and
+// double quotes inside value are escaped so the closing delimiter cannot
+// be confused with content.
+func writeTOMLMultiline(sb *strings.Builder, key, value string) {
+	escaped := escapeTOMLBasic(value)
+	sb.WriteString(key + " = \"\"\"\n")
+	sb.WriteString(escaped)
+	if !strings.HasSuffix(escaped, "\n") {
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("\"\"\"\n")
+}
+
+func writeTOMLStringArray(sb *strings.Builder, key string, values []string) {
+	sb.WriteString(key + " = [")
+	for i, v := range values {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("\"" + escapeTOMLBasic(v) + "\"")
+	}
+	sb.WriteString("]\n")
+}
+
+// escapeTOMLBasic escapes the two characters that can break out of a
+// basic (or basic-multiline) TOML string: backslash and double quote.
+// Newlines pass through unchanged so multiline literals stay readable.
+func escapeTOMLBasic(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}

--- a/internal/adapters/codex/agent_toml_test.go
+++ b/internal/adapters/codex/agent_toml_test.go
@@ -1,0 +1,91 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+func TestAgentTOML_EscapesQuotesAndBackslashes(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "tricky",
+		Body: `Body with "quotes" and a \ backslash and a """ run.`,
+		Meta: map[string]any{"description": `Says "hi" with a \ slash`},
+	}
+	got := agentTOML(a)
+	for _, want := range []string{
+		`description = "Says \"hi\" with a \\ slash"`,
+		`Body with \"quotes\" and a \\ backslash and a \"\"\" run.`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestAgentTOML_BodyFallsBackToDescription(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "minimal",
+		Meta: map[string]any{"description": "describe me"},
+	}
+	got := agentTOML(a)
+	if !strings.Contains(got, `description = "describe me"`) {
+		t.Errorf("missing description:\n%s", got)
+	}
+	if !strings.Contains(got, "describe me\n\"\"\"") {
+		t.Errorf("body should fall back to description when empty:\n%s", got)
+	}
+}
+
+func TestAgentTOML_DescriptionFallsBackToName(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "explorer",
+		Body: "Find things.",
+	}
+	got := agentTOML(a)
+	if !strings.Contains(got, `description = "explorer"`) {
+		t.Errorf("description should fall back to name:\n%s", got)
+	}
+}
+
+func TestAgentTOML_XCodexOverridesTopLevel(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "ag",
+		Body: "x",
+		Meta: map[string]any{
+			"model": "gpt-5",
+			"x-codex": map[string]any{
+				"model": "gpt-5.4",
+			},
+		},
+	}
+	got := agentTOML(a)
+	if !strings.Contains(got, `model = "gpt-5.4"`) {
+		t.Errorf("x-codex.model should win over top-level model:\n%s", got)
+	}
+	if strings.Contains(got, `model = "gpt-5"`+"\n") {
+		t.Errorf("top-level model should not survive once x-codex.model is set:\n%s", got)
+	}
+}
+
+func TestAgentTOML_NicknameCandidatesIgnoresNonStringSlice(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "ag",
+		Body: "x",
+		Meta: map[string]any{
+			"x-codex": map[string]any{
+				"nickname_candidates": []any{"Atlas", 42}, // mixed types: skip
+			},
+		},
+	}
+	got := agentTOML(a)
+	if strings.Contains(got, "nickname_candidates") {
+		t.Errorf("non-string slice should be skipped:\n%s", got)
+	}
+}

--- a/internal/adapters/codex/codex.go
+++ b/internal/adapters/codex/codex.go
@@ -1,4 +1,5 @@
-// Package codex emits AGENTS.md hierarchies for the Codex CLI.
+// Package codex emits AGENTS.md hierarchies and .codex/agents/*.toml
+// files for the Codex CLI.
 //
 // The Codex CLI reads AGENTS.md for project conventions and supports
 // nested AGENTS.md files in subdirectories that scope to that subtree.
@@ -9,9 +10,14 @@
 //   - "**/*"          -> root
 //   - "**/*.go"       -> root (no fixed prefix)
 //
-// Agents and skills attach to the root document only. Codex has no native
-// skill or hook systems, so skills are listed by name + source path and
-// hooks are skipped.
+// Agents emit as one TOML file per agent under .codex/agents/ (override
+// via outputs.codex.agents-dir) following the Codex subagents schema.
+// The root AGENTS.md keeps a `## Agents` reference section listing each
+// agent name, description, and source TOML path so humans browsing the
+// document still see what is available.
+//
+// Codex has no native skill or hook systems: skills are listed by name +
+// source path; hooks are skipped.
 package codex
 
 import (
@@ -25,8 +31,9 @@ import (
 )
 
 const (
-	target         = "codex"
-	defaultOutFile = "AGENTS.md"
+	target           = "codex"
+	defaultOutFile   = "AGENTS.md"
+	defaultAgentsDir = ".codex/agents"
 )
 
 var caps = emit.Capabilities{
@@ -44,8 +51,8 @@ func New() *Adapter { return &Adapter{} }
 // Name returns the target identifier.
 func (Adapter) Name() string { return target }
 
-// Emit writes the root AGENTS.md and any nested AGENTS.md files implied
-// by rule globs.
+// Emit writes the root AGENTS.md, any nested AGENTS.md files implied by
+// rule globs, and one .codex/agents/<name>.toml per agent.
 func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
 		return err
@@ -54,6 +61,14 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	rootFile := emit.OutputFile(cfg, target, defaultOutFile)
 	rootDir := filepath.Dir(rootFile)
 	rootBase := filepath.Base(rootFile)
+	agentsDir := emit.OutputAgentsDir(cfg, target, defaultAgentsDir)
+
+	for _, a := range b.Agents {
+		path := filepath.Join(agentsDir, a.Name+".toml")
+		if err := emit.WriteFile(path, agentTOML(a), dryRun); err != nil {
+			return err
+		}
+	}
 
 	byDir := groupRulesByDir(b.Rules)
 
@@ -67,7 +82,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		writeHeader(&sb, dir)
 		writeRules(&sb, byDir[dir])
 		if dir == "" {
-			writeAgents(&sb, b.Agents)
+			writeAgents(&sb, b.Agents, agentsDir)
 			writeSkills(&sb, b.Skills)
 		}
 		path := filepath.Join(rootDir, dir, rootBase)
@@ -128,13 +143,22 @@ func writeRules(sb *strings.Builder, rules []spec.Entry) {
 	}
 }
 
-func writeAgents(sb *strings.Builder, agents []spec.Entry) {
+// writeAgents renders a reference listing of agents in AGENTS.md. The
+// real definitions live in <agentsDir>/<name>.toml; this section just
+// helps humans see what is available without reading the TOML files.
+func writeAgents(sb *strings.Builder, agents []spec.Entry, agentsDir string) {
 	if len(agents) == 0 {
 		return
 	}
 	sb.WriteString("## Agents\n\n")
+	sb.WriteString("Custom Codex subagents. Definitions live in `" + agentsDir + "/`.\n\n")
 	for _, a := range agents {
-		emit.WriteSection(sb, a.Name, a)
+		sb.WriteString("### " + a.Name + "\n\n")
+		sb.WriteString(emit.SourceComment(a.Path))
+		if d := a.Description(); d != "" {
+			sb.WriteString("_" + d + "_\n\n")
+		}
+		sb.WriteString("Source: `" + filepath.ToSlash(filepath.Join(agentsDir, a.Name+".toml")) + "`\n\n")
 	}
 }
 

--- a/internal/adapters/codex/codex_test.go
+++ b/internal/adapters/codex/codex_test.go
@@ -27,16 +27,103 @@ func TestEmit_RootAgentsMd(t *testing.T) {
 	if !strings.Contains(got, "rule body") {
 		t.Errorf("missing rule body in:\n%s", got)
 	}
-	if !strings.Contains(got, "agent body") {
-		t.Errorf("missing agent body in:\n%s", got)
-	}
 	if !strings.Contains(got, "_agent desc_") {
 		t.Errorf("missing agent description in:\n%s", got)
+	}
+	if !strings.Contains(got, "Source: `.codex/agents/ag1.toml`") {
+		t.Errorf("missing agent toml reference in:\n%s", got)
+	}
+	if strings.Contains(got, "agent body") {
+		t.Errorf("agent body must live only in the toml file, not AGENTS.md:\n%s", got)
 	}
 	for _, want := range []string{"<!-- source: rules/r1.md -->", "<!-- source: agents/ag1.md -->"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing provenance %q in:\n%s", want, got)
 		}
+	}
+}
+
+func TestEmit_AgentTOMLFile(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "pr-reviewer",
+			Body: "Review like an owner.\nLead with concrete findings.",
+			Meta: map[string]any{
+				"description": "PR reviewer",
+				"model":       "gpt-5",
+				"x-codex": map[string]any{
+					"sandbox_mode":           "read-only",
+					"model_reasoning_effort": "high",
+					"nickname_candidates":    []any{"Atlas", "Delta"},
+				},
+			}},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/agents/pr-reviewer.toml"))
+	for _, want := range []string{
+		`name = "pr-reviewer"`,
+		`description = "PR reviewer"`,
+		`developer_instructions = """`,
+		"Review like an owner.",
+		`model = "gpt-5"`,
+		`sandbox_mode = "read-only"`,
+		`model_reasoning_effort = "high"`,
+		`nickname_candidates = ["Atlas", "Delta"]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("toml missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestEmit_AgentTOML_NoExtras(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "explorer", Body: "Trace execution paths."},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/agents/explorer.toml"))
+	for _, want := range []string{
+		`name = "explorer"`,
+		`description = "explorer"`, // falls back to name when frontmatter description missing
+		`developer_instructions = """`,
+		"Trace execution paths.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("toml missing %q in:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{"model =", "sandbox_mode =", "nickname_candidates ="} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("toml should omit empty optional %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestEmit_AgentTOML_RespectsAgentsDirOverride(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{"codex": {AgentsDir: "vendor/codex/agents"}},
+	}
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "scout", Body: "Look around."},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vendor/codex/agents/scout.toml")); err != nil {
+		t.Errorf("expected toml at custom agents-dir: %v", err)
+	}
+	got := readFile(t, filepath.Join(dir, "AGENTS.md"))
+	if !strings.Contains(got, "vendor/codex/agents/scout.toml") {
+		t.Errorf("AGENTS.md should reference the override path:\n%s", got)
 	}
 }
 
@@ -125,12 +212,12 @@ func TestEmit_AgentsAndSkillsAttachToRootOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	root := readFile(t, filepath.Join(dir, "AGENTS.md"))
-	if !strings.Contains(root, "agent body") {
-		t.Errorf("agents must be in root: %s", root)
+	if !strings.Contains(root, "## Agents") {
+		t.Errorf("agents listing must be in root AGENTS.md: %s", root)
 	}
 	srcDoc := readFile(t, filepath.Join(dir, "src", "AGENTS.md"))
-	if strings.Contains(srcDoc, "agent body") {
-		t.Errorf("agents must not be in nested doc: %s", srcDoc)
+	if strings.Contains(srcDoc, "## Agents") {
+		t.Errorf("agents listing must not appear in nested AGENTS.md: %s", srcDoc)
 	}
 }
 

--- a/internal/adapters/internal/emit/output.go
+++ b/internal/adapters/internal/emit/output.go
@@ -41,3 +41,11 @@ func OutputMCPFile(cfg *config.Config, target, fallback string) string {
 	}
 	return fallback
 }
+
+// OutputAgentsDir returns cfg.Outputs[target].AgentsDir when set, otherwise fallback.
+func OutputAgentsDir(cfg *config.Config, target, fallback string) string {
+	if o, ok := cfg.Outputs[target]; ok && o.AgentsDir != "" {
+		return o.AgentsDir
+	}
+	return fallback
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type Output struct {
 	RulesFile string `yaml:"rules-file,omitempty"`
 	RulesDir  string `yaml:"rules-dir,omitempty"`
 	MCPFile   string `yaml:"mcp-file,omitempty"`
+	AgentsDir string `yaml:"agents-dir,omitempty"`
 }
 
 func Load(root string) (*Config, error) {


### PR DESCRIPTION
## Summary
- Each agnostic agent spec now emits a Codex CLI subagent TOML file at `.codex/agents/<name>.toml`, following the [Codex subagents schema](https://developers.openai.com/codex/subagents).
- Required fields: `name`, `description` (frontmatter, falls back to spec name), `developer_instructions` (spec body, falls back to description).
- Optional fields read from frontmatter (override via `x-codex:`): `model`, `model_reasoning_effort`, `sandbox_mode`, `nickname_candidates`.
- New `outputs.codex.agents-dir` overrides the destination.
- `AGENTS.md` `## Agents` section drops body inlining; it now lists each agent with description + source TOML path so the body lives in exactly one place.