### PR TITLE
docs: sync output filenames and config keys with adapter changes

### DIFF
--- a/docs/internal/adding-adapters.md
+++ b/docs/internal/adding-adapters.md
@@ -84,8 +84,33 @@ rather than hand-rolling per adapter:
 - `emit.OutputRulesDir(cfg, target, fallback)` for a rules-directory adapter
 - `emit.OutputRulesFile(cfg, target, fallback)` for the merged rules file
 - `emit.OutputMCPFile(cfg, target, fallback)` for MCP propagation
+- `emit.OutputAgentsDir(cfg, target, fallback)` for per-agent files
+- `emit.OutputSkillsDir(cfg, target, fallback)` for per-skill files / folders
+- `emit.OutputCommandsDir(cfg, target, fallback)` for slash-command directories
+- `emit.OutputInstructionsDir(cfg, target, fallback)` for Copilot-style scoped-rule directories
+- `emit.EmitSkillsAsCommands(cfg, target)` for the opt-in flag that emits skills as slash commands
 
 If a target needs a new field on `config.Output`, add it once and reuse.
+
+## Shared helpers for hierarchical / slash-command adapters
+
+- `emit.GroupRulesByScope(rules)` + `emit.RouteScope(r)` route rules to
+  `<scope>/AGENTS.md` / `<scope>/GEMINI.md` style hierarchies
+  (Codex, Gemini, Amp, Warp).
+- `emit.WriteSection(sb, heading, e)` renders an inlined `### heading`
+  block; `emit.WriteReference(sb, e, sourcePath)` renders a reference
+  pointer (no body) when the real definition lives in a separate file.
+- `emit.WriteTOMLString` / `WriteTOMLMultiline` / `WriteTOMLStringArray`
+  / `EscapeTOMLBasic` build TOML emission (Codex agents, Gemini commands).
+- `emit.Frontmatter(meta)` renders a YAML frontmatter block.
+- `emit.ResolveMeta(meta, target)` flattens the spec's `x-<target>`
+  namespace so adapters read the target's overrides as top-level keys.
+- `emit.MigrateLegacyFile(cfg, target, legacyName, defaultNewPath, dryRun)`
+  renames a previously generated file aside when the default output
+  name changes across releases. Honors capture mode and dry-run.
+- `emit.IsCapturing()` reports whether `sync --check` / `revert` is
+  observing emission; adapters with filesystem side-effects beyond
+  `WriteFile` should consult it before mutating the tree.
 
 ## 5. Add tests
 

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -41,9 +41,15 @@ spec.Bundle ──► adapter.Emit(bundle, config, dryRun) ──► files writt
                  ├─ claude:    .claude/, CLAUDE.md, .mcp.json
                  ├─ codex:     AGENTS.md (lists agents w/ pointers; nested per scope/globs),
                  │             .codex/agents/<name>.toml, .agents/skills/<name>/SKILL.md
+                 ├─ gemini:    GEMINI.md (hierarchical per scope), .gemini/commands/<name>.toml
                  ├─ cursor:    .cursor/rules/, .cursor/mcp.json
