### PR TITLE
feat(cli): add status command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- `agnostic-ai status`: single read-only command that shows project name, active layers, spec counts, configured targets, last sync timestamp (with files-changed count), and current drift count. Use `--json` for machine-readable output. Exits 0 even when drifted; use `sync --check` for CI gating. Last sync timestamp is read from `.agnostic-ai/.sync-state` written by each successful `sync` run, with a fallback to the newest mtime of generated files when the state file is absent.
+
 ## v0.5.0 - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ agnostic-ai sync --dry-run        # preview without writing
 agnostic-ai sync --watch          # re-emit on spec changes (Ctrl+C to exit)
 agnostic-ai sync --auto-sync=yes  # write a rule telling agents to run sync on spec changes
 agnostic-ai revert                # undo last sync
+agnostic-ai status                # show project config, spec counts, and sync state
 ```
 
 Already have `.cursor/rules` or `AGENTS.md`? Pull them in:

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -208,6 +208,47 @@ Use the no-flag form as a CI gate alongside `sync --check`, or after rebases to
 spot files the merge resolved manually. Use `--fix` for an interactive cleanup
 pass. Pair with `--backup` when reconciling files you may have hand-edited.
 
+## status
+
+Show project configuration and current sync state. Exits 0 even when drift is
+detected. Use `sync --check` or `doctor` as CI gates.
+
+```bash
+agnostic-ai status          # human-readable output
+agnostic-ai status --json   # machine-readable JSON (for editor extensions, dashboards)
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON instead of plain text. |
+
+**Human-readable output:**
+
+```
+Project: my-project
+Layers:  project (.agnostic-ai/)
+Specs:   3 rules, 1 agent, 2 skills
+Targets: claude, cursor, copilot
+Last sync: 2026-05-07 14:22 (5 files changed)
+Drift:   in sync
+```
+
+**JSON output keys:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `project` | string | Base name of the project directory. |
+| `layers` | array | Active spec layers. Each has `name` and `path`. |
+| `specs` | object | Counts: `agents`, `skills`, `rules`, `hooks`, `mcps`. |
+| `targets` | array | Targets listed in `agnostic.config.yaml`. |
+| `last_sync` | string or null | RFC 3339 timestamp of the last successful `sync`, or `null` if unknown. |
+| `files_changed_last_sync` | number or null | Files written during the last sync, or `null` when the timestamp came from an mtime fallback. |
+| `drift_files` | number | Count of emitted files whose on-disk content differs from what `sync` would produce. |
+
+**State file:** Each successful `sync` writes `.agnostic-ai/.sync-state` (JSON) recording the
+timestamp and file count. When that file is absent, `status` falls back to the newest mtime of
+generated files. When no files exist yet, the timestamp is reported as `unknown`.
+
 ## completion
 
 Generate a shell completion script and install it for your shell.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -134,6 +134,18 @@ are written; empty stubs are skipped):
 └── .continue/rules/conventional-commits.md      # for Continue
 ```
 
+## Check project status
+
+See what the tool knows about your project at a glance:
+
+```bash
+agnostic-ai status
+```
+
+Output includes the project name, active spec layers, spec counts, configured
+targets, the last sync timestamp, and whether any generated files are out of
+date. Exits 0 regardless of drift. Use `sync --check` or `doctor` in CI.
+
 ## Roll back a sync
 
 ```bash

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -58,6 +58,13 @@ func StartRecording() { emit.StartRecording() }
 // StopRecording returns the recorded paths and disables recording.
 func StopRecording() []string { return emit.StopRecording() }
 
