### PR TITLE
feat(sync): add --watch flag to re-emit on spec changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+- `agnostic-ai sync --watch`: keep the process alive and re-emit on any change under the source directories or `agnostic.config.yaml`. Polls every 200 ms (natural debounce for rapid edits). Ctrl+C exits cleanly. Incompatible with `--check` (errors early).
 - `agnostic-ai init --demo`: seed each source folder with one minimal example spec (`agents/code-reviewer.md`, `skills/yaml-validator.md`, `rules/conventional-commits.md`, `hooks/format-on-save.yaml`, `mcps/filesystem.yaml`) so a fresh project produces real `sync` output immediately. Existing files are never overwritten.
 - `agnostic-ai import <source>`: translate an existing AI CLI configuration into agnostic specs in an already-initialized project. Honors the `sources:` paths from `agnostic.config.yaml`. Sources: `claude`, `codex`, `cursor`, `cline`, `windsurf`, `continue`.
 - Codex subagent emission: each agent now emits to `.codex/agents/<name>.toml` (Codex CLI subagent schema). Override the location with `outputs.codex.agents-dir`. Frontmatter `model`, `model_reasoning_effort`, `sandbox_mode`, `nickname_candidates` (under `x-codex:`) pass through to the TOML.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ agnostic-ai init                  # scaffold .agnostic-ai/{agents,skills,rules,h
 agnostic-ai init --demo           # same, plus one example spec per folder to learn from
 agnostic-ai sync                  # emit native config for every target
 agnostic-ai sync --dry-run        # preview without writing
