### PR TITLE
feat: shell completion (bash/zsh/fish/powershell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- `completion bash|zsh|fish|powershell`: generate shell completion scripts. Tab-completing `--target` reads `agnostic.config.yaml` and falls back to the full default target list when no config is found.
+
 ### Changed
 - GitHub Release body built from `CHANGELOG.md` via `scripts/release-notes.sh` and passed to `goreleaser release --release-notes=NOTES.md`. No post-hoc `gh release edit`.
 - `promote_changelog` writes dated headings as `## vX.Y.Z - YYYY-MM-DD` (no brackets), matching prior history. `## [Unreleased]` keeps brackets.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -201,16 +201,28 @@ pass. Pair with `--backup` when reconciling files you may have hand-edited.
 
 ## completion
 
-Shell completion scripts (cobra).
+Generate a shell completion script and install it for your shell.
 
 ```bash
-agnostic-ai completion bash      # for bash
-agnostic-ai completion zsh       # for zsh
-agnostic-ai completion fish      # for fish
-agnostic-ai completion powershell
+# Bash — system-wide (may need sudo)
+agnostic-ai completion bash > /etc/bash_completion.d/agnostic-ai
+
+# Bash — current user only
+agnostic-ai completion bash > ~/.local/share/bash-completion/completions/agnostic-ai
+
+# Zsh
+agnostic-ai completion zsh > "${fpath[1]}/_agnostic-ai"
+
+# Fish
+agnostic-ai completion fish > ~/.config/fish/completions/agnostic-ai.fish
+
+# PowerShell
+agnostic-ai completion powershell | Out-String | Invoke-Expression
 ```
 
-Install: `agnostic-ai completion <shell> --help`.
+After installing, restart your shell (or `source` the completion file). Tab-completing `--target` reads `agnostic.config.yaml` in the current directory and falls back to the full default target list when no config is found.
+
+Run `agnostic-ai completion <shell> --help` for shell-specific setup instructions.
 
 ## help
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -18,6 +18,23 @@ From source:
 go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest
 ```
 
+## Shell completion
+
+Enable tab completion for subcommands and `--target`:
+
+```bash
+# Zsh
+agnostic-ai completion zsh > "${fpath[1]}/_agnostic-ai"
+
+# Bash (user-level)
+agnostic-ai completion bash > ~/.local/share/bash-completion/completions/agnostic-ai
+
+# Fish
+agnostic-ai completion fish > ~/.config/fish/completions/agnostic-ai.fish
+```
+
+Restart your shell after installing. See `agnostic-ai completion <shell> --help` for more options.
+
 ## Scaffold
 
 ```bash

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -124,6 +124,7 @@ func newDoctorCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&targets, "target", "t", nil, "Targets to check (default: all in config)")
 	cmd.Flags().BoolVar(&fix, "fix", false, "Reconcile drift by writing missing/stale files")
 	cmd.Flags().BoolVar(&backup, "backup", false, "With --fix, copy each existing file to <path>.bak before overwriting")