-                 ├─ copilot:   .github/..., .vscode/mcp.json
-                 ├─ amp/zed/warp/opencode: AGENT.md / .rules / WARP.md / .opencode/AGENTS.md
+                 ├─ copilot:   .github/copilot-instructions.md (always-on),
+                 │             .github/instructions/<name>.instructions.md (applyTo-scoped),
+                 │             .vscode/mcp.json
+                 ├─ amp:       AGENTS.md (hierarchical), .agents/commands/<name>.md
+                 ├─ warp:      AGENTS.md (hierarchical; agents inlined, skills referenced)
+                 ├─ opencode:  .opencode/AGENTS.md, .opencode/commands/<name>.md
+                 ├─ zed:       .rules
                  └─ ...
 ```
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -56,7 +56,8 @@ outputs:
   cursor:
     rules-dir: .cursor/rules   # default
   copilot:
-    file: .github/copilot-instructions.md  # default
+    file: .github/copilot-instructions.md  # default. Always-on rules.
+    instructions-dir: .github/instructions # default. One .instructions.md per scoped rule, agent, skill.
   aider:
     file: CONVENTIONS.md       # default
   cline:
@@ -66,13 +67,17 @@ outputs:
   continue:
     rules-dir: .continue/rules # default
   amp:
-    file: AGENT.md             # default
+    file: AGENTS.md            # default. Hierarchical per scope; was AGENT.md.
+    commands-dir: .agents/commands # default. One .md per agent (and per skill when opted in).
   zed:
     file: .rules               # default
   warp:
-    file: WARP.md              # default
+    file: AGENTS.md            # default. Hierarchical per scope; was WARP.md.
   opencode:
     file: .opencode/AGENTS.md  # default. Routed under .opencode/ to coexist with Codex.
+    commands-dir: .opencode/commands # default. One .md per agent (and per skill when opted in).
+  gemini:
+    commands-dir: .gemini/commands # default. One .toml per agent (and per skill when opted in).
 
 # What to do when a spec kind is unsupported by a target
 # (e.g. hooks for any target other than claude).
@@ -127,17 +132,24 @@ Per-target paths. Each target reads only the fields it understands; irrelevant f
 | `codex` | `file` | `AGENTS.md` | Rules document; nested `<dir>/AGENTS.md` files share this base. Lists agents and skills with pointers to their per-target files. |
 | `codex` | `agents-dir` | `.codex/agents` | One TOML file per agent (Codex subagent schema). |
 | `codex` | `skills-dir` | `.agents/skills` | One folder per skill (`<name>/SKILL.md`, optional `<name>/agents/openai.yaml`) per the Codex skills layout. |
-| `gemini` | `file` | `GEMINI.md` | Single merged document. |
+| `gemini` | `file` | `GEMINI.md` | Root rules + agent/skill references. Hierarchical: nested `<scope>/GEMINI.md` files share this base. |
+| `gemini` | `commands-dir` | `.gemini/commands` | One TOML per agent (one per skill when `emit-skills-as-commands: true`). |
+| `gemini` | `emit-skills-as-commands` | `false` | When true, skills also emit as `.gemini/commands/skill-<name>.toml`. |
 | `cursor` | `rules-dir` | `.cursor/rules` | One `.mdc` per rule and per agent. |
-| `copilot` | `file` | `.github/copilot-instructions.md` | Single merged document. |
+| `copilot` | `file` | `.github/copilot-instructions.md` | Always-on rules (`alwaysApply: true` or no scope). |
+| `copilot` | `instructions-dir` | `.github/instructions` | One `.instructions.md` per scoped rule, agent, skill. `applyTo:` frontmatter derived from `globs` or scope. |
 | `aider` | `file` | `CONVENTIONS.md` | Single merged document. |
 | `cline` | `rules-dir` | `.clinerules` | One `.md` per rule and per agent. |
 | `windsurf` | `rules-dir` | `.windsurf/rules` | One `.md` per rule and per agent. |
 | `continue` | `rules-dir` | `.continue/rules` | One `.md` per rule and per agent. |
-| `amp` | `file` | `AGENT.md` | Single merged document. |
+| `amp` | `file` | `AGENTS.md` | Root rules + agent/skill references. Hierarchical: nested `<scope>/AGENTS.md` files share this base. Renamed from `AGENT.md`; legacy file migrated to `AGENT.md.bak` on first sync. |
+| `amp` | `commands-dir` | `.agents/commands` | One `.md` per agent (one per skill when `emit-skills-as-commands: true`). |
+| `amp` | `emit-skills-as-commands` | `false` | When true, skills also emit as `.agents/commands/skill-<name>.md`. |
 | `zed` | `file` | `.rules` | Single merged document. |
-| `warp` | `file` | `WARP.md` | Single merged document. |
-| `opencode` | `file` | `.opencode/AGENTS.md` | Single merged document; routed under `.opencode/` to coexist with Codex. |
+| `warp` | `file` | `AGENTS.md` | Hierarchical: nested `<scope>/AGENTS.md` files share this base. Renamed from `WARP.md`; legacy file migrated to `WARP.md.bak` on first sync. |
+| `opencode` | `file` | `.opencode/AGENTS.md` | Rules + agent/skill references; routed under `.opencode/` to coexist with Codex. |
+| `opencode` | `commands-dir` | `.opencode/commands` | One `.md` per agent (one per skill when `emit-skills-as-commands: true`). Frontmatter filtered to `description`, `agent`, `model`, `subtask`. |
+| `opencode` | `emit-skills-as-commands` | `false` | When true, skills also emit as `.opencode/commands/skill-<name>.md`. |
 
 ## `targets`
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -119,15 +119,17 @@ are written; empty stubs are skipped):
 ├── rules/
 │   └── conventional-commits.md
 ├── CLAUDE.md                                    # for Claude Code
-├── AGENT.md                                     # for Amp
-├── AGENTS.md                                    # for Codex
+├── AGENTS.md                                    # for Codex / Amp / Warp (shared open standard)
 ├── .codex/agents/<name>.toml                    # for Codex subagents
+├── .agents/commands/<name>.md                   # for Amp slash commands
 ├── GEMINI.md                                    # for Gemini CLI
-├── WARP.md                                      # for Warp
+├── .gemini/commands/<name>.toml                 # for Gemini CLI slash commands
 ├── CONVENTIONS.md                               # for Aider
 ├── .rules                                       # for Zed
 ├── .opencode/AGENTS.md                          # for OpenCode
-├── .github/copilot-instructions.md              # for Copilot
+├── .opencode/commands/<name>.md                 # for OpenCode slash commands
+├── .github/copilot-instructions.md              # for Copilot (always-on rules)
+├── .github/instructions/<name>.instructions.md  # for Copilot path-scoped rules + agents + skills
 ├── .cursor/rules/conventional-commits.mdc       # for Cursor
 ├── .clinerules/conventional-commits.md          # for Cline
 ├── .windsurf/rules/conventional-commits.md      # for Windsurf


### PR DESCRIPTION
## Summary

Sweep-up for the multi-file emission series (#69-#74). Several docs still referenced the previous adapter behavior (`AGENT.md`, `WARP.md`, "single merged document" for adapters that are no longer merged-single). Updates:

- **docs/user/getting-started.md**: replace `AGENT.md` / `WARP.md` from the example tree with `AGENTS.md` (Codex / Amp / Warp share the open standard) and add the new per-agent dirs (`.agents/commands`, `.gemini/commands`, `.opencode/commands`, `.github/instructions`).
- **docs/user/configuration.md**: amp default file is now `AGENTS.md` (was `AGENT.md`), warp is `AGENTS.md` (was `WARP.md`). Add `commands-dir`, `instructions-dir`, `emit-skills-as-commands` rows to the outputs table and the example config. Replace "Single merged document" descriptions for amp / warp / copilot / gemini / opencode with the actual hierarchical / per-file behavior.
- **docs/internal/architecture.md**: refresh the per-adapter output list with the new layouts; promote gemini and the three slash-command adapters (amp, opencode) onto their own rows.
- **docs/internal/adding-adapters.md**: extend the emit-helpers list with the new resolvers and document the hierarchical / slash-command shared helpers (`GroupRulesByScope`, `RouteScope`, `WriteSection` vs `WriteReference`, `WriteTOML*`, `Frontmatter`, `ResolveMeta`, `MigrateLegacyFile`, `IsCapturing`).

No code changes.

## Test plan

- [x] `grep -r "AGENT\.md\|WARP\.md"` across `*.md` returns only intentional migration / CHANGELOG mentions.
- [x] `grep -r "merged in\|Single merged"` only matches aider / zed, which legitimately stay merged.
- [x] `go test -race ./...` still green (no code touched).
- [ ] CI green.