### PR TITLE
feat(sync): add --auto-sync flag and first-run prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+- `agnostic-ai sync --auto-sync=yes|no`: on first `sync`, prompt (TTY) or accept the flag to write an `auto-sync` rule spec instructing agents to run `agnostic-ai sync` when spec files change. Answer persisted to `agnostic.config.yaml` (`autoSync: true/false`) so the prompt fires only once. Skipped in `--dry-run` mode.
 - `agnostic-ai sync --watch`: keep the process alive and re-emit on any change under the source directories or `agnostic.config.yaml`. Polls every 200 ms (natural debounce for rapid edits). Ctrl+C exits cleanly. Incompatible with `--check` (errors early).
 - `agnostic-ai init --demo`: seed each source folder with one minimal example spec (`agents/code-reviewer.md`, `skills/yaml-validator.md`, `rules/conventional-commits.md`, `hooks/format-on-save.yaml`, `mcps/filesystem.yaml`) so a fresh project produces real `sync` output immediately. Existing files are never overwritten.
 - `agnostic-ai import <source>`: translate an existing AI CLI configuration into agnostic specs in an already-initialized project. Honors the `sources:` paths from `agnostic.config.yaml`. Sources: `claude`, `codex`, `cursor`, `cline`, `windsurf`, `continue`.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ agnostic-ai init --demo           # same, plus one example spec per folder to le
 agnostic-ai sync                  # emit native config for every target
 agnostic-ai sync --dry-run        # preview without writing
 agnostic-ai sync --watch          # re-emit on spec changes (Ctrl+C to exit)
