### PR TITLE
feat(spec): precise YAML frontmatter errors with file:line:col

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - CI lint job upgraded to `golangci/golangci-lint-action@v9` with `golangci-lint v2.6`. `.golangci.yml` migrated to v2 schema (`version: "2"`, `linters.default: none`, `formatters` section for `gofmt`/`goimports`).
 
 ### Fixed
+- Spec frontmatter parse errors now report `path:line:col: message` (with column 1 when the YAML parser does not provide one) and the line number is shifted by one for markdown frontmatter so it points at the offending line in the source file. Previously a malformed YAML block was silently treated as plain body, producing an empty `meta` and confusing downstream emission.
 - `extract_changelog_section` accepts both `## [vX.Y.Z]` and `## vX.Y.Z` heading forms.
 
 ## v0.4.0 - 2026-05-05

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -307,7 +307,10 @@ func parseMarkdown(path string) (Entry, error) {
 	if err != nil {
 		return Entry{}, fmt.Errorf("read: %w", err)
 	}
-	meta, body := splitFrontmatter(normalizeLineEndings(data))
+	meta, body, err := splitFrontmatter(normalizeLineEndings(data))
+	if err != nil {
+		return Entry{}, fmt.Errorf("parse frontmatter: %w", err)
+	}
 	name, _ := meta["name"].(string)
 	return Entry{
 		Path: path,
@@ -343,27 +346,33 @@ func normalizeLineEndings(b []byte) []byte {
 	return bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
 }
 
-func splitFrontmatter(data []byte) (map[string]any, string) {
+// splitFrontmatter parses a leading `---` block as YAML and returns the
+// remaining body. A file that does not start with `---`, or whose
+// closing `---` is missing, is treated as body-only with empty meta
+// (this matches the legacy behaviour). Malformed YAML inside a fully
+// delimited block is surfaced as an error rather than silently
+// swallowed.
+func splitFrontmatter(data []byte) (map[string]any, string, error) {
 	const delim = "---"
 	empty := map[string]any{}
 
 	if !bytes.HasPrefix(data, []byte(delim)) {
-		return empty, string(data)
+		return empty, string(data), nil
 	}
 	rest := data[len(delim):]
 	idx := bytes.Index(rest, []byte("\n"+delim))
 	if idx < 0 {
-		return empty, string(data)
+		return empty, string(data), nil
 	}
 	yamlPart := rest[:idx]
 	body := bytes.TrimLeft(rest[idx+len("\n"+delim):], "\n")
 
 	var meta map[string]any
 	if err := yaml.Unmarshal(yamlPart, &meta); err != nil {
-		return empty, string(data)
+		return nil, "", err
 	}
 	if meta == nil {
 		meta = empty
 	}
-	return meta, string(body)
+	return meta, string(body), nil
 }

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -309,7 +309,8 @@ func parseMarkdown(path string) (Entry, error) {
 	}
 	meta, body, err := splitFrontmatter(normalizeLineEndings(data))
 	if err != nil {
-		return Entry{}, fmt.Errorf("parse frontmatter: %w", err)
+		// Frontmatter starts at line 2 (line 1 is the opening `---`).
+		return Entry{}, formatYAMLError(path, err, 1)
 	}
 	name, _ := meta["name"].(string)
 	return Entry{
@@ -327,7 +328,7 @@ func parseYAML(path string) (Entry, error) {
 	}
 	var meta map[string]any
 	if err := yaml.Unmarshal(data, &meta); err != nil {
-		return Entry{}, fmt.Errorf("parse yaml: %w", err)
+		return Entry{}, formatYAMLError(path, err, 0)
 	}
 	name, _ := meta["name"].(string)
 	return Entry{

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -350,7 +350,7 @@ func normalizeLineEndings(b []byte) []byte {
 // splitFrontmatter parses a leading `---` block as YAML and returns the
 // remaining body. A file that does not start with `---`, or whose
 // closing `---` is missing, is treated as body-only with empty meta
-// (this matches the legacy behaviour). Malformed YAML inside a fully
+// (this matches the legacy behavior). Malformed YAML inside a fully
 // delimited block is surfaced as an error rather than silently
 // swallowed.
 func splitFrontmatter(data []byte) (map[string]any, string, error) {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
-	meta, body := splitFrontmatter([]byte("hello world"))
+	meta, body, err := splitFrontmatter([]byte("hello world"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(meta) != 0 {
 		t.Fatalf("expected empty meta, got %v", meta)
 	}
@@ -20,7 +23,10 @@ func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
 
 func TestSplitFrontmatter_WithFrontmatter(t *testing.T) {
 	input := []byte("---\nname: foo\ndescription: bar\n---\nbody here\n")
-	meta, body := splitFrontmatter(input)
+	meta, body, err := splitFrontmatter(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if meta["name"] != "foo" {
 		t.Fatalf("expected name=foo, got %v", meta["name"])
 	}
@@ -31,7 +37,10 @@ func TestSplitFrontmatter_WithFrontmatter(t *testing.T) {
 
 func TestSplitFrontmatter_EmptyMeta(t *testing.T) {
 	input := []byte("---\n---\nbody only\n")
-	meta, body := splitFrontmatter(input)
+	meta, body, err := splitFrontmatter(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(meta) != 0 {
 		t.Fatalf("expected empty meta, got %v", meta)
 	}
@@ -42,9 +51,8 @@ func TestSplitFrontmatter_EmptyMeta(t *testing.T) {
 
 func TestSplitFrontmatter_MalformedYAML(t *testing.T) {
 	input := []byte("---\n: : :\n---\nbody\n")
-	meta, _ := splitFrontmatter(input)
-	if len(meta) != 0 {
-		t.Fatal("expected empty meta on malformed yaml")
+	if _, _, err := splitFrontmatter(input); err == nil {
+		t.Fatal("expected error on malformed yaml")
 	}
 }
 

--- a/internal/spec/yamlerr.go
+++ b/internal/spec/yamlerr.go
@@ -1,0 +1,67 @@
+package spec
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// formatYAMLError wraps a yaml.v3 parse error in a `path:line:col: msg`
+// envelope so editor and CI output can navigate straight to the
+// offending byte. lineOffset is the 1-based line number on which the
+// yaml block starts inside the source file (0 for pure YAML files; 1
+// for markdown frontmatter, where the `---` opener occupies line 1 and
+// yaml content begins on line 2).
+func formatYAMLError(path string, err error, lineOffset int) error {
+	if err == nil {
+		return nil
+	}
+	for _, msg := range yamlErrorMessages(err) {
+		line, col, body := extractPosition(msg)
+		if line > 0 {
+			line += lineOffset
+		} else {
+			line = 1
+		}
+		if col <= 0 {
+			col = 1
+		}
+		return fmt.Errorf("%s:%d:%d: %s", path, line, col, body)
+	}
+	return fmt.Errorf("%s: %s", path, err.Error())
+}
+
+// yamlErrorMessages flattens a yaml.v3 error chain into individual
+// human-readable strings. yaml.TypeError carries multiple lines in its
+// Errors slice; everything else is a single-string error.
+func yamlErrorMessages(err error) []string {
+	if te, ok := err.(*yaml.TypeError); ok && len(te.Errors) > 0 {
+		return te.Errors
+	}
+	return []string{err.Error()}
+}
+
+var (
+	reLineCol = regexp.MustCompile(`^yaml: line (\d+): column (\d+): (.+)$`)
+	reLine    = regexp.MustCompile(`^yaml: line (\d+): (.+)$`)
+)
+
+// extractPosition pulls (line, col, message) out of a yaml.v3 error
+// string. Returns (0, 0, raw) when the format is not recognized so
+// callers fall back to a default position rather than emit "0:0".
+func extractPosition(msg string) (line, col int, body string) {
+	msg = strings.TrimSpace(msg)
+	if m := reLineCol.FindStringSubmatch(msg); m != nil {
+		line, _ = strconv.Atoi(m[1])
+		col, _ = strconv.Atoi(m[2])
+		return line, col, m[3]
+	}
+	if m := reLine.FindStringSubmatch(msg); m != nil {
+		line, _ = strconv.Atoi(m[1])
+		return line, 0, m[2]
+	}
+	return 0, 0, msg
+}

--- a/internal/spec/yamlerr.go
+++ b/internal/spec/yamlerr.go
@@ -19,19 +19,20 @@ func formatYAMLError(path string, err error, lineOffset int) error {
 	if err == nil {
 		return nil
 	}
-	for _, msg := range yamlErrorMessages(err) {
-		line, col, body := extractPosition(msg)
-		if line > 0 {
-			line += lineOffset
-		} else {
-			line = 1
-		}
-		if col <= 0 {
-			col = 1
-		}
-		return fmt.Errorf("%s:%d:%d: %s", path, line, col, body)
+	msgs := yamlErrorMessages(err)
+	if len(msgs) == 0 {
+		return fmt.Errorf("%s: %s", path, err.Error())
 	}
-	return fmt.Errorf("%s: %s", path, err.Error())
+	line, col, body := extractPosition(msgs[0])
+	if line > 0 {
+		line += lineOffset
+	} else {
+		line = 1
+	}
+	if col <= 0 {
+		col = 1
+	}
+	return fmt.Errorf("%s:%d:%d: %s", path, line, col, body)
 }
 
 // yamlErrorMessages flattens a yaml.v3 error chain into individual

--- a/internal/spec/yamlerr_test.go
+++ b/internal/spec/yamlerr_test.go
@@ -1,0 +1,103 @@
+package spec
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestFormatYAMLError_LineAndCol(t *testing.T) {
+	err := errors.New("yaml: line 3: column 5: did not find expected key")
+	got := formatYAMLError("rules/x.md", err, 1).Error()
+	want := "rules/x.md:4:5: did not find expected key"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatYAMLError_LineOnly(t *testing.T) {
+	err := errors.New("yaml: line 2: mapping values are not allowed in this context")
+	got := formatYAMLError("hooks/h.yaml", err, 0).Error()
+	want := "hooks/h.yaml:2:1: mapping values are not allowed in this context"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatYAMLError_Unparseable(t *testing.T) {
+	err := errors.New("totally unrecognized format")
+	got := formatYAMLError("p.md", err, 0).Error()
+	want := "p.md:1:1: totally unrecognized format"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatYAMLError_NilReturnsNil(t *testing.T) {
+	if formatYAMLError("x", nil, 0) != nil {
+		t.Error("expected nil error to round-trip")
+	}
+}
+
+func TestFormatYAMLError_TypeErrorUsesFirstMessage(t *testing.T) {
+	te := &yaml.TypeError{Errors: []string{
+		"yaml: line 4: column 1: cannot unmarshal !!str into int",
+	}}
+	got := formatYAMLError("mcps/m.yaml", te, 0).Error()
+	want := "mcps/m.yaml:4:1: cannot unmarshal !!str into int"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseMarkdown_FrontmatterErrorIncludesPathAndLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.md")
+	// `:` at start of yaml line is invalid; yaml reports the offending
+	// line within the frontmatter block, which the formatter then
+	// shifts by +1 to account for the `---` opener.
+	content := "---\n: : :\n---\nbody\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := parseMarkdown(path)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, path) {
+		t.Errorf("error %q missing path", msg)
+	}
+	if !strings.Contains(msg, ":2:") && !strings.Contains(msg, ":3:") {
+		t.Errorf("error %q missing line number", msg)
+	}
+}
+
+func TestParseYAML_ErrorIncludesPathAndPosition(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "h.yaml")
+	// yaml.v3 reports a position for this construct; the exact line
+	// number depends on the parser, so the test asserts the
+	// `path:line:col:` envelope is present rather than a specific
+	// line.
+	content := "name: foo\nfoo: [1, 2,\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := parseYAML(path)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.HasPrefix(err.Error(), path+":") {
+		t.Errorf("error %q does not start with %q", err.Error(), path+":")
+	}
+	parts := strings.SplitN(err.Error(), ":", 4)
+	if len(parts) < 4 {
+		t.Errorf("error %q missing line:col envelope", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- Stop swallowing yaml.Unmarshal errors in `splitFrontmatter`. Malformed frontmatter now fails the load instead of producing an empty `meta` and a body that contains the entire file.
- New `formatYAMLError` helper wraps every yaml error in a `path:line:col: message` envelope. Frontmatter errors are shifted by +1 line so the position points at the offending line in the source file, not the yaml block. Falls back to `path:1:1: msg` when the parser does not supply a position.
- `parseMarkdown` and `parseYAML` route through the helper.

Closes #41.

## Why

`yaml: line 3: did not find expected key` tells you nothing about which
file. With dozens of specs in a project, locating the broken one was a
manual grep. The new envelope is what every editor and CI scraper
already knows how to parse, so the build log links straight to the
offending byte.