+	registerTargetCompletion(cmd)
 	return cmd
 }
 

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+func registerTargetCompletion(cmd *cobra.Command) {
+	_ = cmd.RegisterFlagCompletionFunc("target",
+		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			cfg, err := config.Load(".")
+			if err != nil {
+				return config.DefaultTargets(), cobra.ShellCompDirectiveNoFileComp
+			}
+			return cfg.Targets, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func runCompletion(t *testing.T, args ...string) string {
+	t.Helper()
+	root := NewRootCmd("test")
+	root.SetArgs(append([]string{"__complete"}, args...))
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(&bytes.Buffer{})
+	_ = root.Execute()
+	return buf.String()
+}
+
+func TestTargetCompletion_FallsBackToDefaults_OutsideProject(t *testing.T) {
+	testutil.Chdir(t, t.TempDir())
+	out := runCompletion(t, "sync", "--target", "")
+	for _, tgt := range config.DefaultTargets() {
+		if !strings.Contains(out, tgt) {
+			t.Errorf("expected default target %q in completion output:\n%s", tgt, out)
+		}
+	}
+}
+
+func TestTargetCompletion_ReadsConfigTargets(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "version: 1\ntargets:\n  - claude\n  - cursor\n"
+	if err := os.WriteFile(filepath.Join(dir, "agnostic.config.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.Chdir(t, dir)
+	out := runCompletion(t, "sync", "--target", "")
+	if !strings.Contains(out, "claude") {
+		t.Errorf("expected 'claude' in completion output:\n%s", out)
+	}
+	if !strings.Contains(out, "cursor") {
+		t.Errorf("expected 'cursor' in completion output:\n%s", out)
+	}
+	if strings.Contains(out, "codex") {
+		t.Errorf("'codex' should not appear when config restricts targets:\n%s", out)
+	}
+}
+
+func TestTargetCompletion_DoctorAndRevert(t *testing.T) {
+	testutil.Chdir(t, t.TempDir())
+	for _, sub := range []string{"doctor", "revert"} {
+		out := runCompletion(t, sub, "--target", "")
+		if !strings.Contains(out, "claude") {
+			t.Errorf("%s --target completion: expected 'claude', got:\n%s", sub, out)
+		}
+	}
+}

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -64,6 +64,7 @@ func newRevertCmd() *cobra.Command {
 	}
 	cmd.Flags().StringSliceVarP(&targets, "target", "t", nil, "Targets to revert (default: all in config)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report intended actions without touching disk")
+	registerTargetCompletion(cmd)
 	return cmd
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,6 +36,7 @@ func NewRootCmd(version string) *cobra.Command {
 		newDoctorCmd(),
 		newRevertCmd(),
 	)
+	root.InitDefaultCompletionCmd()
 	return root
 }
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -73,6 +73,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().StringVar(&gitignoreFlag, "gitignore", "", "Override config: 'on' or 'off' to manage the .gitignore block this run.")
 	cmd.Flags().BoolVar(&watch, "watch", false, "Re-emit on spec changes (Ctrl+C to exit)")
 	cmd.Flags().StringVar(&autoSyncFlag, "auto-sync", "", "Enable agent-managed auto-sync: 'yes' or 'no'")
+	registerTargetCompletion(cmd)
 	return cmd
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ func defaults() *Config {
 			Hooks:  "hooks",
 			MCPs:   "mcps",
 		},
-		Targets: DefaultTargets(),
+		Targets:       DefaultTargets(),
 		OnUnsupported: "warn",
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,14 @@ func Load(root string) (*Config, error) {
 	return cfg, nil
 }
 
+func DefaultTargets() []string {
+	return []string{
+		"claude", "codex", "gemini", "cursor",
+		"copilot", "aider", "cline", "windsurf", "continue",
+		"amp", "zed", "warp", "opencode",
+	}
+}
+
 func defaults() *Config {
 	return &Config{
 		Version: 1,
@@ -70,11 +78,7 @@ func defaults() *Config {
 			Hooks:  "hooks",
 			MCPs:   "mcps",
 		},
-		Targets: []string{
-			"claude", "codex", "gemini", "cursor",
-			"copilot", "aider", "cline", "windsurf", "continue",
-			"amp", "zed", "warp", "opencode",
-		},
+		Targets: DefaultTargets(),
 		OnUnsupported: "warn",
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,18 +76,23 @@ on-unsupported: error
 }
 
 func TestDefaultTargets(t *testing.T) {
-	targets := DefaultTargets()
-	if len(targets) == 0 {
-		t.Fatal("DefaultTargets must not be empty")
+	want := []string{
+		"claude", "codex", "gemini", "cursor",
+		"copilot", "aider", "cline", "windsurf", "continue",
+		"amp", "zed", "warp", "opencode",
 	}
-	want := map[string]bool{
-		"claude": true, "codex": true, "cursor": true, "gemini": true,
+	targets := DefaultTargets()
+	if len(targets) != len(want) {
+		t.Fatalf("expected %d targets, got %d: %v", len(want), len(targets), targets)
+	}
+	wantSet := make(map[string]bool, len(want))
+	for _, w := range want {
+		wantSet[w] = true
 	}
 	for _, tgt := range targets {
-		delete(want, tgt)
-	}
-	if len(want) > 0 {
-		t.Errorf("missing expected targets: %v", want)
+		if !wantSet[tgt] {
+			t.Errorf("unexpected target %q in DefaultTargets()", tgt)
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,22 @@ on-unsupported: error
 	}
 }
 
+func TestDefaultTargets(t *testing.T) {
+	targets := DefaultTargets()
+	if len(targets) == 0 {
+		t.Fatal("DefaultTargets must not be empty")
+	}
+	want := map[string]bool{
+		"claude": true, "codex": true, "cursor": true, "gemini": true,
+	}
+	for _, tgt := range targets {
+		delete(want, tgt)
+	}
+	if len(want) > 0 {
+		t.Errorf("missing expected targets: %v", want)
+	}
+}
+
 func TestLoad_MissingFile(t *testing.T) {
 	dir := t.TempDir()
 	_, err := Load(dir)


### PR DESCRIPTION
Closes #38

## Summary
- Enables Cobra's built-in `completion` subcommand via `InitDefaultCompletionCmd()`
- Adds dynamic `--target` flag completions on `sync`, `doctor`, `revert` — reads `agnostic.config.yaml`, falls back to the full default target list when no config exists
- Extracts `config.DefaultTargets()` to avoid duplication between config defaults and completion fallback
- Expands `docs/user/cli-reference.md` with per-shell install snippets

## Test plan
- [x] `go test ./...` passes
- [x] `agnostic-ai completion zsh` produces a valid script
- [x] `agnostic-ai sync --target <TAB>` completes all 13 targets (verified manually)
- [x] Subcommands complete correctly on `<TAB>`