### PR TITLE
feat(cli): add -q/--quiet and -v/--verbose verbosity flags

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -9,7 +9,9 @@ agnostic-ai [command] [flags]
 | Flag | Description |
 |------|-------------|
 | `-h, --help` | Help for any command |
-| `-v, --version` | Print version and exit |
+| `--version` | Print version and exit |
+| `-q, --quiet` | Errors only |
+| `-v, --verbose` | Per-target detail. Mutually exclusive with `--quiet`. |
 
 ## init
 

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -3,6 +3,8 @@
 package adapters
 
 import (
+	"io"
+
 	"github.com/chemaclass/agnostic-ai/internal/adapters/aider"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/amp"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/claude"
@@ -38,6 +40,10 @@ func StopCapture() []CapturedFile { return emit.StopCapture() }
 // overwriting. Used by `sync --backup` to leave a recovery trail that
 // `revert` can restore from.
 func SetBackup(b bool) { emit.SetBackup(b) }
+
+// SetWarner redirects capability warnings emitted by adapters. The CLI uses
+// this to suppress warnings under --quiet.
+func SetWarner(w io.Writer) { emit.Warner = w }
 
 // StartRecording begins collecting written paths alongside real writes.
 // Unlike capture mode it does not suppress IO. Used by `sync` to learn

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -70,16 +70,16 @@ func printDrift(reports []driftReport) bool {
 	any := false
 	for _, r := range reports {
 		if !r.hasDrift() {
-			fmt.Printf("✓ %s: in sync\n", r.Target)
+			verbosef("✓ %s: in sync\n", r.Target)
 			continue
 		}
 		any = true
-		fmt.Printf("✗ %s: drift\n", r.Target)
+		summaryf("✗ %s: drift\n", r.Target)
 		for _, f := range r.Missing {
-			fmt.Printf("    missing: %s\n", f.Path)
+			verbosef("    missing: %s\n", f.Path)
 		}
 		for _, f := range r.Stale {
-			fmt.Printf("    stale:   %s\n", f.Path)
+			verbosef("    stale:   %s\n", f.Path)
 		}
 	}
 	return any
@@ -117,7 +117,7 @@ func newDoctorCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("→ reconciled %d file(s)\n", fixed)
+			summaryf("→ reconciled %d file(s)\n", fixed)
 			return nil
 		},
 	}

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -32,7 +32,7 @@ func importFromClaude(root string, src config.Sources) error {
 	if c.hooks, err = importClaudeHooks(root, filepath.Join(root, src.Hooks)); err != nil {
 		return err
 	}
-	fmt.Printf("imported %d rules, %d agents, %d skills, %d hooks\n",
+	summaryf("imported %d rules, %d agents, %d skills, %d hooks\n",
 		c.rules, c.agents, c.skills, c.hooks)
 	return nil
 }

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -23,7 +23,7 @@ func importFromCodex(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("imported %d rules\n", n)
+	summaryf("imported %d rules\n", n)
 	return nil
 }
 

--- a/internal/cli/import_cursor.go
+++ b/internal/cli/import_cursor.go
@@ -24,7 +24,7 @@ func importFromCursor(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("imported %d rules\n", n)
+	summaryf("imported %d rules\n", n)
 	return nil
 }
 

--- a/internal/cli/import_rulesdir.go
+++ b/internal/cli/import_rulesdir.go
@@ -131,7 +131,7 @@ func importFromRulesDir(root, target, srcDir string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("imported %d rules, %d agents, %d skills (from %s)\n",
+	summaryf("imported %d rules, %d agents, %d skills (from %s)\n",
 		c.rules, c.agents, c.skills, target)
 	return nil
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -119,11 +119,11 @@ func scaffold(root, base string, demo bool, targets []string) error {
 			return err
 		}
 	}
-	fmt.Printf("scaffold complete. edit %s then run `agnostic-ai sync`.\n", scaffoldHint(base, kinds))
+	summaryf("scaffold complete. edit %s then run `agnostic-ai sync`.\n", scaffoldHint(base, kinds))
 	if demo {
-		fmt.Println("seeded one example spec per source folder. delete or edit to taste.")
+		summaryf("seeded one example spec per source folder. delete or edit to taste.\n")
 	}
-	fmt.Println("import existing AI CLI config with `agnostic-ai import <source>`.")
+	summaryf("import existing AI CLI config with `agnostic-ai import <source>`.\n")
 	return nil
 }
 

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	levelQuiet   = -1
+	levelDefault = 0
+	levelVerbose = 1
+)
+
+var (
+	verbosity           = levelDefault
+	logOut    io.Writer = os.Stdout
+)
+
+//Prints a one line command summary. Can be suppressed using --quiet flag
+func summaryf(format string, a ...any) {
+	if verbosity < levelDefault {
+		return
+	}
+	_, _ = fmt.Fprintf(logOut, format, a...)
+}
+
+// Prints detail on target. Needs -v flag
+func verbosef(format string, a ...any) {
+	if verbosity < levelVerbose {
+		return
+	}
+	_, _ = fmt.Fprintf(logOut, format, a...)
+}

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -17,7 +17,7 @@ var (
 	logOut    io.Writer = os.Stdout
 )
 
