### PR TITLE
feat: status command and --json output for sync, revert, doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+- `sync --json`, `sync --check --json`, `revert --json`, `doctor --json`: stable JSON output for machine consumption. Emits `{version, command, writes, skipped, errors}`. The `writes` array lists per-file records with `target`, `path`, `action` (create/update/skip for sync; missing/stale for check; restore/remove for revert), and `bytes`. Schema versioned at `"1"`; breaking changes will bump it. Documented in `docs/user/cli-reference.md`.
 - `agnostic-ai status`: single read-only command that shows project name, active layers, spec counts, configured targets, last sync timestamp (with files-changed count), and current drift count. Use `--json` for machine-readable output. Exits 0 even when drifted; use `sync --check` for CI gating. Last sync timestamp is read from `.agnostic-ai/.sync-state` written by each successful `sync` run, with a fallback to the newest mtime of generated files when the state file is absent.
 
 ## v0.5.0 - 2026-05-07

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -143,6 +143,7 @@ agnostic-ai sync [flags]
 | `--gitignore <on\|off>` | Override `gitignore.enabled` for this run. |
 | `--watch` | Keep the process alive and re-emit on spec or config changes (200 ms poll). Ctrl+C exits cleanly. Incompatible with `--check`. |
 | `--auto-sync <yes\|no>` | Persist an answer to the first-run auto-sync prompt. Writes an `auto-sync` rule spec instructing agents to run `agnostic-ai sync` when specs change. Persists `autoSync: true/false` to `agnostic.config.yaml`. Skipped under `--dry-run`. Without the flag, on a TTY, `sync` prompts once. |
+| `--json` | Output as JSON instead of plain text. Stable schema; breaking changes bump `version`. |
 
 ```bash
 agnostic-ai sync                       # all targets in config
@@ -154,9 +155,38 @@ agnostic-ai sync --check               # CI gate: fail if outputs are stale
 agnostic-ai sync --backup              # leave a .bak trail for revert
 agnostic-ai sync --watch               # re-emit on spec changes; Ctrl+C exits
 agnostic-ai sync --auto-sync=yes       # opt in to agent-managed auto-sync
+agnostic-ai sync --json                # machine-readable output
+agnostic-ai sync --check --json        # machine-readable drift report
 ```
 
 `--only` and `--except` validate names against the configured targets list and return an error on unknown names (rather than silently skipping).
+
+**JSON output schema (version 1):**
+
+```json
+{
+  "version": "1",
+  "command": "sync",
+  "writes": [
+    {"target": "claude", "path": "CLAUDE.md", "action": "create", "bytes": 1284},
+    {"target": "cursor", "path": ".cursor/rules/foo.mdc", "action": "update", "bytes": 312}
+  ],
+  "skipped": [
+    {"target": "claude", "path": "CLAUDE.md", "action": "skip", "bytes": 1284}
+  ],
+  "errors": []
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string | Schema version. Currently `"1"`. |
+| `command` | string | Command that produced the output (`"sync"` or `"sync --check"`). |
+| `writes` | array | Files written (action `"create"` or `"update"`) or, for `--check`, files that need writing (action `"missing"` or `"stale"`). |
+| `skipped` | array | Files whose on-disk content already matched (action `"skip"`). Empty for `--check`. |
+| `errors` | array | Per-target errors with `target` and `message` fields. |
+
+Each entry in `writes` and `skipped` has: `target` (string), `path` (string), `action` (string), `bytes` (number).
 
 ## revert
 
@@ -173,6 +203,7 @@ agnostic-ai revert [flags]
 | `--only <list>` | Revert only these targets (comma-separated). Mutually exclusive with `--except`. Errors on unknown names. |
 | `--except <list>` | Revert all configured targets except these (comma-separated). Mutually exclusive with `--only`. Errors on unknown names. |
 | `--dry-run` | Report intended actions without touching disk |
+| `--json` | Output as JSON instead of plain text. |
 
 ```bash
 agnostic-ai sync --backup              # 1. snapshot existing files
