### PR TITLE
feat(cli): shareable spec packs (agnostic-ai packs add)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+- `agnostic-ai packs add|remove|update|list`: install shareable spec packs from Git URLs or local directories. Packs land under `.agnostic-ai/packs/<name>/`, are pinned in `agnostic.packs.lock`, and load as a layer between user-global and project so any project-local entry overrides a pack-supplied one. `agnostic-ai packs add github.com/foo/bar@v1.2.0` clones the repo (`--depth 1`), strips `.git`, and records the resolved commit sha in the lockfile. New docs at `docs/user/packs.md` (consumer) and `docs/internal/pack-authors.md` (publisher).
 - `docs/user/ci.md`: dedicated CI page covering `sync --check` and the official `chemaclass/agnostic-ai-action@v1` GitHub Action (3-line drop-in snippet, version pinning, cached binary, drift summary in the job log).
 - `completion bash|zsh|fish|powershell`: generate shell completion scripts. Tab-completing `--target` reads `agnostic.config.yaml` and falls back to the full default target list when no config is found.
 - JSON Schema published at `docs/schemas/config.schema.json` (generated from Go structs) and `docs/schemas/spec.schema.json` (hand-authored). Editors with the YAML Language Server validate `agnostic.config.yaml` and spec frontmatter automatically.

--- a/docs/internal/pack-authors.md
+++ b/docs/internal/pack-authors.md
@@ -1,0 +1,58 @@
+# Authoring a spec pack
+
+A pack is a Git repo (or a local directory) shaped like an agnostic
+project's source layout. Users install it with `agnostic-ai packs add`
+and the contents merge into their layered spec load.
+
+## Layout
+
+```
+<repo-root>/
+├── agents/
+├── skills/
+├── rules/
+├── hooks/
+└── mcps/
+```
+
+Empty directories may be omitted. No `agnostic.config.yaml` is needed
+in a pack: the loader uses the default per-kind subdirectory names.
+
+## Spec content
+
+Specs use the same frontmatter and Markdown body documented in the
+[user spec format](../user/spec-format.md). Pack authors should:
+
+- Name every entry. The `name:` frontmatter field is the merge key
+  consumers will use to override pack content.
+- Keep `description:` short and action-oriented. Adapters surface the
+  description directly in `AGENTS.md`-style merged documents.
+- Avoid project-specific paths in `globs:`. Prefer language- or
+  framework-level globs that travel.
+
+## Versioning
+
+Tag releases with semver (`v1.2.0`). Users pin against a tag when
+they install:
+
+```bash
+agnostic-ai packs add github.com/your-org/your-pack@v1.2.0
+```
+
+Breaking changes (renamed entries, removed kinds, schema bumps) call
+for a major bump. Adding entries is non-breaking; renames are
+breaking because they invalidate downstream overrides.
+
+## Naming
+
+A pack's installed directory defaults to the last path segment of its
+source URL (`github.com/foo/go-rules` → `go-rules`). Pick a name that
+will not collide with another pack a user might also install. Users
+can rename at install time with `--name`, but a stable default
+matters for sharing snippets in docs and READMEs.
+
+## Distribution
+
+Any Git host works. The CLI invokes the system `git` binary for
+clones, so the same auth setup that works for `git clone` works for
+`agnostic-ai packs add`.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -8,6 +8,7 @@ Read in this order. Each builds on the previous.
 4. [Configuration](configuration.md): `agnostic.config.yaml` schema, precedence, and the optional auto-managed `.gitignore` block.
 5. [CLI reference](cli-reference.md): every command and flag, including `sync --watch`, `sync --auto-sync`, `sync --check`, `sync --backup`, `init --demo`, `init -i`, `import <source>`, `revert`, and `doctor`.
 6. [CI](ci.md): drift detection in pull requests with `sync --check`.
+7. [Packs](packs.md): install shared spec packs (`agnostic-ai packs add`).
 
 ## Mental model
 

