### PR TITLE
chore: gitignore NOTES.md (GoReleaser dirty-tree fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,14 @@ AGENT.md
 WARP.md
 .rules
 # =============================================================================
+# Release scaffolding
+# =============================================================================
+# NOTES.md is built by .github/workflows/release.yml from CHANGELOG.md and
+# fed to GoReleaser via --release-notes. GoReleaser refuses to release with
+# a dirty tree, so the file must stay out of git.
+/NOTES.md
+
+# =============================================================================
 # Tooling caches
 # =============================================================================
 /.golangci-cache/


### PR DESCRIPTION
Release workflow writes NOTES.md from CHANGELOG.md before GoReleaser runs. GoReleaser refuses dirty tree. v0.5.0 release tag failed with this exact error. Add NOTES.md to .gitignore.