+agnostic-ai sync --watch          # re-emit on spec changes (Ctrl+C to exit)
 agnostic-ai revert                # undo last sync
 ```
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -12,7 +16,7 @@ import (
 
 func newSyncCmd() *cobra.Command {
 	var targets []string
-	var dryRun, check, backup bool
+	var dryRun, check, backup, watch bool
 	var gitignoreFlag string
 
 	cmd := &cobra.Command{
@@ -21,6 +25,9 @@ func newSyncCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateGitignoreFlag(gitignoreFlag); err != nil {
 				return err
+			}
+			if watch && check {
+				return fmt.Errorf("--watch and --check are incompatible")
 			}
 			if check {
 				reports, err := collectDrift(targets)
@@ -32,42 +39,12 @@ func newSyncCmd() *cobra.Command {
 				}
 				return nil
 			}
-			cfg, b, err := loadProject(".")
-			if err != nil {
-				return err
+			if watch {
+				ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+				defer stop()
+				return watchSync(ctx, 200*time.Millisecond, ".", targets, dryRun, backup, gitignoreFlag)
 			}
-			if len(targets) == 0 {
-				targets = cfg.Targets
-			}
-			if backup {
-				adapters.SetBackup(true)
-				defer adapters.SetBackup(false)
-			}
-			gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
-			if gitignoreOn {
-				adapters.StartRecording()
-			}
-			for _, t := range targets {
-				adapter, ok := adapters.Get(t)
-				if !ok {
-					fmt.Fprintf(os.Stderr, "! unknown target: %s\n", t)
-					continue
-				}
-				fmt.Printf("→ emit %s\n", t)
-				if err := adapter.Emit(b, cfg, dryRun); err != nil {
-					if gitignoreOn {
-						adapters.StopRecording()
-					}
-					return fmt.Errorf("%s: %w", t, err)
-				}
-			}
-			if gitignoreOn {
-				if err := updateGitignore(cfg, normalizeAndSort(adapters.StopRecording())); err != nil {
-					return fmt.Errorf("gitignore: %w", err)
-				}
-				fmt.Println("→ updated .gitignore")
-			}
-			return nil
+			return runSyncOnce(".", targets, dryRun, backup, gitignoreFlag)
 		},
 	}
 	cmd.Flags().StringSliceVarP(&targets, "target", "t", nil, "Targets to emit (default: all in config)")
@@ -75,7 +52,48 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&check, "check", false, "Compare emitted output to disk; non-zero exit on drift")
 	cmd.Flags().BoolVar(&backup, "backup", false, "Copy each existing target file to <path>.bak before overwriting")
 	cmd.Flags().StringVar(&gitignoreFlag, "gitignore", "", "Override config: 'on' or 'off' to manage the .gitignore block this run.")
+	cmd.Flags().BoolVar(&watch, "watch", false, "Re-emit on spec changes (Ctrl+C to exit)")
 	return cmd
+}
+
+func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
+	cfg, b, err := loadProject(root)
+	if err != nil {
+		return err
+	}
+	effectiveTargets := targets
+	if len(effectiveTargets) == 0 {
+		effectiveTargets = cfg.Targets
+	}
+	if backup {
+		adapters.SetBackup(true)
+		defer adapters.SetBackup(false)
+	}
+	gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
+	if gitignoreOn {
+		adapters.StartRecording()
+	}
+	for _, t := range effectiveTargets {
+		adapter, ok := adapters.Get(t)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "! unknown target: %s\n", t)
+			continue
+		}
+		fmt.Printf("→ emit %s\n", t)
+		if err := adapter.Emit(b, cfg, dryRun); err != nil {
+			if gitignoreOn {
+				adapters.StopRecording()
+			}
+			return fmt.Errorf("%s: %w", t, err)
+		}
+	}
+	if gitignoreOn {
+		if err := updateGitignore(cfg, normalizeAndSort(adapters.StopRecording())); err != nil {
+			return fmt.Errorf("gitignore: %w", err)
+		}
+		fmt.Println("→ updated .gitignore")
+	}
+	return nil
 }
 
 // resolveGitignore picks the effective gitignore mode: the --gitignore

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// watchSync runs an initial sync then re-runs whenever a watched path changes.
+// Polls every interval; Ctrl-C (or ctx cancellation) exits cleanly.
+func watchSync(ctx context.Context, interval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
+	if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(root)
+	if err != nil {
+		return err
+	}
+	watched := watchDirs(root, cfg)
+	snapshot := collectMtimes(watched)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	fmt.Println("→ watching for changes (Ctrl+C to exit)")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			curr := collectMtimes(watched)
+			if !mtimesChanged(snapshot, curr) {
+				continue
+			}
+			snapshot = curr
+			fmt.Println("→ change detected, re-syncing")
+			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
+				fmt.Fprintf(os.Stderr, "! sync: %v\n", err)
+			}
+			if newCfg, err := config.Load(root); err == nil {
+				watched = watchDirs(root, newCfg)
+				snapshot = collectMtimes(watched)
+			}
+		}
+	}
+}
+
+// watchDirs returns the config file and source directories to watch.
+func watchDirs(root string, cfg *config.Config) []string {
+	paths := []string{filepath.Join(root, "agnostic.config.yaml")}
+	for _, src := range []string{
+		cfg.Sources.Agents,
+		cfg.Sources.Skills,
+		cfg.Sources.Rules,
+		cfg.Sources.Hooks,
+		cfg.Sources.MCPs,
+	} {
+		if src != "" {
+			paths = append(paths, filepath.Join(root, src))
+		}
+	}
+	pu := filepath.Join(root, defaultProjectUser)
+	if dirExists(pu) {
+		paths = append(paths, pu)
+	}
+	return paths
+}
+
+// collectMtimes walks paths and returns a file-path → mtime map.
+func collectMtimes(paths []string) map[string]time.Time {
+	mtimes := make(map[string]time.Time)
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			mtimes[p] = info.ModTime()
+			continue
+		}
+		_ = filepath.WalkDir(p, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			fi, err := d.Info()
+			if err != nil {
+				return nil
+			}
+			mtimes[path] = fi.ModTime()
+			return nil
+		})
+	}
+	return mtimes
+}
+
+// mtimesChanged reports whether any file was added, removed, or modified.
+func mtimesChanged(prev, curr map[string]time.Time) bool {
+	if len(prev) != len(curr) {
+		return true
+	}
+	for k, t := range curr {
+		if prev[k] != t {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func TestMtimesChanged_DetectsAdd(t *testing.T) {
+	prev := map[string]time.Time{"a": time.Unix(1, 0)}
+	curr := map[string]time.Time{"a": time.Unix(1, 0), "b": time.Unix(2, 0)}
+	if !mtimesChanged(prev, curr) {
+		t.Error("expected changed when file added")
+	}
+}
+
+func TestMtimesChanged_DetectsRemove(t *testing.T) {
+	prev := map[string]time.Time{"a": time.Unix(1, 0), "b": time.Unix(2, 0)}
+	curr := map[string]time.Time{"a": time.Unix(1, 0)}
+	if !mtimesChanged(prev, curr) {
+		t.Error("expected changed when file removed")
+	}
+}
+
+func TestMtimesChanged_DetectsModify(t *testing.T) {
+	prev := map[string]time.Time{"a": time.Unix(1, 0)}
+	curr := map[string]time.Time{"a": time.Unix(2, 0)}
+	if !mtimesChanged(prev, curr) {
+		t.Error("expected changed when mtime updated")
+	}
+}
+
+func TestMtimesChanged_NoChange(t *testing.T) {
+	prev := map[string]time.Time{"a": time.Unix(1, 0)}
+	curr := map[string]time.Time{"a": time.Unix(1, 0)}
+	if mtimesChanged(prev, curr) {
+		t.Error("expected no change when mtimes identical")
+	}
+}
+
+func TestCollectMtimes_WalksDir(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "x.md")
+	if err := os.WriteFile(f, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := collectMtimes([]string{dir})
+	if _, ok := m[f]; !ok {
+		t.Errorf("expected %s in mtimes map", f)
+	}
+}
+
+func TestCollectMtimes_SkipsMissingPath(t *testing.T) {
+	m := collectMtimes([]string{"/no/such/path/xyz"})
+	if len(m) != 0 {
+		t.Errorf("expected empty map for missing path, got %d entries", len(m))
+	}
+}
+
+func TestWatchSync_ReEmitsOnChange(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- watchSync(ctx, 10*time.Millisecond, ".", []string{"claude"}, false, false, "off")
+	}()
+
+	// Wait for initial sync.
+	time.Sleep(80 * time.Millisecond)
+
+	claudeMD := filepath.Join(dir, "CLAUDE.md")
+	if _, err := os.Stat(claudeMD); err != nil {
+		t.Fatal("initial sync did not produce CLAUDE.md")
+	}
+
+	// Remove the file so we can verify re-emit.
+	if err := os.Remove(claudeMD); err != nil {
+		t.Fatal(err)
+	}
+
+	// Touch the spec to trigger re-emit.
+	specPath := filepath.Join(dir, "rules", "r1.md")
+	content, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(15 * time.Millisecond) // ensure mtime advances
+	if err := os.WriteFile(specPath, append(content, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for watch loop to pick up the change.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(claudeMD); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if _, err := os.Stat(claudeMD); err != nil {
+		t.Error("watch did not re-emit CLAUDE.md after spec change")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWatchSync_CheckAndWatchIncompatible(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--watch", "--check"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for --watch --check combination")
+	}
+}


### PR DESCRIPTION
## Summary

- `sync --watch` polls source dirs and `agnostic.config.yaml` every 200 ms, re-emitting on any mtime change.
- Natural 200 ms debounce: rapid edits within one poll window trigger a single sync.
- `Ctrl+C` exits cleanly via `signal.NotifyContext`.
- `--watch --check` errors early (incompatible).
- Pure stdlib, no new dependencies.

Closes #23