-//Prints a one line command summary. Can be suppressed using --quiet flag
+// Prints a one line command summary. Can be suppressed using --quiet flag
 func summaryf(format string, a ...any) {
 	if verbosity < levelDefault {
 		return

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -52,7 +52,7 @@ func newRevertCmd() *cobra.Command {
 					return fmt.Errorf("%s: %w", t, err)
 				}
 				files := adapters.StopCapture()
-				fmt.Printf("← revert %s\n", t)
+				summaryf("← revert %s\n", t)
 				for _, f := range files {
 					if err := revertOne(f.Path, dryRun); err != nil {
 						return fmt.Errorf("%s: %w", t, err)
@@ -75,7 +75,7 @@ func revertOne(path string, dryRun bool) error {
 	switch {
 	case err == nil:
 		if dryRun {
-			fmt.Printf("    restore: %s ← %s\n", path, bak)
+			verbosef("    restore: %s ← %s\n", path, bak)
 			return nil
 		}
 		if err := os.WriteFile(path, data, 0o644); err != nil {
@@ -84,19 +84,19 @@ func revertOne(path string, dryRun bool) error {
 		if err := os.Remove(bak); err != nil {
 			return fmt.Errorf("remove %s: %w", bak, err)
 		}
-		fmt.Printf("    restored: %s\n", path)
+		verbosef("    restored: %s\n", path)
 		return nil
 	case !errors.Is(err, fs.ErrNotExist):
 		return fmt.Errorf("read backup %s: %w", bak, err)
 	}
 
 	if dryRun {
-		fmt.Printf("    remove:  %s\n", path)
+		verbosef("    remove:  %s\n", path)
 		return nil
 	}
 	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove %s: %w", path, err)
 	}
-	fmt.Printf("    removed:  %s\n", path)
+	verbosef("    removed:  %s\n", path)
 	return nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,8 +2,12 @@
 package cli
 
 import (
+	"fmt"
+	"io"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
@@ -27,6 +31,33 @@ func NewRootCmd(version string) *cobra.Command {
   # CI gate: fail when emitted files drift from specs
   agnostic-ai sync --check`,
 	}
+
+	var quiet bool
+	root.PersistentFlags().CountP("verbose", "v", "Increase output verbosity")
+	root.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress non-error output")
+
+	// Cobra auto binds -v to --version when Version is set so
+	// So here taking -v back for verbosity by clearing the shorthand on the version flag.
+	root.InitDefaultVersionFlag()
+	if vf := root.Flags().Lookup("version"); vf != nil {
+		vf.Shorthand = ""
+	}
+
+	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		v, _ := cmd.Flags().GetCount("verbose")
+		if quiet && v > 0 {
+			return fmt.Errorf("--quiet and --verbose are mutually exclusive")
+		}
+		switch {
+		case quiet:
+			verbosity = levelQuiet
+			adapters.SetWarner(io.Discard)
+		default:
+			verbosity = v
+		}
+		return nil
+	}
+
 	root.AddCommand(
 		newSyncCmd(),
 		newValidateCmd(),

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -23,6 +23,55 @@ func TestRoot_VersionFlag(t *testing.T) {
 	}
 }
 
+func TestRoot_VerboseShortDoesNotPrintVersion(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("9.9.9")
+	root.SetArgs([]string{"-v", "validate"})
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("9.9.9")) {
+		t.Errorf("-v should be verbosity, not version; got %s", buf.Bytes())
+	}
+}
+
+func TestRoot_QuietAndVerboseAreMutuallyExclusive(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"-q", "-v", "validate"})
+	if err := root.Execute(); err == nil {
+		t.Error("expected error when --quiet and --verbose combined")
+	}
+}
+
+func TestRoot_QuietSuppressesSummary(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	prev := logOut
+	buf := &bytes.Buffer{}
+	logOut = buf
+	t.Cleanup(func() { logOut = prev })
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"-q", "sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("--quiet should suppress summary output, got %q", buf.String())
+	}
+}
+
 func TestSync_Validate_List_OnFixture(t *testing.T) {
 	dir := setupFixture(t)
 	testutil.Chdir(t, dir)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -99,7 +99,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 			fmt.Fprintf(os.Stderr, "! unknown target: %s\n", t)
 			continue
 		}
-		fmt.Printf("→ emit %s\n", t)
+		verbosef("→ emit %s\n", t)
 		if err := adapter.Emit(b, cfg, dryRun); err != nil {
 			if gitignoreOn {
 				adapters.StopRecording()
@@ -111,7 +111,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		if err := updateGitignore(cfg, normalizeAndSort(adapters.StopRecording())); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
-		fmt.Println("→ updated .gitignore")
+		summaryf("→ updated .gitignore\n")
 	}
 	return nil
 }

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -28,7 +28,7 @@ func watchSync(ctx context.Context, interval time.Duration, root string, targets
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	fmt.Println("→ watching for changes (Ctrl+C to exit)")
+	summaryf("→ watching for changes (Ctrl+C to exit)\n")
 
 	for {
 		select {
@@ -40,7 +40,7 @@ func watchSync(ctx context.Context, interval time.Duration, root string, targets
 				continue
 			}
 			snapshot = curr
-			fmt.Println("→ change detected, re-syncing")
+			summaryf("→ change detected, re-syncing\n")
 			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
 				fmt.Fprintf(os.Stderr, "! sync: %v\n", err)
 			}


### PR DESCRIPTION
## Summary
- Adds persistent `-q/--quiet` and `-v/--verbose` root flags so every command can be silenced or made verbose.
- Reclaims `-v` from Cobra's auto-bound `--version` shorthand; `--version` long form still works.
- Routes adapter capability warnings through `adapters.SetWarner` so they're suppressed under `--quiet`.

Closes #42