--- a/docs/user/packs.md
+++ b/docs/user/packs.md
@@ -1,0 +1,89 @@
+# Spec packs
+
+A pack is a versioned directory of agnostic specs (agents, skills,
+rules, hooks, MCPs) published as a Git repo or shared on disk. Packs
+let teams and the wider community ship reusable conventions without
+copying spec files between projects.
+
+## Install
+
+```bash
+agnostic-ai packs add github.com/chemaclass/go-rules@v1.2.0
+agnostic-ai packs add ./shared/security-rules
+```
+
+The pack is fetched into `.agnostic-ai/packs/<name>/` and pinned in
+`agnostic.packs.lock`. Subsequent runs of `agnostic-ai sync` load
+specs from every installed pack as a layer below the project layer,
+so any project-local spec with the same name overrides the
+pack-supplied version.
+
+## List, update, remove
+
+```bash
+agnostic-ai packs list
+agnostic-ai packs update                # all packs
+agnostic-ai packs update go-rules       # one pack
+agnostic-ai packs remove go-rules
+```
+
+`update` re-fetches each pack at the ref recorded in the lockfile and
+refreshes the captured commit sha.
+
+## Sources
+
+| Source           | Example                              |
+|------------------|--------------------------------------|
+| Git URL          | `github.com/foo/bar`, `gitlab.com/x` |
+| Git URL with ref | `github.com/foo/bar@v1.2.0`          |
+| Local directory  | `./local/pack`, `file:///abs/path`   |
+
+Git URLs are cloned with `--depth 1` and the `.git` directory is
+stripped after the resolved sha is captured.
+
+## Pack layout
+
+A pack mirrors the standard agnostic source layout at its root:
+
+```
+<pack>/
+├── agents/
+├── skills/
+├── rules/
+├── hooks/
+└── mcps/
+```
+
+Empty directories may be omitted. Frontmatter rules and conventions
+mirror the [spec format](spec-format.md). Packs ship one or more
+kinds; nothing requires a pack to populate every directory.
+
+## Lockfile
+
+`agnostic.packs.lock` is a YAML file at the project root:
+
+```yaml
+version: 1
+packs:
+  - name: go-rules
+    source: github.com/chemaclass/go-rules
+    ref: v1.2.0
+    sha: 9f8b3c1e0a5d4e8b2c7d6f3a1b0c4d5e6f7a8b9c
+```
+
+Commit the lockfile so peers and CI install the same revisions. The
+file is written sorted by name; removing the last pack deletes the
+file entirely.
+
+## Layer precedence
+
+Packs slot between the user-global layer and the project layer:
+
+```
+user-global  →  packs  →  project  →  project-user
+```
+
+Higher layers override by `(kind, name)`. A project rule named
+`conventional-commits` masks the pack version with the same name,
+which is the intended escape hatch when a single pack convention
+needs project-specific tweaks.

