### PR TITLE
chore: gitignore generated .codex/, .opencode/, .agents/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ desktop.ini
 /.clinerules/
 /.windsurf/
 /.continue/
+/.codex/
+/.opencode/
+/.agents/
 /CLAUDE.md
 /GEMINI.md
 /CONVENTIONS.md


### PR DESCRIPTION
## Summary

Add `/.codex/`, `/.opencode/`, `/.agents/` to `.gitignore`. These
directories are produced by the codex and opencode adapters
(per-agent TOML files, per-skill SKILL.md) but were missing from the
ignore list. A fresh `agnostic-ai sync` left an untracked tree,
which breaks the release script's clean-tree precondition.

Fix is one-line per directory under the existing "agnostic-ai
generated outputs at the project root" block.