+agnostic-ai sync --auto-sync=yes  # write a rule telling agents to run sync on spec changes
 agnostic-ai revert                # undo last sync
 ```
 

--- a/internal/cli/autosync.go
+++ b/internal/cli/autosync.go
@@ -54,7 +54,7 @@ func handleAutoSync(root, flag string, in io.Reader, out io.Writer) error {
 		if err := writeAutoSyncSpec(rulesDir); err != nil {
 			return fmt.Errorf("write auto-sync spec: %w", err)
 		}
-		fmt.Fprintln(out, "→ auto-sync enabled: agents will run `agnostic-ai sync` when specs change")
+		_, _ = fmt.Fprintln(out, "→ auto-sync enabled: agents will run `agnostic-ai sync` when specs change")
 	}
 
 	return nil
@@ -93,7 +93,7 @@ func resolveAutoSync(cfg *config.Config, flag string, in io.Reader, out io.Write
 }
 
 func promptAutoSync(in io.Reader, out io.Writer) (bool, error) {
-	fmt.Fprint(out, "Sync automatically when specs change? [y/N] ")
+	_, _ = fmt.Fprint(out, "Sync automatically when specs change? [y/N] ")
 	br := bufio.NewReader(in)
 	line, err := br.ReadString('\n')
 	if err != nil && err != io.EOF {

--- a/internal/cli/autosync.go
+++ b/internal/cli/autosync.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/x/term"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const autoSyncSpecName = "auto-sync"
+
+const autoSyncSpecContent = `---
+name: auto-sync
+description: Run agnostic-ai sync when spec files change.
+alwaysApply: true
+---
+
+When any file under the agnostic-ai source directories (agents, skills, rules, hooks, or MCPs) is added, edited, or removed during a session, run ` + "`agnostic-ai sync`" + ` to regenerate all target configs.
+`
+
+// handleAutoSync runs the one-time auto-sync setup when appropriate.
+// Prompts on first sync (TTY only), or follows --auto-sync=yes|no.
+// A nil return means no action was taken (already decided, non-TTY, dry-run).
+func handleAutoSync(root, flag string, in io.Reader, out io.Writer) error {
+	if err := validateAutoSyncFlag(flag); err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(root)
+	if err != nil {
+		return err
+	}
+
+	enabled, err := resolveAutoSync(cfg, flag, in, out)
+	if err != nil {
+		return err
+	}
+	if enabled == nil {
+		return nil
+	}
+
+	if err := config.PersistAutoSync(root, *enabled); err != nil {
+		return fmt.Errorf("persist auto-sync: %w", err)
+	}
+
+	if *enabled {
+		rulesDir := filepath.Join(root, cfg.Sources.Rules)
+		if err := writeAutoSyncSpec(rulesDir); err != nil {
+			return fmt.Errorf("write auto-sync spec: %w", err)
+		}
+		fmt.Fprintln(out, "→ auto-sync enabled: agents will run `agnostic-ai sync` when specs change")
+	}
+
+	return nil
+}
+
+// resolveAutoSync returns whether auto-sync should be enabled.
+// Returns nil when no action is needed (already decided, or non-TTY without flag).
+func resolveAutoSync(cfg *config.Config, flag string, in io.Reader, out io.Writer) (*bool, error) {
+	yes, no := true, false
+
+	switch flag {
+	case "yes":
+		return &yes, nil
+	case "no":
+		return &no, nil
+	}
+
+	// Already answered: don't prompt again.
+	if cfg.AutoSync != nil {
+		return nil, nil
+	}
+
+	// First run: prompt only on a real terminal.
+	if file, ok := in.(*os.File); ok && term.IsTerminal(file.Fd()) {
+		answered, err := promptAutoSync(in, out)
+		if err != nil {
+			return nil, err
+		}
+		if answered {
+			return &yes, nil
+		}
+		return &no, nil
+	}
+
+	return nil, nil
+}
+
+func promptAutoSync(in io.Reader, out io.Writer) (bool, error) {
+	fmt.Fprint(out, "Sync automatically when specs change? [y/N] ")
+	br := bufio.NewReader(in)
+	line, err := br.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	return strings.ToLower(strings.TrimSpace(line)) == "y", nil
+}
+
+// writeAutoSyncSpec writes the auto-sync rule spec to rulesDir.
+// Skips when the file already exists (idempotent).
+func writeAutoSyncSpec(rulesDir string) error {
+	path := filepath.Join(rulesDir, autoSyncSpecName+".md")
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(autoSyncSpecContent), 0o644)
+}
+
+func validateAutoSyncFlag(flag string) error {
+	switch flag {
+	case "", "yes", "no":
+		return nil
+	}
+	return fmt.Errorf("--auto-sync: expected 'yes' or 'no', got %q", flag)
+}

--- a/internal/cli/autosync_test.go
+++ b/internal/cli/autosync_test.go
@@ -1,0 +1,329 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// helpers
+
+func boolPtr(b bool) *bool { return &b }
+
+func writeSimpleConfig(t *testing.T, dir string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(dir, "agnostic.config.yaml"),
+		[]byte("version: 1\n"), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// PersistAutoSync tests
+
+func TestPersistAutoSync_AppendsWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleConfig(t, dir)
+
+	if err := config.PersistAutoSync(dir, true); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if !strings.Contains(string(data), "autoSync: true") {
+		t.Errorf("expected autoSync: true in config, got:\n%s", data)
+	}
+}
+
+func TestPersistAutoSync_UpdatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	content := "version: 1\nautoSync: false\n"
+	if err := os.WriteFile(filepath.Join(dir, "agnostic.config.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := config.PersistAutoSync(dir, true); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if !strings.Contains(string(data), "autoSync: true") {
+		t.Errorf("expected autoSync: true after update, got:\n%s", data)
+	}
+	if strings.Contains(string(data), "autoSync: false") {
+		t.Error("old autoSync: false still present after update")
+	}
+}
+
+func TestPersistAutoSync_IdempotentOnRepeat(t *testing.T) {
+	dir := t.TempDir()
+	writeSimpleConfig(t, dir)
+
+	for range 3 {
+		if err := config.PersistAutoSync(dir, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	count := strings.Count(string(data), "autoSync:")
+	if count != 1 {
+		t.Errorf("expected exactly 1 autoSync: line, got %d:\n%s", count, data)
+	}
+}
+
+// resolveAutoSync tests
+
+func TestResolveAutoSync_FlagYes(t *testing.T) {
+	cfg := &config.Config{}
+	result, err := resolveAutoSync(cfg, "yes", bytes.NewReader(nil), &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil || !*result {
+		t.Error("expected true for flag=yes")
+	}
+}
+
+func TestResolveAutoSync_FlagNo(t *testing.T) {
+	cfg := &config.Config{}
+	result, err := resolveAutoSync(cfg, "no", bytes.NewReader(nil), &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil || *result {
+		t.Error("expected false for flag=no")
+	}
+}
+
+func TestResolveAutoSync_AlreadyAnsweredTrue(t *testing.T) {
+	cfg := &config.Config{AutoSync: boolPtr(true)}
+	result, err := resolveAutoSync(cfg, "", bytes.NewReader(nil), &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != nil {
+		t.Error("expected nil when already answered")
+	}
+}
+
+func TestResolveAutoSync_AlreadyAnsweredFalse(t *testing.T) {
+	cfg := &config.Config{AutoSync: boolPtr(false)}
+	result, err := resolveAutoSync(cfg, "", bytes.NewReader(nil), &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != nil {
+		t.Error("expected nil when already answered false")
+	}
+}
+
+func TestResolveAutoSync_NonTTYNoFlag(t *testing.T) {
+	cfg := &config.Config{} // AutoSync nil = first run
+	// bytes.Reader is not *os.File, so no TTY prompt fires
+	result, err := resolveAutoSync(cfg, "", strings.NewReader("y\n"), &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != nil {
+		t.Error("expected nil for non-TTY without flag")
+	}
+}
+
+// promptAutoSync tests
+
+func TestPromptAutoSync_Yes(t *testing.T) {
+	out := &bytes.Buffer{}
+	answered, err := promptAutoSync(strings.NewReader("y\n"), out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !answered {
+		t.Error("expected true for input 'y'")
+	}
+}
+
+func TestPromptAutoSync_YesUppercase(t *testing.T) {
+	out := &bytes.Buffer{}
+	answered, err := promptAutoSync(strings.NewReader("Y\n"), out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !answered {
+		t.Error("expected true for input 'Y'")
+	}
+}
+
+func TestPromptAutoSync_No(t *testing.T) {
+	out := &bytes.Buffer{}
+	answered, err := promptAutoSync(strings.NewReader("n\n"), out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answered {
+		t.Error("expected false for input 'n'")
+	}
+}
+
+func TestPromptAutoSync_Empty(t *testing.T) {
+	out := &bytes.Buffer{}
+	answered, err := promptAutoSync(strings.NewReader("\n"), out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answered {
+		t.Error("expected false (default N) for empty input")
+	}
+}
+
+// writeAutoSyncSpec tests
+
+func TestWriteAutoSyncSpec_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeAutoSyncSpec(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "auto-sync.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "agnostic-ai sync") {
+		t.Error("spec file missing sync instruction")
+	}
+}
+
+func TestWriteAutoSyncSpec_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	// Write custom content first
+	custom := "custom content"
+	if err := os.WriteFile(filepath.Join(dir, "auto-sync.md"), []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Should not overwrite existing file
+	if err := writeAutoSyncSpec(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "auto-sync.md"))
+	if string(data) != custom {
+		t.Error("writeAutoSyncSpec overwrote existing file")
+	}
+}
+
+// handleAutoSync integration tests
+
+func TestHandleAutoSync_FlagYesWritesSpec(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+
+	out := &bytes.Buffer{}
+	if err := handleAutoSync(".", "yes", bytes.NewReader(nil), out); err != nil {
+		t.Fatal(err)
+	}
+
+	specPath := filepath.Join(dir, "rules", "auto-sync.md")
+	if _, err := os.Stat(specPath); err != nil {
+		t.Error("auto-sync spec not written to rules dir")
+	}
+
+	cfgData, _ := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if !strings.Contains(string(cfgData), "autoSync: true") {
+		t.Error("config not updated with autoSync: true")
+	}
+}
+
+func TestHandleAutoSync_FlagNoSkipsSpec(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+
+	out := &bytes.Buffer{}
+	if err := handleAutoSync(".", "no", bytes.NewReader(nil), out); err != nil {
+		t.Fatal(err)
+	}
+
+	specPath := filepath.Join(dir, "rules", "auto-sync.md")
+	if _, err := os.Stat(specPath); err == nil {
+		t.Error("auto-sync spec should not be written for flag=no")
+	}
+
+	cfgData, _ := os.ReadFile(filepath.Join(dir, "agnostic.config.yaml"))
+	if !strings.Contains(string(cfgData), "autoSync: false") {
+		t.Error("config not updated with autoSync: false")
+	}
+}
+
+func TestHandleAutoSync_BadFlag(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	if err := handleAutoSync(".", "maybe", bytes.NewReader(nil), &bytes.Buffer{}); err == nil {
+		t.Error("expected error for invalid --auto-sync value")
+	}
+}
+
+// sync command integration
+
+func TestSync_AutoSyncFlagYes(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--auto-sync=yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "rules", "auto-sync.md")); err != nil {
+		t.Error("auto-sync spec not created via sync --auto-sync=yes")
+	}
+}
+
+func TestSync_AutoSyncFlagNo(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--auto-sync=no"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "rules", "auto-sync.md")); err == nil {
+		t.Error("auto-sync spec should not exist for --auto-sync=no")
+	}
+}
+
+func TestSync_AutoSyncFlagBad(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--auto-sync=maybe"})
+	if err := root.Execute(); err == nil {
+		t.Error("expected error for invalid --auto-sync value")
+	}
+}
+
+func TestSync_DryRunSkipsAutoSync(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--dry-run", "--auto-sync=yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// dry-run: spec must not be written
+	if _, err := os.Stat(filepath.Join(dir, "rules", "auto-sync.md")); err == nil {
+		t.Error("auto-sync spec should not be written in --dry-run mode")
+	}
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -17,7 +17,7 @@ import (
 func newSyncCmd() *cobra.Command {
 	var targets []string
 	var dryRun, check, backup, watch bool
-	var gitignoreFlag string
+	var gitignoreFlag, autoSyncFlag string
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -53,6 +53,11 @@ func newSyncCmd() *cobra.Command {
 				}
 				return nil
 			}
+			if !dryRun {
+				if err := handleAutoSync(".", autoSyncFlag, cmd.InOrStdin(), cmd.OutOrStdout()); err != nil {
+					return err
+				}
+			}
 			if watch {
 				ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 				defer stop()
@@ -67,6 +72,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&backup, "backup", false, "Copy each existing target file to <path>.bak before overwriting")
 	cmd.Flags().StringVar(&gitignoreFlag, "gitignore", "", "Override config: 'on' or 'off' to manage the .gitignore block this run.")
 	cmd.Flags().BoolVar(&watch, "watch", false, "Re-emit on spec changes (Ctrl+C to exit)")
+	cmd.Flags().StringVar(&autoSyncFlag, "auto-sync", "", "Enable agent-managed auto-sync: 'yes' or 'no'")
 	return cmd
 }
 

--- a/internal/config/autosync.go
+++ b/internal/config/autosync.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PersistAutoSync writes autoSync: true/false to agnostic.config.yaml.
+// Replaces the existing line when present, otherwise appends.
+// The rest of the file is preserved as-is.
+func PersistAutoSync(root string, enabled bool) error {
+	path := filepath.Join(root, "agnostic.config.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	val := "false"
+	if enabled {
+		val = "true"
+	}
+	newLine := "autoSync: " + val
+	content := string(data)
+
+	if strings.Contains(content, "autoSync:") {
+		lines := strings.Split(content, "\n")
+		for i, line := range lines {
+			if strings.HasPrefix(strings.TrimSpace(line), "autoSync:") {
+				lines[i] = newLine
+				break
+			}
+		}
+		content = strings.Join(lines, "\n")
+	} else {
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += newLine + "\n"
+	}
+
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Outputs       map[string]Output `yaml:"outputs"`
 	OnUnsupported string            `yaml:"on-unsupported"`
 	Gitignore     Gitignore         `yaml:"gitignore"`
+	AutoSync      *bool             `yaml:"autoSync,omitempty"`
 }
 
 // Gitignore controls automatic management of .gitignore entries for the


### PR DESCRIPTION
## Summary

- On first `sync` in a project (`autoSync` absent in config), prompts on a real TTY: `Sync automatically when specs change? [y/N]`.
- Answering `y` (or passing `--auto-sync=yes`) writes an `auto-sync.md` rule spec to the project rules dir. Every configured target then gets the instruction via the normal emit path.
- Answer persisted to `agnostic.config.yaml` as `autoSync: true/false` so the prompt fires only once.
- `--auto-sync=yes|no` overrides the prompt for CI and scripts.
- Skipped entirely in `--dry-run` mode (no writes).
- `PersistAutoSync` updates the config file in-place: replaces an existing `autoSync:` line or appends one, preserving the rest of the file.

Closes #24