@@ -180,7 +211,10 @@ agnostic-ai sync --backup              # 1. snapshot existing files
 agnostic-ai revert                     # 2. roll back to the snapshot
 agnostic-ai revert --only claude       # 3. roll back only claude
 agnostic-ai revert --except codex      # 4. roll back everything except codex
+agnostic-ai revert --json              # machine-readable output
 ```
+
+The `--json` output uses the same schema as `sync --json`. Actions are `"restore"` (`.bak` was applied), `"remove"` (file was deleted), or `"skip"` (file was already absent).
 
 Without a prior `--backup`, `revert` removes the generated files;
 nothing is restored.
@@ -203,6 +237,7 @@ agnostic-ai doctor --fix --backup   # save .bak of hand-edits before overwrite
 | `-t, --target <list>` | Comma-separated targets (default: all in config) |
 | `--fix` | Write missing/stale files. In-sync files untouched. |
 | `--backup` | With `--fix`, copy each existing file to `<path>.bak` before overwriting. |
+| `--json` | Output drift report as JSON. Same schema as `sync --check --json`. |
 
 Use the no-flag form as a CI gate alongside `sync --check`, or after rebases to
 spot files the merge resolved manually. Use `--fix` for an interactive cleanup

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -31,6 +31,10 @@ import (
 // emit tree can consume capture output.
 type CapturedFile = emit.CapturedFile
 
+// WrittenFile mirrors emit.WrittenFile so callers outside the internal
+// emit tree can consume detailed recording output.
+type WrittenFile = emit.WrittenFile
+
 // StartCapture redirects subsequent adapter writes to an in-memory buffer.
 // Pair with StopCapture. Used by drift detection (`sync --check`, `doctor`)
 // and `revert` to inspect what each adapter would emit without touching disk.
@@ -64,6 +68,15 @@ func StartCounting() { emit.StartCounting() }
 
 // StopCounting returns the count of files written since StartCounting.
 func StopCounting() int { return emit.StopCounting() }
+
+// StartDetailedRecording begins collecting per-file write results alongside
+// real writes. Determines each file's action (create/update/skip) by
+// comparing new content against the existing file before writing.
+func StartDetailedRecording() { emit.StartDetailedRecording() }
+
+// StopDetailedRecording returns the collected write records and disables
+// detailed recording mode.
+func StopDetailedRecording() []WrittenFile { return emit.StopDetailedRecording() }
 
 // WriteFile writes content to path through the shared emit layer,
 // honoring the current capture, recording, and backup modes.

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -26,6 +26,15 @@ type CapturedFile struct {
 	Content string
 }
 
+// WrittenFile is one write event recorded during detailed recording mode.
+// Action is "create" (new file), "update" (existing file with changed
+// content), or "skip" (existing file with identical content, not rewritten).
+type WrittenFile struct {
+	Path   string
+	Bytes  int
+	Action string
+}
+
 // state holds the package-global mode flags. Adapters and the CLI mutate
 // state through SetBackup, StartCapture, StopCapture, and StartRecording;
 // every read in WriteFile takes the same mutex so go test -race stays
@@ -39,6 +48,8 @@ var state struct {
 	recorded  []string
 	counting  bool
 	counted   int
+	detailing bool
+	detailed  []WrittenFile
 }
 
 // SetBackup toggles backup mode. When enabled, WriteFile copies an
@@ -111,16 +122,43 @@ func StopCounting() int {
 	return n
 }
 
+// StartDetailedRecording begins collecting per-file write results alongside
+// real writes. Unlike capture mode this does not suppress IO. Unlike counting
+// and recording modes it also determines the action ("create", "update", or
+// "skip") by comparing the new content against what is on disk before writing.
+// Files whose content is unchanged are not rewritten and are recorded with
+// action "skip".
+func StartDetailedRecording() {
+	state.mu.Lock()
+	state.detailing = true
+	state.detailed = nil
+	state.mu.Unlock()
+}
+
+// StopDetailedRecording returns the collected write records and disables
+// detailed recording mode.
+func StopDetailedRecording() []WrittenFile {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.detailing = false
+	out := state.detailed
+	state.detailed = nil
+	return out
+}
+
 // WriteFile creates parent directories as needed and writes content to path.
 // When dryRun is true the file is not written; the path and content are
 // printed to stdout instead. When capture mode is active, the call is
 // recorded and no IO occurs. When recording mode is active, the path is
-// appended to the recorder.
+// appended to the recorder. When detailed recording mode is active, the
+// action (create/update/skip) is determined by comparing against existing
+// content; unchanged files are skipped and not rewritten.
 func WriteFile(path, content string, dryRun bool) error {
 	state.mu.Lock()
 	capturing := state.capturing
 	backup := state.backup
 	recording := state.recording
+	detailing := state.detailing
 	if capturing {
 		state.captured = append(state.captured, CapturedFile{Path: path, Content: content})
 	}
@@ -142,6 +180,37 @@ func WriteFile(path, content string, dryRun bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}
+
+	// Detailed recording: inspect existing content to classify the action.
+	if detailing {
+		existing, err := os.ReadFile(path)
+		var action string
+		switch {
+		case os.IsNotExist(err):
+			action = "create"
+		case err == nil && string(existing) == content:
+			// File is already up to date; skip the write.
+			state.mu.Lock()
+			state.detailed = append(state.detailed, WrittenFile{Path: path, Bytes: len(content), Action: "skip"})
+			state.mu.Unlock()
+			return nil
+		default:
+			action = "update"
+		}
+		if backup && action == "update" {
+			if err := os.WriteFile(path+".bak", existing, filePerm); err != nil {
+				return fmt.Errorf("backup %s: %w", path, err)
+			}
+		}
+		if err := os.WriteFile(path, []byte(content), filePerm); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+		state.mu.Lock()
+		state.detailed = append(state.detailed, WrittenFile{Path: path, Bytes: len(content), Action: action})
+		state.mu.Unlock()
+		return nil
+	}
+
 	if backup {
 		if existing, err := os.ReadFile(path); err == nil && string(existing) != content {
 			if err := os.WriteFile(path+".bak", existing, filePerm); err != nil {

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -87,7 +87,7 @@ func printDrift(reports []driftReport) bool {
 
 func newDoctorCmd() *cobra.Command {
 	var targets []string
-	var fix, backup bool
+	var fix, backup, jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Diagnose drift between specs and emitted target files.",
@@ -101,11 +101,17 @@ func newDoctorCmd() *cobra.Command {
   agnostic-ai doctor
 
   # Reconcile drift in place, keeping a .bak of each hand-edited file
-  agnostic-ai doctor --fix --backup`,
+  agnostic-ai doctor --fix --backup
+
+  # Machine-readable drift report for CI dashboards
+  agnostic-ai doctor --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reports, err := collectDrift(targets)
 			if err != nil {
 				return err
+			}
+			if jsonOut {
+				return printDoctorJSON(cmd, reports)
 			}
 			if !printDrift(reports) {
 				return nil
@@ -124,8 +130,42 @@ func newDoctorCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&targets, "target", "t", nil, "Targets to check (default: all in config)")
 	cmd.Flags().BoolVar(&fix, "fix", false, "Reconcile drift by writing missing/stale files")
 	cmd.Flags().BoolVar(&backup, "backup", false, "With --fix, copy each existing file to <path>.bak before overwriting")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for machine consumption")
 	registerTargetCompletion(cmd)
 	return cmd
