### PR TITLE
ci: bump golangci-lint-action to v9, migrate config to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.62
+          version: v2.6
 
   build:
     name: Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,37 @@
+version: "2"
+
 run:
   timeout: 5m
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - govet
     - ineffassign
-    - staticcheck
-    - unused
-    - gofmt
-    - goimports
     - misspell
     - revive
+    - staticcheck
+    - unused
+  settings:
+    misspell:
+      locale: US
+    revive:
+      severity: warning
+  exclusions:
+    generated: lax
 
-linters-settings:
-  gofmt:
-    simplify: true
-  goimports:
-    local-prefixes: github.com/chemaclass/agnostic-ai
-  misspell:
-    locale: US
-  revive:
-    severity: warning
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/chemaclass/agnostic-ai
 
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 - GitHub Release body built from `CHANGELOG.md` via `scripts/release-notes.sh` and passed to `goreleaser release --release-notes=NOTES.md`. No post-hoc `gh release edit`.
 - `promote_changelog` writes dated headings as `## vX.Y.Z - YYYY-MM-DD` (no brackets), matching prior history. `## [Unreleased]` keeps brackets.
+- CI lint job upgraded to `golangci/golangci-lint-action@v9` with `golangci-lint v2.6`. `.golangci.yml` migrated to v2 schema (`version: "2"`, `linters.default: none`, `formatters` section for `gofmt`/`goimports`).
 
 ### Fixed
 - `extract_changelog_section` accepts both `## [vX.Y.Z]` and `## vX.Y.Z` heading forms.


### PR DESCRIPTION
## Summary
- Bump `golangci/golangci-lint-action` from v6 to v9 and pin `golangci-lint` to `v2.6`.
- Migrate `.golangci.yml` to v2 schema: `version: "2"`, `linters.default: none`, `gofmt`/`goimports` moved to `formatters`.
- Supersedes #9 (dependabot bump that fails because action v9 rejects `v1.62`: `invalid version string 'v1.62', golangci-lint v1 is not supported by golangci-lint-action >= v7`).

Verified locally with `golangci-lint v2.6.0 run ./...` → `0 issues`.