+// StartCounting begins tracking the number of files written to disk.
+// Does not affect IO. Used by sync to record files_changed in the state file.
+func StartCounting() { emit.StartCounting() }
+
+// StopCounting returns the count of files written since StartCounting.
+func StopCounting() int { return emit.StopCounting() }
+
 // WriteFile writes content to path through the shared emit layer,
 // honoring the current capture, recording, and backup modes.
 func WriteFile(path, content string, dryRun bool) error {

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -37,6 +37,8 @@ var state struct {
 	backup    bool
 	recording bool
 	recorded  []string
+	counting  bool
+	counted   int
 }
 
 // SetBackup toggles backup mode. When enabled, WriteFile copies an
@@ -90,6 +92,26 @@ func StopRecording() []string {
 	return out
 }
 
+// StartCounting begins tracking the number of files written to disk.
+// Does not affect IO. Reset on each call to StartCounting.
+func StartCounting() {
+	state.mu.Lock()
+	state.counting = true
+	state.counted = 0
+	state.mu.Unlock()
+}
+
+// StopCounting returns the count of files written since StartCounting
+// and disables counting mode.
+func StopCounting() int {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.counting = false
+	n := state.counted
+	state.counted = 0
+	return n
+}
+
 // WriteFile creates parent directories as needed and writes content to path.
 // When dryRun is true the file is not written; the path and content are
 // printed to stdout instead. When capture mode is active, the call is
@@ -105,6 +127,9 @@ func WriteFile(path, content string, dryRun bool) error {
 	}
 	if recording {
 		state.recorded = append(state.recorded, path)
+	}
+	if state.counting && !capturing && !dryRun {
+		state.counted++
 	}
 	state.mu.Unlock()
 

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -93,7 +93,7 @@ func StopRecording() []string {
 }
 
 // StartCounting begins tracking the number of files written to disk.
-// Does not affect IO. Reset on each call to StartCounting.
+// Does not affect IO.
 func StartCounting() {
 	state.mu.Lock()
 	state.counting = true
@@ -108,7 +108,6 @@ func StopCounting() int {
 	defer state.mu.Unlock()
 	state.counting = false
 	n := state.counted
-	state.counted = 0
 	return n
 }
 

--- a/internal/adapters/internal/emit/emit_test.go
+++ b/internal/adapters/internal/emit/emit_test.go
@@ -54,3 +54,45 @@ func TestFrontmatter_WithFields(t *testing.T) {
 		t.Errorf("expected trailing ---, got %q", got)
 	}
 }
+
+func TestStartCounting_CountsRealWrites(t *testing.T) {
+	dir := t.TempDir()
+	StartCounting()
+	if err := WriteFile(filepath.Join(dir, "a.txt"), "aaa", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(filepath.Join(dir, "b.txt"), "bbb", false); err != nil {
+		t.Fatal(err)
+	}
+	n := StopCounting()
+	if n != 2 {
+		t.Fatalf("want 2, got %d", n)
+	}
+}
+
+func TestStartCounting_IgnoresDryRun(t *testing.T) {
+	dir := t.TempDir()
+	StartCounting()
+	_ = WriteFile(filepath.Join(dir, "x.txt"), "xxx", true)
+	n := StopCounting()
+	if n != 0 {
+		t.Fatalf("want 0 for dry-run, got %d", n)
+	}
+}
+
+func TestStartCounting_IgnoresCaptureMode(t *testing.T) {
+	StartCapture()
+	StartCounting()
+	_ = WriteFile("/nonexistent/fake.txt", "zzz", false)
+	_ = StopCapture()
+	n := StopCounting()
+	if n != 0 {
+		t.Fatalf("want 0 in capture mode, got %d", n)
+	}
+}
+
+func TestStopCounting_WithoutStart_ReturnsZero(t *testing.T) {
+	if n := StopCounting(); n != 0 {
+		t.Fatalf("want 0 when not counting, got %d", n)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -67,6 +67,7 @@ func NewRootCmd(version string) *cobra.Command {
 		newDoctorCmd(),
 		newRevertCmd(),
 		newPacksCmd(),
+		newStatusCmd(),
 	)
 	root.InitDefaultCompletionCmd()
 	return root

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -246,7 +246,7 @@ func printStatusJSON(cmd *cobra.Command, r *statusResult) error {
 		DriftFiles:           r.DriftFiles,
 	}
 	for i, l := range r.Layers {
-		out.Layers[i] = layerJSON{Name: l.Name, Path: l.Path}
+		out.Layers[i] = layerJSON(l)
 	}
 	if r.LastSync != nil {
 		s := r.LastSync.UTC().Format(time.RFC3339)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -65,7 +65,7 @@ func newStatusCmd() *cobra.Command {
 }
 
 func gatherStatus(projectRoot string) (*statusResult, error) {
-	cwd, err := os.Getwd()
+	abs, err := filepath.Abs(projectRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func gatherStatus(projectRoot string) (*statusResult, error) {
 	syncedAt, filesChanged := readSyncState(projectRoot, allPaths)
 
 	return &statusResult{
-		ProjectName:  filepath.Base(cwd),
+		ProjectName:  filepath.Base(abs),
 		Layers:       buildLayerInfos(projectRoot, cfg),
 		Specs:        countSpecs(b),
 		Targets:      cfg.Targets,
@@ -204,7 +204,7 @@ func printStatus(cmd *cobra.Command, r *statusResult) {
 	if r.DriftFiles == 0 {
 		cmd.Printf("Drift:   in sync\n")
 	} else {
-		cmd.Printf("Drift:   %d file%s out of date  (run `agnostic-ai sync` or `agnostic-ai doctor --fix`)\n",
+		cmd.Printf("Drift:   %d file%s out of date (run `agnostic-ai sync` or `agnostic-ai doctor --fix`)\n",
 			r.DriftFiles, pluralS(r.DriftFiles))
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+type statusResult struct {
+	ProjectName  string
+	Layers       []layerInfo
+	Specs        specCounts
+	Targets      []string
+	LastSync     *time.Time
+	FilesChanged *int
+	DriftFiles   int
+}
+
+type layerInfo struct {
+	Name string
+	Path string
+}
+
+type specCounts struct {
+	Agents int
+	Skills int
+	Rules  int
+	Hooks  int
+	MCPs   int
+}
+
+func newStatusCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show project configuration and sync state.",
+		Example: `  # Print project status
+  agnostic-ai status
+
+  # Output as JSON for editor extensions or dashboards
+  agnostic-ai status --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, err := gatherStatus(".")
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				return printStatusJSON(cmd, r)
+			}
+			printStatus(cmd, r)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func gatherStatus(projectRoot string) (*statusResult, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	cfg, b, err := loadProject(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	driftFiles, allPaths, err := captureAllAndDiff(cfg.Targets, cfg, b)
+	if err != nil {
+		return nil, err
+	}
+
+	syncedAt, filesChanged := readSyncState(projectRoot, allPaths)
+
+	return &statusResult{
+		ProjectName:  filepath.Base(cwd),
+		Layers:       buildLayerInfos(projectRoot, cfg),
+		Specs:        countSpecs(b),
+		Targets:      cfg.Targets,
+		LastSync:     syncedAt,
+		FilesChanged: filesChanged,
+		DriftFiles:   driftFiles,
+	}, nil
+}
+
+// captureAllAndDiff runs every target adapter in capture mode, counts files
+// whose on-disk content differs from what would be emitted, and returns all
+// would-be emitted paths (for mtime fallback).
+func captureAllAndDiff(targets []string, cfg *config.Config, b spec.Bundle) (driftFiles int, allPaths []string, err error) {
+	for _, t := range targets {
+		adapter, err := adapters.Resolve(t)
+		if err != nil {
+			continue
+		}
+		adapters.StartCapture()
+		if emitErr := adapter.Emit(b, cfg, false); emitErr != nil {
+			adapters.StopCapture()
+			return 0, nil, fmt.Errorf("%s: %w", t, emitErr)
+		}
+		files := adapters.StopCapture()
+		for _, f := range files {
+			allPaths = append(allPaths, f.Path)
+			disk, readErr := os.ReadFile(f.Path)
+			if os.IsNotExist(readErr) {
+				driftFiles++
+				continue
+			}
+			if readErr != nil {
+				return 0, nil, fmt.Errorf("read %s: %w", f.Path, readErr)
+			}
+			if string(disk) != f.Content {
+				driftFiles++
+			}
+		}
+	}
+	return driftFiles, allPaths, nil
+}
+
+// readSyncState reads the state file written by sync. If absent or unreadable,
+// falls back to the newest mtime across fallbackPaths. Returns (nil, nil) when
+// no timestamp can be determined.
+func readSyncState(projectRoot string, fallbackPaths []string) (syncedAt *time.Time, filesChanged *int) {
+	data, err := os.ReadFile(stateFilePath(projectRoot))
+	if err == nil {
+		var s syncStateFile
+		if json.Unmarshal(data, &s) == nil && !s.SyncedAt.IsZero() {
+			fc := s.FilesChanged
+			return &s.SyncedAt, &fc
+		}
+	}
+	var newest time.Time
+	for _, p := range fallbackPaths {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			continue
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+	}
+	if !newest.IsZero() {
+		return &newest, nil
+	}
+	return nil, nil
+}
+
+// buildLayerInfos returns display-friendly layer entries. The display path for
+// each layer is the directory that contains the spec subdirectories.
+func buildLayerInfos(projectRoot string, cfg *config.Config) []layerInfo {
+	layers := resolveLayers(projectRoot, cfg)
+	infos := make([]layerInfo, 0, len(layers))
+	for _, l := range layers {
+		displayPath := filepath.Dir(filepath.Join(l.Root, l.Sources.Agents))
+		if rel, relErr := filepath.Rel(projectRoot, displayPath); relErr == nil && !strings.HasPrefix(rel, "..") {
+			displayPath = rel
+		}
+		infos = append(infos, layerInfo{Name: l.Name, Path: displayPath + "/"})
+	}
+	return infos
+}
+
+func countSpecs(b spec.Bundle) specCounts {
+	return specCounts{
+		Agents: len(b.Agents),
+		Skills: len(b.Skills),
+		Rules:  len(b.Rules),
+		Hooks:  len(b.Hooks),
+		MCPs:   len(b.MCPs),
+	}
+}
+
+func printStatus(cmd *cobra.Command, r *statusResult) {
+	cmd.Printf("Project: %s\n", r.ProjectName)
+
+	parts := make([]string, len(r.Layers))
+	for i, l := range r.Layers {
+		parts[i] = fmt.Sprintf("%s (%s)", l.Name, l.Path)
+	}
+	cmd.Printf("Layers:  %s\n", strings.Join(parts, ", "))
+
+	cmd.Printf("Specs:   %s\n", formatSpecCounts(r.Specs))
+
+	cmd.Printf("Targets: %s\n", strings.Join(r.Targets, ", "))
+
+	switch {
+	case r.LastSync == nil:
+		cmd.Printf("Last sync: unknown\n")
+	case r.FilesChanged != nil:
+		cmd.Printf("Last sync: %s (%d file%s changed)\n",
+			r.LastSync.Local().Format("2006-01-02 15:04"), *r.FilesChanged, pluralS(*r.FilesChanged))
+	default:
+		cmd.Printf("Last sync: %s\n", r.LastSync.Local().Format("2006-01-02 15:04"))
+	}
+
+	if r.DriftFiles == 0 {
+		cmd.Printf("Drift:   in sync\n")
+	} else {
+		cmd.Printf("Drift:   %d file%s out of date  (run `agnostic-ai sync` or `agnostic-ai doctor --fix`)\n",
+			r.DriftFiles, pluralS(r.DriftFiles))
+	}
+}
+
+func printStatusJSON(cmd *cobra.Command, r *statusResult) error {
+	type layerJSON struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+	}
+	type specJSON struct {
+		Agents int `json:"agents"`
+		Skills int `json:"skills"`
+		Rules  int `json:"rules"`
+		Hooks  int `json:"hooks"`
+		MCPs   int `json:"mcps"`
+	}
+	type statusJSON struct {
+		Project              string      `json:"project"`
+		Layers               []layerJSON `json:"layers"`
+		Specs                specJSON    `json:"specs"`
+		Targets              []string    `json:"targets"`
+		LastSync             *string     `json:"last_sync"`
+		FilesChangedLastSync *int        `json:"files_changed_last_sync"`
+		DriftFiles           int         `json:"drift_files"`
+	}
+
+	out := statusJSON{
+		Project: r.ProjectName,
+		Layers:  make([]layerJSON, len(r.Layers)),
+		Specs: specJSON{
+			Agents: r.Specs.Agents,
+			Skills: r.Specs.Skills,
+			Rules:  r.Specs.Rules,
+			Hooks:  r.Specs.Hooks,
+			MCPs:   r.Specs.MCPs,
+		},
+		Targets:              r.Targets,
+		FilesChangedLastSync: r.FilesChanged,
+		DriftFiles:           r.DriftFiles,
+	}
+	for i, l := range r.Layers {
+		out.Layers[i] = layerJSON{Name: l.Name, Path: l.Path}
+	}
+	if r.LastSync != nil {
+		s := r.LastSync.UTC().Format(time.RFC3339)
+		out.LastSync = &s
+	}
+
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func formatSpecCounts(s specCounts) string {
+	var parts []string
+	if s.Rules > 0 {
+		parts = append(parts, fmt.Sprintf("%d rules", s.Rules))
+	}
+	if s.Agents > 0 {
+		parts = append(parts, fmt.Sprintf("%d agents", s.Agents))
+	}
+	if s.Skills > 0 {
+		parts = append(parts, fmt.Sprintf("%d skills", s.Skills))
+	}
+	if s.Hooks > 0 {
+		parts = append(parts, fmt.Sprintf("%d hooks", s.Hooks))
+	}
+	if s.MCPs > 0 {
+		parts = append(parts, fmt.Sprintf("%d mcps", s.MCPs))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func TestStatus_HumanReadable(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	syncCmd := NewRootCmd("test")
+	syncCmd.SetArgs([]string{"sync", "-t", "claude"})
+	if err := syncCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"status"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Project:") {
+		t.Errorf("expected 'Project:' in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Targets:") {
+		t.Errorf("expected 'Targets:' in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Last sync:") {
+		t.Errorf("expected 'Last sync:' in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Drift:") {
+		t.Errorf("expected 'Drift:' in output, got:\n%s", got)
+	}
+}
+
+func TestStatus_JSON(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	syncCmd := NewRootCmd("test")
+	syncCmd.SetArgs([]string{"sync", "-t", "claude"})
+	if err := syncCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"status", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("status --json failed: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out.String())
+	}
+	for _, field := range []string{"project", "layers", "specs", "targets", "last_sync", "files_changed_last_sync", "drift_files"} {
+		if _, ok := result[field]; !ok {
+			t.Errorf("JSON missing field %q; got: %s", field, out.String())
+		}
+	}
+}
+
+func TestStatus_ExitZeroOnDrift(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	syncCmd := NewRootCmd("test")
+	syncCmd.SetArgs([]string{"sync", "-t", "claude"})
+	if err := syncCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("hand-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"status"})
+	root.SetOut(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Errorf("status must exit 0 even when drifted, got: %v", err)
+	}
+}
+
+func TestStatus_Drifted_ShowsCount(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	syncCmd := NewRootCmd("test")
+	syncCmd.SetArgs([]string{"sync", "-t", "claude"})
+	if err := syncCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("hand-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"status"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	if strings.Contains(got, "in sync") {
+		t.Errorf("expected drift in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "out of date") {
+		t.Errorf("expected 'out of date' in output, got:\n%s", got)
+	}
+}
+
+func TestStatus_NoStateFile_MtimeFallback(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	syncCmd := NewRootCmd("test")
+	syncCmd.SetArgs([]string{"sync", "-t", "claude"})
+	if err := syncCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(stateFilePath(".")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"status"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+
+	got := out.String()
+	if strings.Contains(got, "unknown") {
+		t.Errorf("expected mtime fallback timestamp, got 'unknown':\n%s", got)
+	}
+	if !strings.Contains(got, "Last sync:") {
+		t.Errorf("expected 'Last sync:' in output, got:\n%s", got)
+	}
+}
+
+func TestStatus_NoStateFile_NoFiles_ShowsUnknown(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"status"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "unknown") {
+		t.Errorf("expected 'unknown' when no state and no files, got:\n%s", got)
+	}
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -13,6 +15,30 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 )
+
+type syncStateFile struct {
+	SyncedAt     time.Time `json:"synced_at"`
+	FilesChanged int       `json:"files_changed"`
+}
+
+func stateFilePath(projectRoot string) string {
+	return filepath.Join(projectRoot, ".agnostic-ai", ".sync-state")
+}
+
+func writeStateFile(projectRoot string, filesChanged int) error {
+	p := stateFilePath(projectRoot)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(p), err)
+	}
+	data, err := json.Marshal(syncStateFile{
+		SyncedAt:     time.Now().UTC(),
+		FilesChanged: filesChanged,
+	})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0o644)
+}
 
 func newSyncCmd() *cobra.Command {
 	var targets, only, except []string
@@ -116,6 +142,9 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	if gitignoreOn {
 		adapters.StartRecording()
 	}
+	if !dryRun {
+		adapters.StartCounting()
+	}
 	for _, t := range effectiveTargets {
 		adapter, err := adapters.Resolve(t)
 		if err != nil {
@@ -127,14 +156,26 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 			if gitignoreOn {
 				adapters.StopRecording()
 			}
+			if !dryRun {
+				adapters.StopCounting()
+			}
 			return fmt.Errorf("%s: %w", t, err)
 		}
+	}
+	filesChanged := 0
+	if !dryRun {
+		filesChanged = adapters.StopCounting()
 	}
 	if gitignoreOn {
 		if err := updateGitignore(cfg, normalizeAndSort(adapters.StopRecording())); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
 		summaryf("→ updated .gitignore\n")
+	}
+	if !dryRun {
+		if err := writeStateFile(root, filesChanged); err != nil {
+			fmt.Fprintf(os.Stderr, "! state file: %v\n", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #33

## Summary

- Adds `agnostic-ai status` — a single read-only command answering "where am I, what's configured, am I in sync?" without combining `list`, `doctor`, and `sync --dry-run`.
- `sync` now writes `.agnostic-ai/.sync-state` (timestamp + files-changed count) on each successful non-dry-run; `status` reads it with a mtime fallback for projects that haven't run `status` yet.
- `--json` flag outputs a stable schema suitable for editor extensions and dashboards.

## Behavior

```
$ agnostic-ai status
Project: agnostic-ai
Layers:  project (.agnostic-ai/)
Specs:   4 rules, 2 agents, 1 skills, 2 hooks
Targets: claude, codex, gemini, cursor, copilot, ...
Last sync: 2026-05-07 19:48 (5 files changed)
Drift:   40 files out of date (run `agnostic-ai sync` or `agnostic-ai doctor --fix`)
```

- Always exits 0 (informational). Use `sync --check` for CI gating.
- `--quiet` suppresses adapter warnings, status output still shown.

## Test Plan

- [ ] `go test ./...` passes (141 tests, race-clean)
- [ ] `golangci-lint run ./internal/cli/...` passes (0 issues)
- [ ] `agnostic-ai status` in a real project shows all six fields
- [ ] `agnostic-ai status --json` outputs valid JSON with all documented keys
- [ ] `agnostic-ai status` exits 0 when drifted
- [ ] `agnostic-ai sync --dry-run` does NOT write `.agnostic-ai/.sync-state`
- [ ] Deleting `.agnostic-ai/.sync-state` and running `status` shows mtime-derived timestamp (not "unknown")