### PR TITLE
chore: bump Go toolchain to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
 
       - name: Vet
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
 
       - name: golangci-lint
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
 
       - name: Build
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
 
       - name: Regenerate schema

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chemaclass/agnostic-ai
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/charmbracelet/huh v1.0.0


### PR DESCRIPTION
## Summary

Unblocks dependabot PRs #62 (`invopop/jsonschema` 0.14) and #63 (`charmbracelet/x/term` 0.2.2). Both fail CI because their `go.mod` files now require Go 1.24 and our matrix runs 1.23 with `GOTOOLCHAIN=local`.

- `go.mod`: `go 1.23.0` → `go 1.24.0`
- `.github/workflows/ci.yml`: `go-version: '1.23'` → `'1.24'` across all five jobs (test matrix ×3, lint, build, schema-drift)

Go 1.24 has been GA for over a year. Nothing in this repo uses APIs that broke across the upgrade.

After this lands, dependabot will rebase #62 and #63 onto a green main; both should then merge cleanly.

## Test plan

- [x] `go test -race ./...` green locally on Go 1.26 (covers ≥1.24).
- [x] `go vet ./...` and `gofmt -l .` clean.
- [x] `go mod tidy` produced no `go.sum` churn (current deps still satisfied).
- [ ] CI green on Go 1.24.