--- a/internal/cli/layers.go
+++ b/internal/cli/layers.go
@@ -42,6 +42,7 @@ func resolveLayers(projectRoot string, cfg *config.Config) []spec.Layer {
 	if l, ok := resolveUserGlobalLayer(); ok {
 		layers = append(layers, l)
 	}
+	layers = append(layers, resolvePacksLayers(projectRoot)...)
 	layers = append(layers, resolveProjectLayer(projectRoot, cfg))
 	if l, ok := resolveProjectUserLayer(projectRoot); ok {
 		layers = append(layers, l)

--- a/internal/cli/layers.go
+++ b/internal/cli/layers.go
@@ -39,31 +39,52 @@ func defaultLayerSources() config.Sources {
 // not exist.
 func resolveLayers(projectRoot string, cfg *config.Config) []spec.Layer {
 	var layers []spec.Layer
-
-	if root, ok := userGlobalRoot(); ok {
-		layers = append(layers, spec.Layer{
-			Name:    layerNameUserGlobal,
-			Root:    root,
-			Sources: defaultLayerSources(),
-		})
+	if l, ok := resolveUserGlobalLayer(); ok {
+		layers = append(layers, l)
 	}
+	layers = append(layers, resolveProjectLayer(projectRoot, cfg))
+	if l, ok := resolveProjectUserLayer(projectRoot); ok {
+		layers = append(layers, l)
+	}
+	return layers
+}
 
-	layers = append(layers, spec.Layer{
+// resolveUserGlobalLayer returns the user-global layer when
+// AGNOSTIC_AI_HOME or ~/.agnostic-ai resolves to an existing directory.
+func resolveUserGlobalLayer() (spec.Layer, bool) {
+	root, ok := userGlobalRoot()
+	if !ok {
+		return spec.Layer{}, false
+	}
+	return spec.Layer{
+		Name:    layerNameUserGlobal,
+		Root:    root,
+		Sources: defaultLayerSources(),
+	}, true
+}
+
+// resolveProjectLayer returns the always-present project layer using
+// the configurable source paths from cfg.
+func resolveProjectLayer(projectRoot string, cfg *config.Config) spec.Layer {
+	return spec.Layer{
 		Name:    layerNameProject,
 		Root:    projectRoot,
 		Sources: cfg.Sources,
-	})
-
-	pu := filepath.Join(projectRoot, defaultProjectUser)
-	if dirExists(pu) {
-		layers = append(layers, spec.Layer{
-			Name:    layerNameProjectUser,
-			Root:    pu,
-			Sources: defaultLayerSources(),
-		})
 	}
+}
 
-	return layers
+// resolveProjectUserLayer returns the project-user layer when
+// `<projectRoot>/.agnostic-ai.local` exists.
+func resolveProjectUserLayer(projectRoot string) (spec.Layer, bool) {
+	pu := filepath.Join(projectRoot, defaultProjectUser)
+	if !dirExists(pu) {
+		return spec.Layer{}, false
+	}
+	return spec.Layer{
+		Name:    layerNameProjectUser,
+		Root:    pu,
+		Sources: defaultLayerSources(),
+	}, true
 }
 
 // userGlobalRoot resolves the user-global layer root. AGNOSTIC_AI_HOME

--- a/internal/cli/packs.go
+++ b/internal/cli/packs.go
@@ -159,7 +159,7 @@ func runPacksAdd(root, source, nameOverride string, out io.Writer) error {
 	if err := writePacksLock(root, lock); err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "✓ added %s\n", name)
+	_, _ = fmt.Fprintf(out, "✓ added %s\n", name)
 	return nil
 }
 
@@ -179,7 +179,7 @@ func runPacksRemove(root, name string, out io.Writer) error {
 	if err := writePacksLock(root, lock); err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "✓ removed %s\n", name)
+	_, _ = fmt.Fprintf(out, "✓ removed %s\n", name)
 	return nil
 }
 
@@ -189,7 +189,7 @@ func runPacksList(root string, out io.Writer) error {
 		return err
 	}
 	if len(lock.Packs) == 0 {
-		fmt.Fprintln(out, "no packs installed.")
+		_, _ = fmt.Fprintln(out, "no packs installed.")
 		return nil
 	}
 	for _, p := range lock.Packs {
@@ -197,11 +197,11 @@ func runPacksList(root string, out io.Writer) error {
 		if ref == "" {
 			ref = "HEAD"
 		}
-		fmt.Fprintf(out, "%s\t%s@%s", p.Name, p.Source, ref)
+		_, _ = fmt.Fprintf(out, "%s\t%s@%s", p.Name, p.Source, ref)
 		if p.Sha != "" {
-			fmt.Fprintf(out, " (%s)", short(p.Sha))
+			_, _ = fmt.Fprintf(out, " (%s)", short(p.Sha))
 		}
-		fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out)
 	}
 	return nil
 }
@@ -212,7 +212,7 @@ func runPacksUpdate(root, only string, out io.Writer) error {
 		return err
 	}
 	if len(lock.Packs) == 0 {
-		fmt.Fprintln(out, "no packs installed.")
+		_, _ = fmt.Fprintln(out, "no packs installed.")
 		return nil
 	}
 	updated := 0
@@ -229,7 +229,7 @@ func runPacksUpdate(root, only string, out io.Writer) error {
 			return fmt.Errorf("packs update %s: %w", p.Name, err)
 		}
 		lock.Packs[i].Sha = sha
-		fmt.Fprintf(out, "✓ updated %s\n", p.Name)
+		_, _ = fmt.Fprintf(out, "✓ updated %s\n", p.Name)
 		updated++
 	}
 	if only != "" && updated == 0 {
@@ -252,17 +252,17 @@ func isLocalSource(s string) bool {
 	if strings.HasPrefix(s, "file://") {
 		return true
 	}
-	if strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") || strings.HasPrefix(s, "/") {
+	if strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") {
+		return true
+	}
+	if filepath.IsAbs(s) {
 		return true
 	}
 	return false
 }
 
 func localPath(s string) string {
-	if strings.HasPrefix(s, "file://") {
-		return strings.TrimPrefix(s, "file://")
-	}
-	return s
+	return strings.TrimPrefix(s, "file://")
 }
 
 func copyTree(src, dst string) error {
@@ -349,12 +349,12 @@ func splitSourceRef(s string) (src, ref string) {
 }
 
 // derivePackName picks an install directory name from a source string.
-// Strategy: take the last path component, drop a `.git` suffix.
+// Strategy: take the last path component, drop a `.git` suffix. Path
+// separators are normalized so an absolute Windows path like
+// `C:\Users\me\pack` still produces `pack`.
 func derivePackName(source string) string {
-	s := source
-	if strings.HasPrefix(s, "file://") {
-		s = strings.TrimPrefix(s, "file://")
-	}
+	s := strings.TrimPrefix(source, "file://")
+	s = filepath.ToSlash(s)
 	s = strings.TrimSuffix(s, "/")
 	s = strings.TrimSuffix(s, ".git")
 	if u, err := url.Parse(s); err == nil && u.Path != "" && u.Host != "" {

--- a/internal/cli/packs.go
+++ b/internal/cli/packs.go
@@ -1,0 +1,489 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+const (
+	// packsDir is the on-disk root for all installed packs, relative to
+	// the project root.
+	packsDir = ".agnostic-ai/packs"
+	// packsLockfile pins each installed pack to a specific source and
+	// revision so layered loads stay reproducible across machines.
+	packsLockfile = "agnostic.packs.lock"
+
+	layerNamePackPrefix = "pack:"
+)
+
+// packEntry is one row of agnostic.packs.lock. Source is the user-given
+// argument verbatim (Git URL or local path); Ref is the resolved branch,
+// tag, or commit; Sha is the commit hash captured at install time and
+// used by `update` to detect changes.
+type packEntry struct {
+	Name   string `yaml:"name"`
+	Source string `yaml:"source"`
+	Ref    string `yaml:"ref,omitempty"`
+	Sha    string `yaml:"sha,omitempty"`
+}
+
+// packsLock is the on-disk format of agnostic.packs.lock.
+type packsLock struct {
+	Version int         `yaml:"version"`
+	Packs   []packEntry `yaml:"packs"`
+}
+
+func newPacksCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "packs",
+		Short: "Manage shareable spec packs.",
+		Long: "Spec packs are versioned directories of agnostic specs " +
+			"published as Git repos or local directories. Installed packs " +
+			"are loaded as a layer below the project layer, so the project " +
+			"can override any pack-supplied entry by name.",
+		Example: `  # Install a pack at a tag
+  agnostic-ai packs add github.com/chemaclass/go-rules@v1.2.0
+
+  # Install from a local directory
+  agnostic-ai packs add ./path/to/pack
+
+  # List installed packs
+  agnostic-ai packs list
+
+  # Update one or all packs
+  agnostic-ai packs update
+  agnostic-ai packs update go-rules
+
+  # Remove a pack
+  agnostic-ai packs remove go-rules`,
+	}
+	cmd.AddCommand(newPacksAddCmd(), newPacksRemoveCmd(), newPacksListCmd(), newPacksUpdateCmd())
+	return cmd
+}
+
+func newPacksAddCmd() *cobra.Command {
+	var name string
+	cmd := &cobra.Command{
+		Use:   "add <source>",
+		Short: "Install a spec pack from a Git URL or local directory.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPacksAdd(".", args[0], name, cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "Override the install directory name (default: derived from source)")
+	return cmd
+}
+
+func newPacksRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Uninstall a spec pack.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPacksRemove(".", args[0], cmd.OutOrStdout())
+		},
+	}
+}
+
+func newPacksListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List installed spec packs.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPacksList(".", cmd.OutOrStdout())
+		},
+	}
+}
+
+func newPacksUpdateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update [<name>]",
+		Short: "Reinstall pack(s) at the lockfile-recorded ref.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			only := ""
+			if len(args) == 1 {
+				only = args[0]
+			}
+			return runPacksUpdate(".", only, cmd.OutOrStdout())
+		},
+	}
+}
+
+// runPacksAdd installs one pack and updates the lockfile. Re-installing
+// an existing pack overwrites its directory and lockfile entry so an
+// `add` after a manual edit restores a clean state.
+func runPacksAdd(root, source, nameOverride string, out io.Writer) error {
+	name := nameOverride
+	src, ref := splitSourceRef(source)
+	if name == "" {
+		name = derivePackName(src)
+	}
+	if name == "" {
+		return fmt.Errorf("packs add: cannot derive a pack name from %q; pass --name", source)
+	}
+	if err := validatePackName(name); err != nil {
+		return err
+	}
+
+	dest := filepath.Join(root, packsDir, name)
+	if err := os.RemoveAll(dest); err != nil {
+		return fmt.Errorf("packs add: clean dest: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("packs add: mkdir: %w", err)
+	}
+
+	sha, err := fetchPack(src, ref, dest)
+	if err != nil {
+		return fmt.Errorf("packs add: %w", err)
+	}
+
+	lock, err := readPacksLock(root)
+	if err != nil {
+		return err
+	}
+	lock.upsert(packEntry{Name: name, Source: src, Ref: ref, Sha: sha})
+	if err := writePacksLock(root, lock); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "✓ added %s\n", name)
+	return nil
+}
+
+func runPacksRemove(root, name string, out io.Writer) error {
+	lock, err := readPacksLock(root)
+	if err != nil {
+		return err
+	}
+	if !lock.has(name) {
+		return fmt.Errorf("packs remove: %q not installed", name)
+	}
+	dest := filepath.Join(root, packsDir, name)
+	if err := os.RemoveAll(dest); err != nil {
+		return fmt.Errorf("packs remove: %w", err)
+	}
+	lock.remove(name)
+	if err := writePacksLock(root, lock); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "✓ removed %s\n", name)
+	return nil
+}
+
+func runPacksList(root string, out io.Writer) error {
+	lock, err := readPacksLock(root)
+	if err != nil {
+		return err
+	}
+	if len(lock.Packs) == 0 {
+		fmt.Fprintln(out, "no packs installed.")
+		return nil
+	}
+	for _, p := range lock.Packs {
+		ref := p.Ref
+		if ref == "" {
+			ref = "HEAD"
+		}
+		fmt.Fprintf(out, "%s\t%s@%s", p.Name, p.Source, ref)
+		if p.Sha != "" {
+			fmt.Fprintf(out, " (%s)", short(p.Sha))
+		}
+		fmt.Fprintln(out)
+	}
+	return nil
+}
+
+func runPacksUpdate(root, only string, out io.Writer) error {
+	lock, err := readPacksLock(root)
+	if err != nil {
+		return err
+	}
+	if len(lock.Packs) == 0 {
+		fmt.Fprintln(out, "no packs installed.")
+		return nil
+	}
+	updated := 0
+	for i, p := range lock.Packs {
+		if only != "" && p.Name != only {
+			continue
+		}
+		dest := filepath.Join(root, packsDir, p.Name)
+		if err := os.RemoveAll(dest); err != nil {
+			return fmt.Errorf("packs update %s: %w", p.Name, err)
+		}
+		sha, err := fetchPack(p.Source, p.Ref, dest)
+		if err != nil {
+			return fmt.Errorf("packs update %s: %w", p.Name, err)
+		}
+		lock.Packs[i].Sha = sha
+		fmt.Fprintf(out, "✓ updated %s\n", p.Name)
+		updated++
+	}
+	if only != "" && updated == 0 {
+		return fmt.Errorf("packs update: %q not installed", only)
+	}
+	return writePacksLock(root, lock)
+}
+
+// fetchPack populates dest with the pack contents and returns the
+// resolved commit sha when the source is a Git URL. Local-directory
+// sources (file://, ./, ../, /) copy the tree and return an empty sha.
+func fetchPack(source, ref, dest string) (string, error) {
+	if isLocalSource(source) {
+		return "", copyTree(localPath(source), dest)
+	}
+	return gitClone(source, ref, dest)
+}
+
+func isLocalSource(s string) bool {
+	if strings.HasPrefix(s, "file://") {
+		return true
+	}
+	if strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") || strings.HasPrefix(s, "/") {
+		return true
+	}
+	return false
+}
+
+func localPath(s string) string {
+	if strings.HasPrefix(s, "file://") {
+		return strings.TrimPrefix(s, "file://")
+	}
+	return s
+}
+
+func copyTree(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s: not a directory", src)
+	}
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
+// gitClone clones source at ref into dest using the system git binary
+// and returns the resolved HEAD commit. When ref is empty the default
+// branch is fetched.
+func gitClone(source, ref, dest string) (string, error) {
+	cloneURL := source
+	if !strings.Contains(cloneURL, "://") && !strings.HasPrefix(cloneURL, "git@") {
+		cloneURL = "https://" + cloneURL
+	}
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, cloneURL, dest)
+	if err := runCmd("git", args...); err != nil {
+		return "", fmt.Errorf("git clone: %w", err)
+	}
+	sha, err := captureCmd(dest, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse: %w", err)
+	}
+	if err := os.RemoveAll(filepath.Join(dest, ".git")); err != nil {
+		return "", fmt.Errorf("strip .git: %w", err)
+	}
+	return strings.TrimSpace(sha), nil
+}
+
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func captureCmd(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return string(out), err
+}
+
+// splitSourceRef splits "github.com/foo/bar@v1.2.0" into
+// ("github.com/foo/bar", "v1.2.0"). A bare source returns ref "".
+// The split honors only the last "@" so SSH-style "git@host:path@ref"
+// still parses correctly.
+func splitSourceRef(s string) (src, ref string) {
+	at := strings.LastIndex(s, "@")
+	if at < 0 {
+		return s, ""
+	}
+	return s[:at], s[at+1:]
+}
+
+// derivePackName picks an install directory name from a source string.
+// Strategy: take the last path component, drop a `.git` suffix.
+func derivePackName(source string) string {
+	s := source
+	if strings.HasPrefix(s, "file://") {
+		s = strings.TrimPrefix(s, "file://")
+	}
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	if u, err := url.Parse(s); err == nil && u.Path != "" && u.Host != "" {
+		s = strings.TrimPrefix(u.Path, "/")
+	}
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		s = s[i+1:]
+	}
+	if i := strings.LastIndex(s, ":"); i >= 0 {
+		s = s[i+1:]
+	}
+	return s
+}
+
+// validatePackName rejects names that would escape the packs directory
+// or collide with disallowed characters. A pack name is a single path
+// segment.
+func validatePackName(name string) error {
+	if name == "" || name == "." || name == ".." {
+		return fmt.Errorf("packs: invalid pack name %q", name)
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("packs: pack name must be a single path segment, got %q", name)
+	}
+	return nil
+}
+
+func short(sha string) string {
+	if len(sha) < 8 {
+		return sha
+	}
+	return sha[:8]
+}
+
+// readPacksLock loads agnostic.packs.lock, returning an empty lock if
+// the file does not exist.
+func readPacksLock(root string) (*packsLock, error) {
+	path := filepath.Join(root, packsLockfile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &packsLock{Version: 1}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", packsLockfile, err)
+	}
+	var lock packsLock
+	if err := yaml.Unmarshal(data, &lock); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", packsLockfile, err)
+	}
+	if lock.Version == 0 {
+		lock.Version = 1
+	}
+	return &lock, nil
+}
+
+// writePacksLock atomically rewrites agnostic.packs.lock. When the
+// resulting list is empty the file is removed so adding then removing a
+// pack leaves no residue.
+func writePacksLock(root string, lock *packsLock) error {
+	path := filepath.Join(root, packsLockfile)
+	if len(lock.Packs) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", packsLockfile, err)
+		}
+		return nil
+	}
+	sort.Slice(lock.Packs, func(i, j int) bool { return lock.Packs[i].Name < lock.Packs[j].Name })
+	data, err := yaml.Marshal(lock)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", packsLockfile, err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func (l *packsLock) has(name string) bool {
+	for _, p := range l.Packs {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *packsLock) upsert(p packEntry) {
+	for i, ex := range l.Packs {
+		if ex.Name == p.Name {
+			l.Packs[i] = p
+			return
+		}
+	}
+	l.Packs = append(l.Packs, p)
+}
+
+func (l *packsLock) remove(name string) {
+	out := l.Packs[:0]
+	for _, p := range l.Packs {
+		if p.Name == name {
+			continue
+		}
+		out = append(out, p)
+	}
+	l.Packs = out
+}
+
+// resolvePacksLayers returns one spec.Layer per installed pack, in
+// alphabetical order so emit output stays deterministic across runs.
+// Each pack is named "pack:<name>" so list/validate output is
+// self-explanatory. Returns nil when no packs are installed.
+func resolvePacksLayers(projectRoot string) []spec.Layer {
+	lock, err := readPacksLock(projectRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "! %v\n", err)
+		return nil
+	}
+	if len(lock.Packs) == 0 {
+		return nil
+	}
+	out := make([]spec.Layer, 0, len(lock.Packs))
+	for _, p := range lock.Packs {
+		root := filepath.Join(projectRoot, packsDir, p.Name)
+		if !dirExists(root) {
+			fmt.Fprintf(os.Stderr, "! pack %q listed in %s but missing on disk; run `agnostic-ai packs update`\n", p.Name, packsLockfile)
+			continue
+		}
+		out = append(out, spec.Layer{
+			Name:    layerNamePackPrefix + p.Name,
+			Root:    root,
+			Sources: defaultLayerSources(),
+		})
+	}
+	return out
+}

