### PR TITLE
perf(watch): use fsnotify with poll fallback and --watch-poll flag

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -141,7 +141,8 @@ agnostic-ai sync [flags]
 | `--check` | Compare emitted output to disk; exit non-zero on drift. Writes nothing. |
 | `--backup` | Copy each existing target file to `<path>.bak` before overwriting. Pair with `revert` to restore. |
 | `--gitignore <on\|off>` | Override `gitignore.enabled` for this run. |
-| `--watch` | Keep the process alive and re-emit on spec or config changes (200 ms poll). Ctrl+C exits cleanly. Incompatible with `--check`. |
+| `--watch` | Keep the process alive and re-emit on spec or config changes. Uses OS file events (fsnotify) with a 50 ms debounce; falls back to a 200 ms poll on filesystems where fsnotify fails. Ctrl+C exits cleanly. Incompatible with `--check`. |
+| `--watch-poll` | Force the polling backend (200 ms) even when fsnotify is available. Use on network mounts or container volumes where fsnotify misses events. Requires `--watch`. |
 | `--auto-sync <yes\|no>` | Persist an answer to the first-run auto-sync prompt. Writes an `auto-sync` rule spec instructing agents to run `agnostic-ai sync` when specs change. Persists `autoSync: true/false` to `agnostic.config.yaml`. Skipped under `--dry-run`. Without the flag, on a TTY, `sync` prompts once. |
 | `--all` | Emit every configured target without running the first-sync target picker. Useful for ad-hoc full emission or scripted runs that should bypass interactive prompts. |
 | `--json` | Output as JSON instead of plain text. Stable schema; breaking changes bump `version`. |

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -172,9 +172,12 @@ Skip the manual `sync` after every spec edit:
 agnostic-ai sync --watch
 ```
 
-Polls every 200 ms for changes under the source directories or
-`agnostic.config.yaml` and re-emits affected targets. Ctrl+C exits
-cleanly. Incompatible with `--check`.
+Watches the source directories and `agnostic.config.yaml` via OS file
+events (fsnotify) with a 50 ms debounce, so saves trigger a re-sync in
+under 100 ms. On filesystems where fsnotify fails (some network mounts,
+specific container volumes), `sync` falls back to a 200 ms poll. Force
+the poll backend with `--watch-poll`. Ctrl+C exits cleanly. Incompatible
+with `--check`.
 
 ## Auto-sync rule
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/x/term v0.2.2
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/invopop/jsonschema v0.14.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -42,7 +42,7 @@ func writeStateFile(projectRoot string, filesChanged int) error {
 
 func newSyncCmd() *cobra.Command {
 	var targets, only, except []string
-	var dryRun, check, backup, watch, jsonOut, allTargets bool
+	var dryRun, check, backup, watch, watchPoll, jsonOut, allTargets bool
 	var gitignoreFlag, autoSyncFlag string
 
 	cmd := &cobra.Command{
@@ -121,10 +121,13 @@ func newSyncCmd() *cobra.Command {
 					return err
 				}
 			}
+			if watchPoll && !watch {
+				return fmt.Errorf("--watch-poll requires --watch")
+			}
 			if watch {
 				ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 				defer stop()
-				return watchSync(ctx, 200*time.Millisecond, ".", effective, dryRun, backup, gitignoreFlag)
+				return watchSync(ctx, 200*time.Millisecond, ".", effective, dryRun, backup, gitignoreFlag, watchPoll)
 			}
 			if jsonOut {
 				return runSyncJSON(cmd, ".", effective, dryRun, backup, gitignoreFlag)
@@ -140,6 +143,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&backup, "backup", false, "Copy each existing target file to <path>.bak before overwriting")
 	cmd.Flags().StringVar(&gitignoreFlag, "gitignore", "", "Override config: 'on' or 'off' to manage the .gitignore block this run.")
 	cmd.Flags().BoolVar(&watch, "watch", false, "Re-emit on spec changes (Ctrl+C to exit)")
+	cmd.Flags().BoolVar(&watchPoll, "watch-poll", false, "Force polling instead of fsnotify (use on filesystems where fsnotify is unreliable, e.g. some network mounts)")
 	cmd.Flags().StringVar(&autoSyncFlag, "auto-sync", "", "Enable agent-managed auto-sync: 'yes' or 'no'")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for machine consumption")
 	cmd.Flags().BoolVar(&allTargets, "all", false, "Sync every configured target without prompting (skip the first-sync target picker)")

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -46,7 +46,7 @@ func watchSyncFsnotify(ctx context.Context, root string, targets []string, dryRu
 	if err != nil {
 		return err
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	if err := addWatchPaths(w, watchDirs(root, cfg)); err != nil {
 		return err

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -8,16 +8,112 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+
 	"github.com/chemaclass/agnostic-ai/internal/config"
 )
 
-// watchSync runs an initial sync then re-runs whenever a watched path changes.
-// Polls every interval; Ctrl-C (or ctx cancellation) exits cleanly.
-func watchSync(ctx context.Context, interval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
+// debounceWindow coalesces editor save flurries (write-then-truncate,
+// rename-into-place, multi-file save) into a single re-sync.
+const debounceWindow = 50 * time.Millisecond
+
+// watchSync runs an initial sync, then re-runs whenever a watched path
+// changes. When forcePoll is false it tries fsnotify and falls back to
+// polling if the watcher cannot be created.
+func watchSync(ctx context.Context, pollInterval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string, forcePoll bool) error {
 	if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
 		return err
 	}
+	if !forcePoll {
+		err := watchSyncFsnotify(ctx, root, targets, dryRun, backup, gitignoreFlag)
+		if err == nil || ctx.Err() != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "! fsnotify unavailable (%v); falling back to polling\n", err)
+	}
+	return watchSyncPoll(ctx, pollInterval, root, targets, dryRun, backup, gitignoreFlag)
+}
 
+// watchSyncFsnotify watches via OS file events. Returns the first
+// unrecoverable setup error so the caller can fall back to polling.
+// Per-event errors during the loop are logged and the loop continues.
+func watchSyncFsnotify(ctx context.Context, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
+	cfg, err := config.Load(root)
+	if err != nil {
+		return err
+	}
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	if err := addWatchPaths(w, watchDirs(root, cfg)); err != nil {
+		return err
+	}
+
+	summaryf("→ watching for changes (Ctrl+C to exit)\n")
+
+	var (
+		debounce *time.Timer
+		fire     = make(chan struct{}, 1)
+	)
+	defer func() {
+		if debounce != nil {
+			debounce.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-w.Events:
+			if !ok {
+				return nil
+			}
+			if isIgnoredEvent(ev) {
+				continue
+			}
+			// New directory under a watched root: add it so children
+			// emit events too. fsnotify is not recursive on its own.
+			if ev.Op&fsnotify.Create != 0 {
+				if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
+					_ = addWatchPaths(w, []string{ev.Name})
+				}
+			}
+			if debounce == nil {
+				debounce = time.AfterFunc(debounceWindow, func() {
+					select {
+					case fire <- struct{}{}:
+					default:
+					}
+				})
+			} else {
+				debounce.Reset(debounceWindow)
+			}
+		case err, ok := <-w.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "! watch: %v\n", err)
+		case <-fire:
+			summaryf("→ change detected, re-syncing\n")
+			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
+				fmt.Fprintf(os.Stderr, "! sync: %v\n", err)
+			}
+			// Pick up source roots that may have appeared (e.g. a
+			// hooks/ dir created mid-session) by re-reading config.
+			if newCfg, err := config.Load(root); err == nil {
+				_ = addWatchPaths(w, watchDirs(root, newCfg))
+			}
+		}
+	}
+}
+
+// watchSyncPoll is the original mtime-poll loop. Used as a fallback
+// when fsnotify fails (e.g. some network mounts) or with --watch-poll.
+func watchSyncPoll(ctx context.Context, interval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
 	cfg, err := config.Load(root)
 	if err != nil {
 		return err
@@ -50,6 +146,65 @@ func watchSync(ctx context.Context, interval time.Duration, root string, targets
 			}
 		}
 	}
+}
+
+// addWatchPaths registers a file or directory and (for directories) every
+// nested subdirectory with the watcher. Already-watched paths are
+// silently skipped. Missing paths are skipped without error so callers
+// can pass speculative roots.
+func addWatchPaths(w *fsnotify.Watcher, paths []string) error {
+	existing := make(map[string]struct{}, len(w.WatchList()))
+	for _, p := range w.WatchList() {
+		existing[p] = struct{}{}
+	}
+	add := func(p string) error {
+		if _, ok := existing[p]; ok {
+			return nil
+		}
+		if err := w.Add(p); err != nil {
+			return fmt.Errorf("watch %s: %w", p, err)
+		}
+		existing[p] = struct{}{}
+		return nil
+	}
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			if err := add(p); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := add(p); err != nil {
+			return err
+		}
+		walkErr := filepath.WalkDir(p, func(sub string, d fs.DirEntry, err error) error {
+			if err != nil || !d.IsDir() || sub == p {
+				return nil
+			}
+			return add(sub)
+		})
+		if walkErr != nil {
+			return walkErr
+		}
+	}
+	return nil
+}
+
+// isIgnoredEvent filters out events that should never trigger a re-sync:
+// chmod-only events (editor "touch" on save) and writes to the .sync-state
+// file we own.
+func isIgnoredEvent(ev fsnotify.Event) bool {
+	if ev.Op == fsnotify.Chmod {
+		return true
+	}
+	if filepath.Base(ev.Name) == ".sync-state" {
+		return true
+	}
+	return false
 }
 
 // watchDirs returns the config file and source directories to watch.

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
@@ -71,7 +73,7 @@ func TestWatchSync_ReEmitsOnChange(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- watchSync(ctx, 10*time.Millisecond, ".", []string{"claude"}, false, false, "off")
+		done <- watchSync(ctx, 10*time.Millisecond, ".", []string{"claude"}, false, false, "off", false)
 	}()
 
 	// Wait for initial sync.
@@ -127,5 +129,85 @@ func TestWatchSync_CheckAndWatchIncompatible(t *testing.T) {
 	err := root.Execute()
 	if err == nil {
 		t.Fatal("expected error for --watch --check combination")
+	}
+}
+
+func TestWatchSync_WatchPollWithoutWatch(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--watch-poll"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when --watch-poll is used without --watch")
+	}
+}
+
+func TestWatchSync_PollFallback(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		// forcePoll = true exercises the polling backend explicitly.
+		done <- watchSync(ctx, 20*time.Millisecond, ".", []string{"claude"}, false, false, "off", true)
+	}()
+
+	time.Sleep(80 * time.Millisecond)
+
+	claudeMD := filepath.Join(dir, "CLAUDE.md")
+	if _, err := os.Stat(claudeMD); err != nil {
+		t.Fatal("initial sync did not produce CLAUDE.md")
+	}
+	if err := os.Remove(claudeMD); err != nil {
+		t.Fatal(err)
+	}
+
+	specPath := filepath.Join(dir, "rules", "r1.md")
+	content, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(15 * time.Millisecond)
+	if err := os.WriteFile(specPath, append(content, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(claudeMD); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := os.Stat(claudeMD); err != nil {
+		t.Error("polling watch did not re-emit CLAUDE.md after spec change")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsIgnoredEvent_Chmod(t *testing.T) {
+	if !isIgnoredEvent(fsnotify.Event{Name: "x", Op: fsnotify.Chmod}) {
+		t.Error("chmod-only events must be ignored")
+	}
+	if isIgnoredEvent(fsnotify.Event{Name: "x", Op: fsnotify.Write}) {
+		t.Error("write events must not be ignored")
+	}
+}
+
+func TestIsIgnoredEvent_SyncStateFile(t *testing.T) {
+	ev := fsnotify.Event{Name: filepath.Join("anywhere", ".sync-state"), Op: fsnotify.Write}
+	if !isIgnoredEvent(ev) {
+		t.Error(".sync-state writes must be ignored to avoid feedback loops")
 	}
 }


### PR DESCRIPTION
## Summary

- `sync --watch` now uses [fsnotify](https://github.com/fsnotify/fsnotify) for OS-level file events with a 50 ms debounce, replacing the 200 ms mtime poll loop.
- Polling backend kept as an automatic fallback when `fsnotify.NewWatcher` or `Add` fails (network mounts, some container volumes).
- New `--watch-poll` flag forces the polling backend (errors out if used without `--watch`).
- New directories created mid-session are auto-added to the watcher (fsnotify is not recursive).
- Filters chmod-only events and writes to `.sync-state` to avoid feedback loops.
- Docs updated in `cli-reference.md` and `getting-started.md`.

Closes #36

## Test plan

- [x] `go test -race ./...` green (all 13 adapters + cli + integration).
- [x] New tests: `TestWatchSync_PollFallback`, `TestWatchSync_WatchPollWithoutWatch`, `TestIsIgnoredEvent_Chmod`, `TestIsIgnoredEvent_SyncStateFile`. Existing `TestWatchSync_ReEmitsOnChange` still passes via the fsnotify path.
- [ ] Manual smoke test on macOS (done locally), Linux, Windows.