+}
+
+// printDoctorJSON emits a JSON drift report for `doctor`. Mirrors the schema
+// used by `sync --check --json`: missing/stale files appear in writes,
+// up-to-date files appear in skipped.
+func printDoctorJSON(cmd *cobra.Command, reports []driftReport) error {
+	out := jsonOutput{Version: "1", Command: "doctor"}
+	for _, r := range reports {
+		for _, f := range r.Missing {
+			out.Writes = append(out.Writes, fileRecord{
+				Target: r.Target,
+				Path:   f.Path,
+				Action: "missing",
+				Bytes:  len(f.Content),
+			})
+		}
+		for _, f := range r.Stale {
+			out.Writes = append(out.Writes, fileRecord{
+				Target: r.Target,
+				Path:   f.Path,
+				Action: "stale",
+				Bytes:  len(f.Content),
+			})
+		}
+	}
+	hasDrift := len(out.Writes) > 0
+	if err := emitJSON(cmd, out); err != nil {
+		return err
+	}
+	if hasDrift {
+		return fmt.Errorf("drift detected")
+	}
+	return nil
 }
 
 // fixDrift writes the captured content for every missing or stale file in

--- a/internal/cli/json_output.go
+++ b/internal/cli/json_output.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+)
+
+// fileRecord is one entry in a JSON command output's writes or skipped list.
+type fileRecord struct {
+	Target string `json:"target"`
+	Path   string `json:"path"`
+	Action string `json:"action"`
+	Bytes  int    `json:"bytes"`
+}
+
+// errorRecord reports a per-target error in a JSON command output.
+type errorRecord struct {
+	Target  string `json:"target"`
+	Message string `json:"message"`
+}
+
+// jsonOutput is the stable schema emitted by --json on sync, revert, and
+// doctor. The version field is bumped on any breaking change.
+type jsonOutput struct {
+	Version string        `json:"version"`
+	Command string        `json:"command"`
+	Writes  []fileRecord  `json:"writes"`
+	Skipped []fileRecord  `json:"skipped"`
+	Errors  []errorRecord `json:"errors"`
+}
+
+func emitJSON(cmd *cobra.Command, out jsonOutput) error {
+	if out.Writes == nil {
+		out.Writes = []fileRecord{}
+	}
+	if out.Skipped == nil {
+		out.Skipped = []fileRecord{}
+	}
+	if out.Errors == nil {
+		out.Errors = []errorRecord{}
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}

--- a/internal/cli/json_output_test.go
+++ b/internal/cli/json_output_test.go
@@ -1,0 +1,317 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// assertJSONShape verifies the top-level fields expected in every --json output.
+func assertJSONShape(t *testing.T, out *bytes.Buffer) map[string]any {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out.String())
+	}
+	for _, field := range []string{"version", "command", "writes", "skipped", "errors"} {
+		if _, ok := result[field]; !ok {
+			t.Errorf("JSON missing field %q; got: %s", field, out.String())
+		}
+	}
+	if v, _ := result["version"].(string); v != "1" {
+		t.Errorf("expected version=1, got %q", v)
+	}
+	return result
+}
+
+func TestSyncJSON_Shape(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync --json failed: %v", err)
+	}
+
+	result := assertJSONShape(t, out)
+	if cmd, _ := result["command"].(string); cmd != "sync" {
+		t.Errorf("expected command=sync, got %q", cmd)
+	}
+
+	writes, _ := result["writes"].([]any)
+	if len(writes) == 0 {
+		t.Fatal("expected at least one write record")
+	}
+	rec, _ := writes[0].(map[string]any)
+	for _, field := range []string{"target", "path", "action", "bytes"} {
+		if _, ok := rec[field]; !ok {
+			t.Errorf("write record missing field %q; got: %v", field, rec)
+		}
+	}
+	if target, _ := rec["target"].(string); target != "claude" {
+		t.Errorf("expected target=claude, got %q", target)
+	}
+}
+
+func TestSyncJSON_SkipUnchanged(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	// First sync: creates the file.
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--json"})
+	root.SetOut(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second sync: file is unchanged, should be skipped.
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("second sync --json failed: %v", err)
+	}
+
+	result := assertJSONShape(t, out)
+	writes, _ := result["writes"].([]any)
+	skipped, _ := result["skipped"].([]any)
+	if len(writes) != 0 {
+		t.Errorf("expected 0 writes on second sync, got %d", len(writes))
+	}
+	if len(skipped) == 0 {
+		t.Error("expected at least one skipped record on second sync")
+	}
+}
+
+func TestSyncJSON_Actions(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	// First sync: all files should be "create".
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	result := assertJSONShape(t, out)
+	writes, _ := result["writes"].([]any)
+	for _, w := range writes {
+		rec := w.(map[string]any)
+		if action, _ := rec["action"].(string); action != "create" {
+			t.Errorf("expected action=create on first sync, got %q for %v", action, rec["path"])
+		}
+	}
+
+	// Modify the file, then sync again: should be "update".
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("hand-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--json"})
+	out = &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	result = assertJSONShape(t, out)
+	writes, _ = result["writes"].([]any)
+	found := false
+	for _, w := range writes {
+		rec := w.(map[string]any)
+		path, _ := rec["path"].(string)
+		if filepath.Base(path) == "CLAUDE.md" {
+			found = true
+			if action, _ := rec["action"].(string); action != "update" {
+				t.Errorf("expected action=update for CLAUDE.md, got %q", action)
+			}
+		}
+	}
+	if !found {
+		t.Error("CLAUDE.md not found in writes after modification")
+	}
+}
+
+func TestSyncCheckJSON_Shape(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	// Sync first so the check passes.
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--check", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync --check --json failed: %v", err)
+	}
+
+	result := assertJSONShape(t, out)
+	if cmd, _ := result["command"].(string); cmd != "sync --check" {
+		t.Errorf("expected command=sync --check, got %q", cmd)
+	}
+}
+
+func TestSyncCheckJSON_ReportsDrift(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--check", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	err := root.Execute()
+	// Should fail because files don't exist.
+	if err == nil {
+		t.Fatal("sync --check --json should fail when files are missing")
+	}
+
+	result := assertJSONShape(t, out)
+	writes, _ := result["writes"].([]any)
+	if len(writes) == 0 {
+		t.Error("expected drift entries in writes")
+	}
+	rec, _ := writes[0].(map[string]any)
+	if action, _ := rec["action"].(string); action != "missing" {
+		t.Errorf("expected action=missing for un-synced file, got %q", action)
+	}
+}
+
+func TestDoctorJSON_Shape(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"doctor", "-t", "claude", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("doctor --json failed: %v", err)
+	}
+
+	result := assertJSONShape(t, out)
+	if cmd, _ := result["command"].(string); cmd != "doctor" {
+		t.Errorf("expected command=doctor, got %q", cmd)
+	}
+}
+
+func TestDoctorJSON_ReportsDrift(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"doctor", "-t", "claude", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("doctor --json should fail when files are missing")
+	}
+
+	result := assertJSONShape(t, out)
+	writes, _ := result["writes"].([]any)
+	if len(writes) == 0 {
+		t.Error("expected drift entries in writes")
+	}
+}
+
+func TestRevertJSON_Shape(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"revert", "-t", "claude", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("revert --json failed: %v", err)
+	}
+
+	result := assertJSONShape(t, out)
+	if cmd, _ := result["command"].(string); cmd != "revert" {
+		t.Errorf("expected command=revert, got %q", cmd)
+	}
+	writes, _ := result["writes"].([]any)
+	if len(writes) == 0 {
+		t.Error("expected at least one write record in revert output")
+	}
+	rec, _ := writes[0].(map[string]any)
+	if action, _ := rec["action"].(string); action != "remove" {
+		t.Errorf("expected action=remove, got %q", action)
+	}
+}
+
+func TestSyncJSON_EmptyArraysWhenClean(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	// Pre-sync so second sync skips everything.
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// All three arrays must be present (not null) even when empty.
+	var result map[string]any
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"writes", "skipped", "errors"} {
+		v, ok := result[field]
+		if !ok {
+			t.Errorf("field %q missing", field)
+			continue
+		}
+		if v == nil {
+			t.Errorf("field %q is null, expected empty array", field)
+		}
+	}
+}

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -13,7 +13,7 @@ import (
 
 func newRevertCmd() *cobra.Command {
 	var targets, only, except []string
-	var dryRun bool
+	var dryRun, jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "revert",
@@ -34,7 +34,10 @@ func newRevertCmd() *cobra.Command {
   agnostic-ai revert --only claude,cursor
 
   # Revert everything except Codex
-  agnostic-ai revert --except codex`,
+  agnostic-ai revert --except codex
+
+  # Machine-readable output for CI dashboards and editor extensions
+  agnostic-ai revert --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(only) > 0 && len(except) > 0 {
 				return fmt.Errorf("--only and --except are mutually exclusive")
@@ -51,6 +54,11 @@ func newRevertCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			if jsonOut {
+				return runRevertJSON(cmd, effective, dryRun)
+			}
+
 			for _, t := range effective {
 				adapter, err := adapters.Resolve(t)
 				if err != nil {
@@ -68,7 +76,7 @@ func newRevertCmd() *cobra.Command {
 				files := adapters.StopCapture()
 				summaryf("← revert %s\n", t)
 				for _, f := range files {
-					if err := revertOne(f.Path, dryRun); err != nil {
+					if _, err := revertOne(f.Path, dryRun); err != nil {
 						return fmt.Errorf("%s: %w", t, err)
 					}
 				}
@@ -80,40 +88,84 @@ func newRevertCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&only, "only", nil, "Revert only these targets (comma-separated); mutually exclusive with --except")
 	cmd.Flags().StringSliceVar(&except, "except", nil, "Revert all configured targets except these (comma-separated); mutually exclusive with --only")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report intended actions without touching disk")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for machine consumption")
 	registerTargetCompletion(cmd)
 	return cmd
 }
 
 // revertOne restores path from path+".bak" if the backup exists, else
 // removes path. Missing files at either location are ignored.
-func revertOne(path string, dryRun bool) error {
+// Returns the action taken: "restore", "remove", or "skip" (file absent).
+func revertOne(path string, dryRun bool) (string, error) {
 	bak := path + ".bak"
 	data, err := os.ReadFile(bak)
 	switch {
 	case err == nil:
 		if dryRun {
 			verbosef("    restore: %s ← %s\n", path, bak)
-			return nil
+			return "restore", nil
 		}
 		if err := os.WriteFile(path, data, 0o644); err != nil {
-			return fmt.Errorf("restore %s: %w", path, err)
+			return "", fmt.Errorf("restore %s: %w", path, err)
 		}
 		if err := os.Remove(bak); err != nil {
-			return fmt.Errorf("remove %s: %w", bak, err)
+			return "", fmt.Errorf("remove %s: %w", bak, err)
 		}
 		verbosef("    restored: %s\n", path)
-		return nil
+		return "restore", nil
 	case !errors.Is(err, fs.ErrNotExist):
-		return fmt.Errorf("read backup %s: %w", bak, err)
+		return "", fmt.Errorf("read backup %s: %w", bak, err)
 	}
 
 	if dryRun {
 		verbosef("    remove:  %s\n", path)
-		return nil
+		return "remove", nil
 	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("remove %s: %w", path, err)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "skip", nil
+		}
+		return "", fmt.Errorf("remove %s: %w", path, err)
 	}
 	verbosef("    removed:  %s\n", path)
-	return nil
+	return "remove", nil
+}
+
+// runRevertJSON performs the revert and emits a JSON result describing each
+// file restored, removed, or skipped per target.
+func runRevertJSON(cmd *cobra.Command, targets []string, dryRun bool) error {
+	cfg, b, err := loadProject(".")
+	if err != nil {
+		return err
+	}
+
+	out := jsonOutput{Version: "1", Command: "revert"}
+	for _, t := range targets {
+		adapter, err := adapters.Resolve(t)
+		if err != nil {
+			out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
+			continue
+		}
+		adapters.StartCapture()
+		if err := adapter.Emit(b, cfg, true); err != nil {
+			adapters.StopCapture()
+			out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
+			continue
+		}
+		files := adapters.StopCapture()
+		for _, f := range files {
+			action, err := revertOne(f.Path, dryRun)
+			if err != nil {
+				out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
+				continue
+			}
+			rec := fileRecord{Target: t, Path: f.Path, Action: action, Bytes: 0}
+			if action == "skip" {
+				out.Skipped = append(out.Skipped, rec)
+			} else {
+				out.Writes = append(out.Writes, rec)
+			}
+		}
+	}
+	return emitJSON(cmd, out)
 }

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -19,7 +19,7 @@ func TestRevertOne_RestoresFromBak(t *testing.T) {
 	if err := os.WriteFile(path+".bak", []byte("original"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := revertOne(path, false); err != nil {
+	if _, err := revertOne(path, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(path)
@@ -42,7 +42,7 @@ func TestRevertOne_RemovesWhenNoBak(t *testing.T) {
 	if err := os.WriteFile(path, []byte("generated"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := revertOne(path, false); err != nil {
+	if _, err := revertOne(path, false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -58,7 +58,7 @@ func TestRevertOne_DryRunNoSideEffects(t *testing.T) {
 	if err := os.WriteFile(path, []byte("generated"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := revertOne(path, true); err != nil {
+	if _, err := revertOne(path, true); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(path); err != nil {
@@ -70,7 +70,7 @@ func TestRevertOne_MissingFileIsNoop(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)
 
-	if err := revertOne(filepath.Join(dir, "ghost.md"), false); err != nil {
+	if _, err := revertOne(filepath.Join(dir, "ghost.md"), false); err != nil {
 		t.Errorf("unexpected error reverting missing file: %v", err)
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -42,7 +42,7 @@ func writeStateFile(projectRoot string, filesChanged int) error {
 
 func newSyncCmd() *cobra.Command {
 	var targets, only, except []string
-	var dryRun, check, backup, watch bool
+	var dryRun, check, backup, watch, jsonOut bool
 	var gitignoreFlag, autoSyncFlag string
 
 	cmd := &cobra.Command{
@@ -64,7 +64,10 @@ func newSyncCmd() *cobra.Command {
   agnostic-ai sync --check
 
   # Back up each existing file to <path>.bak before overwriting
-  agnostic-ai sync --backup`,
+  agnostic-ai sync --backup
+
+  # Machine-readable output for CI dashboards and editor extensions
+  agnostic-ai sync --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateGitignoreFlag(gitignoreFlag); err != nil {
 				return err
@@ -94,6 +97,9 @@ func newSyncCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				if jsonOut {
+					return printSyncCheckJSON(cmd, reports)
+				}
 				if printDrift(reports) {
 					return fmt.Errorf("drift detected")
 				}
@@ -109,6 +115,9 @@ func newSyncCmd() *cobra.Command {
 				defer stop()
 				return watchSync(ctx, 200*time.Millisecond, ".", effective, dryRun, backup, gitignoreFlag)
 			}
+			if jsonOut {
+				return runSyncJSON(cmd, ".", effective, dryRun, backup, gitignoreFlag)
+			}
 			return runSyncOnce(".", effective, dryRun, backup, gitignoreFlag)
 		},
 	}
@@ -121,6 +130,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().StringVar(&gitignoreFlag, "gitignore", "", "Override config: 'on' or 'off' to manage the .gitignore block this run.")
 	cmd.Flags().BoolVar(&watch, "watch", false, "Re-emit on spec changes (Ctrl+C to exit)")
 	cmd.Flags().StringVar(&autoSyncFlag, "auto-sync", "", "Enable agent-managed auto-sync: 'yes' or 'no'")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for machine consumption")
 	registerTargetCompletion(cmd)
 	return cmd
 }
@@ -176,6 +186,95 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		if err := writeStateFile(root, filesChanged); err != nil {
 			fmt.Fprintf(os.Stderr, "! state file: %v\n", err)
 		}
+	}
+	return nil
+}
+
+// runSyncJSON runs a real sync pass and emits a JSON result describing each
+// file written, updated, or skipped per target.
+func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
+	cfg, b, err := loadProject(root)
+	if err != nil {
+		return err
+	}
+	effectiveTargets := targets
+	if len(effectiveTargets) == 0 {
+		effectiveTargets = cfg.Targets
+	}
+	if backup {
+		adapters.SetBackup(true)
+		defer adapters.SetBackup(false)
+	}
+	gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
+	if gitignoreOn {
+		adapters.StartRecording()
+	}
+
+	out := jsonOutput{Version: "1", Command: "sync"}
+	for _, t := range effectiveTargets {
+		adapter, err := adapters.Resolve(t)
+		if err != nil {
+			out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
+			continue
+		}
+		adapters.StartDetailedRecording()
+		if err := adapter.Emit(b, cfg, dryRun); err != nil {
+			adapters.StopDetailedRecording()
+			out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
+			continue
+		}
+		for _, f := range adapters.StopDetailedRecording() {
+			rec := fileRecord{Target: t, Path: f.Path, Action: f.Action, Bytes: f.Bytes}
+			if f.Action == "skip" {
+				out.Skipped = append(out.Skipped, rec)
+			} else {
+				out.Writes = append(out.Writes, rec)
+			}
+		}
+	}
+
+	if gitignoreOn {
+		if err := updateGitignore(cfg, normalizeAndSort(adapters.StopRecording())); err != nil {
+			return fmt.Errorf("gitignore: %w", err)
+		}
+	}
+	if !dryRun {
+		if err := writeStateFile(root, len(out.Writes)); err != nil {
+			fmt.Fprintf(os.Stderr, "! state file: %v\n", err)
+		}
+	}
+	return emitJSON(cmd, out)
+}
+
+// printSyncCheckJSON emits a JSON result for `sync --check`. Files that need
+// to be written appear in writes (action: "missing" or "stale"); files that
+// are already in sync appear in skipped (action: "ok").
+func printSyncCheckJSON(cmd *cobra.Command, reports []driftReport) error {
+	out := jsonOutput{Version: "1", Command: "sync --check"}
+	for _, r := range reports {
+		for _, f := range r.Missing {
+			out.Writes = append(out.Writes, fileRecord{
+				Target: r.Target,
+				Path:   f.Path,
+				Action: "missing",
+				Bytes:  len(f.Content),
+			})
+		}
+		for _, f := range r.Stale {
+			out.Writes = append(out.Writes, fileRecord{
+				Target: r.Target,
+				Path:   f.Path,
+				Action: "stale",
+				Bytes:  len(f.Content),
+			})
+		}
+	}
+	hasDrift := len(out.Writes) > 0
+	if err := emitJSON(cmd, out); err != nil {
+		return err
+	}
+	if hasDrift {
+		return fmt.Errorf("drift detected")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `agnostic-ai status` command: shows project name, layers, spec counts, configured targets, last sync timestamp, and drift count. Supports `--json` for machine-readable output. Exits 0 even when drifted (use `sync --check` for CI gating).
- Adds `--json` flag to `sync`, `sync --check`, `revert`, and `doctor` so CI dashboards and editor extensions can consume a stable JSON contract instead of scraping human output.

Closes #37.

## JSON schema (version 1)

```json
{
  "version": "1",
  "command": "sync",
  "writes": [
    {"target": "claude", "path": "CLAUDE.md", "action": "create", "bytes": 1284}
  ],
  "skipped": [
    {"target": "cursor", "path": ".cursor/rules/foo.mdc", "action": "skip", "bytes": 312}
  ],
  "errors": []
}
```

Actions by command:
- `sync --json`: `create`, `update`, `skip` (unchanged files are not rewritten)
- `sync --check --json` / `doctor --json`: `missing`, `stale`
- `revert --json`: `restore`, `remove`, `skip`

The schema is versioned at `"1"`; breaking changes will bump it.

## Implementation notes

A new `StartDetailedRecording`/`StopDetailedRecording` mode was added to the emit layer. When active, `WriteFile` reads the existing file before writing to classify each write as create/update/skip — without a second adapter pass. Unchanged files are skipped (not rewritten), which is a small efficiency win alongside JSON mode.

The sync state file (`files_changed`) counts only actual writes (not skips), consistent with prior behavior.

## Test plan

- [ ] `go test ./...` passes (9 new JSON shape tests added)
- [ ] `golangci-lint run` clean
- [ ] `agnostic-ai sync --json` emits valid JSON with correct actions on first and second run
- [ ] `agnostic-ai sync --check --json` reports missing/stale and exits non-zero
- [ ] `agnostic-ai revert --json` reports restore/remove
- [ ] `agnostic-ai doctor --json` mirrors `sync --check --json`