--- a/internal/cli/packs_test.go
+++ b/internal/cli/packs_test.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func TestSplitSourceRef(t *testing.T) {
+	cases := []struct {
+		in, src, ref string
+	}{
+		{"github.com/foo/bar", "github.com/foo/bar", ""},
+		{"github.com/foo/bar@v1.2.0", "github.com/foo/bar", "v1.2.0"},
+		{"git@host:foo/bar@v1", "git@host:foo/bar", "v1"},
+		{"./local/pack", "./local/pack", ""},
+	}
+	for _, c := range cases {
+		gotSrc, gotRef := splitSourceRef(c.in)
+		if gotSrc != c.src || gotRef != c.ref {
+			t.Errorf("splitSourceRef(%q)=(%q,%q), want (%q,%q)", c.in, gotSrc, gotRef, c.src, c.ref)
+		}
+	}
+}
+
+func TestDerivePackName(t *testing.T) {
+	cases := map[string]string{
+		"github.com/chemaclass/go-rules":     "go-rules",
+		"https://github.com/foo/bar.git":     "bar",
+		"git@github.com:foo/baz":             "baz",
+		"./local/pack":                       "pack",
+		"file:///tmp/sample-pack/":           "sample-pack",
+		"https://example.com/team/security/": "security",
+	}
+	for in, want := range cases {
+		if got := derivePackName(in); got != want {
+			t.Errorf("derivePackName(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestValidatePackName(t *testing.T) {
+	good := []string{"foo", "go-rules", "team_security", "v1"}
+	for _, n := range good {
+		if err := validatePackName(n); err != nil {
+			t.Errorf("validatePackName(%q) unexpected err: %v", n, err)
+		}
+	}
+	bad := []string{"", ".", "..", "foo/bar", `foo\bar`}
+	for _, n := range bad {
+		if err := validatePackName(n); err == nil {
+			t.Errorf("validatePackName(%q) accepted, expected error", n)
+		}
+	}
+}
+
+func TestPacksLifecycle_LocalSource(t *testing.T) {
+	root := testutil.TempCwd(t)
+
+	src := filepath.Join(t.TempDir(), "go-rules")
+	mustWrite(t, filepath.Join(src, "rules", "x.md"), "---\nname: x\n---\nbody")
+	mustWrite(t, filepath.Join(src, "agents", "y.md"), "---\nname: y\n---\nbody")
+
+	var out bytes.Buffer
+	if err := runPacksAdd(root, src, "", &out); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if !strings.Contains(out.String(), "added go-rules") {
+		t.Errorf("add output: %q", out.String())
+	}
+
+	dest := filepath.Join(root, packsDir, "go-rules", "rules", "x.md")
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("expected copied rule at %s: %v", dest, err)
+	}
+
+	lock, err := readPacksLock(root)
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	if len(lock.Packs) != 1 || lock.Packs[0].Name != "go-rules" {
+		t.Fatalf("lock state: %+v", lock.Packs)
+	}
+
+	out.Reset()
+	if err := runPacksList(root, &out); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out.String(), "go-rules") {
+		t.Errorf("list output: %q", out.String())
+	}
+
+	out.Reset()
+	if err := runPacksRemove(root, "go-rules", &out); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, packsDir, "go-rules")); !os.IsNotExist(err) {
+		t.Errorf("expected pack dir removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, packsLockfile)); !os.IsNotExist(err) {
+		t.Errorf("expected empty lock removed, stat err=%v", err)
+	}
+}
+
+func TestPacksRemove_NotInstalled(t *testing.T) {
+	root := testutil.TempCwd(t)
+	var out bytes.Buffer
+	if err := runPacksRemove(root, "missing", &out); err == nil {
+		t.Fatal("expected error removing missing pack")
+	}
+}
+
+func TestPacksUpdate_LocalSource(t *testing.T) {
+	root := testutil.TempCwd(t)
+
+	src := filepath.Join(t.TempDir(), "go-rules")
+	mustWrite(t, filepath.Join(src, "rules", "x.md"), "---\nname: x\n---\nv1")
+
+	var out bytes.Buffer
+	if err := runPacksAdd(root, src, "", &out); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	mustWrite(t, filepath.Join(src, "rules", "x.md"), "---\nname: x\n---\nv2")
+
+	out.Reset()
+	if err := runPacksUpdate(root, "", &out); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, packsDir, "go-rules", "rules", "x.md"))
+	if !strings.Contains(string(got), "v2") {
+		t.Errorf("expected v2 after update, got %q", got)
+	}
+}
+
+func TestResolveLayers_PacksLayerInsertedBetweenUserGlobalAndProject(t *testing.T) {
+	t.Setenv(envUserGlobalRoot, "/nonexistent-agnostic-ai-test-path")
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	src := filepath.Join(t.TempDir(), "p1")
+	mustWrite(t, filepath.Join(src, "rules", "r.md"), "---\nname: r\n---\nb")
+
+	var out bytes.Buffer
+	if err := runPacksAdd(root, src, "", &out); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	cfg := &config.Config{Sources: defaultLayerSources()}
+	layers := resolveLayers(root, cfg)
+	if len(layers) != 2 {
+		t.Fatalf("expected 2 layers (pack + project), got %d (%+v)", len(layers), layers)
+	}
+	if !strings.HasPrefix(layers[0].Name, layerNamePackPrefix) {
+		t.Errorf("layer[0]=%q, want pack:* (lower precedence than project)", layers[0].Name)
+	}
+	if layers[1].Name != layerNameProject {
+		t.Errorf("layer[1]=%q, want %q", layers[1].Name, layerNameProject)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -66,6 +66,7 @@ func NewRootCmd(version string) *cobra.Command {
 		newImportCmd(),
 		newDoctorCmd(),
 		newRevertCmd(),
+		newPacksCmd(),
 	)
 	root.InitDefaultCompletionCmd()
 	return root


### PR DESCRIPTION
## Summary

- New top-level command `agnostic-ai packs` with `add`, `remove`, `update`, and `list` subcommands.
- Installs Git URLs (cloned `--depth 1`, sha captured) and local directories into `.agnostic-ai/packs/<name>/`.
- Pinned in `agnostic.packs.lock` (YAML, sorted by name).
- Layered loader picks up installed packs as a new layer between user-global and project, so any project spec overrides a pack entry of the same name.
- User docs (`docs/user/packs.md`) and publisher docs (`docs/internal/pack-authors.md`).

Closes #46.

## Why

Most rules and conventions are not repo-specific. Conventional commits,
secret-scanning, language idioms, framework conventions: all reusable.
Packs make the spec format a sharing medium, not just a build target,
without standing up a registry. Users get the same project-overrides
escape hatch they already have for the user-global layer.