### PR TITLE
feat(cli): add new and render for tighter authoring loop

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -124,6 +124,47 @@ agnostic-ai list
 When no specs are loaded, `list` prints the same stderr hint and keeps
 stdout empty so pipes stay clean.
 
+## new
+
+Scaffold a single spec file with kind-appropriate frontmatter under the
+source directory configured for that kind. Replaces "copy from `--demo`
+and edit" as the starting point for one new agent, skill, rule, hook,
+or MCP.
+
+```bash
+agnostic-ai new rule no-console-log     # → <rules>/no-console-log.md
+agnostic-ai new agent code-reviewer     # → <agents>/code-reviewer.md
+agnostic-ai new skill yaml-validator    # → <skills>/yaml-validator.md
+agnostic-ai new hook fmt-on-save        # → <hooks>/fmt-on-save.yaml
+agnostic-ai new mcp filesystem          # → <mcps>/filesystem.yaml
+```
+
+Errors if the destination file already exists. Names must be lowercase
+slugs (`[a-z0-9][a-z0-9-]*`); the same form Cursor and Cline expect.
+Honors `sources:` from `agnostic.config.yaml`, so a project that puts
+specs under `specs/` lands files there automatically.
+
+## render
+
+Print the emission for a single spec to stdout, per target. Iterate on
+one spec and see exactly what each adapter would produce, without
+writing files or rerunning a full sync.
+
+```bash
+agnostic-ai render rules/no-console-log.md --target cursor
+agnostic-ai render rules/no-console-log.md --target claude,codex
+agnostic-ai render rules/no-console-log.md         # all configured targets
+```
+
+| Flag | Description |
+|------|-------------|
+| `-t, --target <list>` | Target(s) to render. Repeat or comma-separate. Default: every target in `agnostic.config.yaml`. |
+
+Output format is `# target: <name> — <output path>` followed by the file
+body, one block per emitted file. Targets that produce no output for the
+spec's kind print a short note. Render writes nothing to disk; pair with
+`sync` once the output looks right.
+
 ## sync
 
 Emit per-target configs.

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// newSpecKinds is the canonical list shown in `new --help` and used for
+// argument validation. Order matches spec.AllKinds.
+var newSpecKinds = []string{
+	string(spec.KindAgent),
+	string(spec.KindSkill),
+	string(spec.KindRule),
+	string(spec.KindHook),
+	string(spec.KindMCP),
+}
+
+var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+func newNewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "new <kind> <name>",
+		Short: "Scaffold a single spec file with kind-appropriate frontmatter.",
+		Long: "Creates one spec file under the directory configured for <kind> " +
+			"in agnostic.config.yaml. Replaces 'copy from --demo and edit' as " +
+			"the starting point for a single new agent, skill, rule, hook, or MCP.",
+		Example: `  # Add a new rule
+  agnostic-ai new rule no-console-log
+
+  # Add a new agent
+  agnostic-ai new agent code-reviewer
+
+  # Add a new MCP server config
+  agnostic-ai new mcp filesystem`,
+		Args: cobra.ExactArgs(2),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return newSpecKinds, cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind, name := strings.ToLower(args[0]), args[1]
+			if !validKind(kind) {
+				return fmt.Errorf("unknown kind %q; expected one of: %s", kind, strings.Join(newSpecKinds, ", "))
+			}
+			if !slugRe.MatchString(name) {
+				return fmt.Errorf("invalid name %q; use lowercase letters, digits, and hyphens (e.g. no-console-log)", name)
+			}
+			cfg, err := config.Load(".")
+			if err != nil {
+				return err
+			}
+			path, err := newSpecPath(cfg, kind, name)
+			if err != nil {
+				return err
+			}
+			if _, err := os.Stat(path); err == nil {
+				return fmt.Errorf("%s already exists", path)
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+			}
+			body := newSpecTemplate(kind, name)
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				return fmt.Errorf("write %s: %w", path, err)
+			}
+			summaryf("wrote %s\n", path)
+			summaryf("→ edit it, then run `agnostic-ai render %s --target <name>` to preview, or `agnostic-ai sync` to fan out.\n", path)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func validKind(k string) bool {
+	for _, v := range newSpecKinds {
+		if v == k {
+			return true
+		}
+	}
+	return false
+}
+
+// newSpecPath resolves the destination file for a `new` invocation by
+// joining the source directory configured for that kind with the slug.
+// Hooks and MCPs are pure YAML; everything else is Markdown.
+func newSpecPath(cfg *config.Config, kind, name string) (string, error) {
+	dir, err := sourceDirForKind(cfg, kind)
+	if err != nil {
+		return "", err
+	}
+	ext := ".md"
+	if kind == string(spec.KindHook) || kind == string(spec.KindMCP) {
+		ext = ".yaml"
+	}
+	return filepath.Join(dir, name+ext), nil
+}
+
+func sourceDirForKind(cfg *config.Config, kind string) (string, error) {
+	switch kind {
+	case string(spec.KindAgent):
+		return cfg.Sources.Agents, nil
+	case string(spec.KindSkill):
+		return cfg.Sources.Skills, nil
+	case string(spec.KindRule):
+		return cfg.Sources.Rules, nil
+	case string(spec.KindHook):
+		return cfg.Sources.Hooks, nil
+	case string(spec.KindMCP):
+		return cfg.Sources.MCPs, nil
+	}
+	return "", fmt.Errorf("unknown kind %q", kind)
+}
+
+// newSpecTemplate returns kind-specific frontmatter pre-filled with the
+// canonical fields each adapter consumes. Bodies are intentionally tiny
+// so the user replaces them rather than editing around boilerplate.
+func newSpecTemplate(kind, name string) string {
+	switch kind {
+	case string(spec.KindAgent):
+		return fmt.Sprintf(`---
+name: %s
+description: TODO short description shown in agent pickers.
+tools: [Read, Grep, Bash]
+model: sonnet
+---
+
+TODO: agent system prompt body.
+`, name)
+	case string(spec.KindSkill):
+		return fmt.Sprintf(`---
+name: %s
+description: TODO when this skill should fire (mention the trigger words).
+---
+
+# %s
+
+TODO: skill body. Describe steps, inputs, outputs.
+`, name, name)
+	case string(spec.KindRule):
+		return fmt.Sprintf(`---
+name: %s
+description: TODO short description.
+globs: "**/*"
+alwaysApply: true
+---
+
+TODO: rule body.
+`, name)
+	case string(spec.KindHook):
+		return fmt.Sprintf(`name: %s
+description: TODO short description.
+event: PostToolUse
+matcher: "Edit|Write"
+command: "echo TODO"
+`, name)
+	case string(spec.KindMCP):
+		return fmt.Sprintf(`name: %s
+description: TODO short description.
+command: npx
+args:
+  - -y
+  - "@example/server"
+`, name)
+	}
+	return ""
+}

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func setupEmptyProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := `version: 1
+sources:
+  agents: .agnostic-ai/agents
+  skills: .agnostic-ai/skills
+  rules: .agnostic-ai/rules
+  hooks: .agnostic-ai/hooks
+  mcps: .agnostic-ai/mcps
+targets:
+  - claude
+  - cursor
+`
+	if err := os.WriteFile(filepath.Join(dir, "agnostic.config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestNew_WritesRule(t *testing.T) {
+	dir := setupEmptyProject(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"new", "rule", "no-console-log"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, ".agnostic-ai", "rules", "no-console-log.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected rule file at %s: %v", path, err)
+	}
+	if !strings.Contains(string(body), "name: no-console-log") {
+		t.Errorf("rule body missing frontmatter name field:\n%s", body)
+	}
+	if !strings.Contains(string(body), "alwaysApply: true") {
+		t.Errorf("rule body missing alwaysApply: %s", body)
+	}
+}
+
+func TestNew_HookEmitsYAML(t *testing.T) {
+	dir := setupEmptyProject(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"new", "hook", "fmt-on-save"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".agnostic-ai", "hooks", "fmt-on-save.yaml")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected hook YAML at %s", path)
+	}
+}
+
+func TestNew_ErrorsIfFileExists(t *testing.T) {
+	dir := setupEmptyProject(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	first := NewRootCmd("test")
+	first.SetArgs([]string{"new", "rule", "dup"})
+	if err := first.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	second := NewRootCmd("test")
+	second.SetArgs([]string{"new", "rule", "dup"})
+	err := second.Execute()
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already-exists error, got %v", err)
+	}
+}
+
+func TestNew_RejectsUnknownKind(t *testing.T) {
+	dir := setupEmptyProject(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"new", "wat", "x"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unknown kind") {
+		t.Fatalf("expected unknown-kind error, got %v", err)
+	}
+}
+
+func TestNew_RejectsBadName(t *testing.T) {
+	dir := setupEmptyProject(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"new", "rule", "Bad Name!"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid name") {
+		t.Fatalf("expected invalid-name error, got %v", err)
+	}
+}
+
+func TestNew_HonorsConfiguredSources(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `version: 1
+sources:
+  agents: specs/agents
+  skills: specs/skills
+  rules: specs/rules
+  hooks: specs/hooks
+  mcps: specs/mcps
+targets: [claude]
+`
+	if err := os.WriteFile(filepath.Join(dir, "agnostic.config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"new", "rule", "x"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "specs", "rules", "x.md")); err != nil {
+		t.Errorf("expected file under custom sources: %v", err)
+	}
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+func newRenderCmd() *cobra.Command {
+	var targetFlags []string
+	cmd := &cobra.Command{
+		Use:   "render <spec>",
+		Short: "Print the emission for a single spec to stdout, per target.",
+		Long: "Loads one spec by path and prints what each chosen target would " +
+			"write, without touching disk. Useful while iterating on a single " +
+			"rule, agent, skill, hook, or MCP. <spec> is resolved relative to " +
+			"the current directory.",
+		Example: `  # Render a single rule for cursor
+  agnostic-ai render rules/no-console-log.md --target cursor
+
+  # Multi-target preview
+  agnostic-ai render rules/no-console-log.md --target claude,codex
+
+  # Default targets come from agnostic.config.yaml
+  agnostic-ai render rules/no-console-log.md`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, bundle, err := loadProject(".")
+			if err != nil {
+				return err
+			}
+			entry, err := findSpecEntry(args[0], bundle)
+			if err != nil {
+				return err
+			}
+			targets := targetFlags
+			if len(targets) == 0 {
+				targets = cfg.Targets
+			}
+			single := singleEntryBundle(entry)
+			out := cmd.OutOrStdout()
+			anyOutput := false
+			for _, t := range targets {
+				adapter, err := adapters.Resolve(t)
+				if err != nil {
+					return err
+				}
+				captured, err := captureEmit(adapter, single, cfg)
+				if err != nil {
+					return fmt.Errorf("%s: %w", t, err)
+				}
+				if len(captured) == 0 {
+					fmt.Fprintf(out, "# target: %s — (no output for kind %s)\n", t, entry.Kind)
+					continue
+				}
+				anyOutput = true
+				for _, f := range captured {
+					fmt.Fprintf(out, "# target: %s — %s\n", t, f.Path)
+					fmt.Fprint(out, f.Content)
+					if !strings.HasSuffix(f.Content, "\n") {
+						fmt.Fprintln(out)
+					}
+					fmt.Fprintln(out)
+				}
+			}
+			if !anyOutput {
+				return fmt.Errorf("no targets produced output for spec %s", entry.Path)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVarP(&targetFlags, "target", "t", nil, "Target(s) to render (default: all in config). Repeat or comma-separate.")
+	registerTargetCompletion(cmd)
+	return cmd
+}
+
+// findSpecEntry resolves the user-supplied path to a loaded spec entry.
+// Tries direct equality first, then absolute-path equality, then falls
+// back to a "did you mean" hint based on file basename.
+func findSpecEntry(input string, b spec.Bundle) (spec.Entry, error) {
+	all := b.All()
+	for _, e := range all {
+		if e.Path == input {
+			return e, nil
+		}
+	}
+	abs, _ := filepath.Abs(input)
+	if abs != "" {
+		for _, e := range all {
+			ea, _ := filepath.Abs(e.Path)
+			if ea == abs {
+				return e, nil
+			}
+		}
+	}
+	if _, err := os.Stat(input); err == nil {
+		return spec.Entry{}, fmt.Errorf("%s exists but is not loaded as a spec; ensure it lives under a configured source directory and uses a recognized extension", input)
+	}
+	base := filepath.Base(input)
+	var hints []string
+	for _, e := range all {
+		if filepath.Base(e.Path) == base {
+			hints = append(hints, e.Path)
+		}
+	}
+	sort.Strings(hints)
+	if len(hints) > 0 {
+		return spec.Entry{}, fmt.Errorf("spec %q not found. Did you mean: %s", input, strings.Join(hints, ", "))
+	}
+	return spec.Entry{}, fmt.Errorf("spec %q not found", input)
+}
+
+// singleEntryBundle returns a Bundle that contains only the given entry,
+// dispatched into the correct kind bucket.
+func singleEntryBundle(e spec.Entry) spec.Bundle {
+	var b spec.Bundle
+	switch e.Kind {
+	case spec.KindAgent:
+		b.Agents = []spec.Entry{e}
+	case spec.KindSkill:
+		b.Skills = []spec.Entry{e}
+	case spec.KindRule:
+		b.Rules = []spec.Entry{e}
+	case spec.KindHook:
+		b.Hooks = []spec.Entry{e}
+	case spec.KindMCP:
+		b.MCPs = []spec.Entry{e}
+	}
+	return b
+}
+
+// captureEmit runs an adapter's Emit under capture mode so output stays
+// in memory instead of writing to disk. dryRun is false because dryRun
+// prints to stdout, which would defeat the purpose of capturing.
+func captureEmit(a adapters.Adapter, b spec.Bundle, cfg *config.Config) ([]adapters.CapturedFile, error) {
+	adapters.StartCapture()
+	err := a.Emit(b, cfg, false)
+	captured := adapters.StopCapture()
+	if err != nil {
+		return nil, err
+	}
+	return captured, nil
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -58,17 +58,17 @@ func newRenderCmd() *cobra.Command {
 					return fmt.Errorf("%s: %w", t, err)
 				}
 				if len(captured) == 0 {
-					fmt.Fprintf(out, "# target: %s — (no output for kind %s)\n", t, entry.Kind)
+					_, _ = fmt.Fprintf(out, "# target: %s — (no output for kind %s)\n", t, entry.Kind)
 					continue
 				}
 				anyOutput = true
 				for _, f := range captured {
-					fmt.Fprintf(out, "# target: %s — %s\n", t, f.Path)
-					fmt.Fprint(out, f.Content)
+					_, _ = fmt.Fprintf(out, "# target: %s — %s\n", t, filepath.ToSlash(f.Path))
+					_, _ = fmt.Fprint(out, f.Content)
 					if !strings.HasSuffix(f.Content, "\n") {
-						fmt.Fprintln(out)
+						_, _ = fmt.Fprintln(out)
 					}
-					fmt.Fprintln(out)
+					_, _ = fmt.Fprintln(out)
 				}
 			}
 			if !anyOutput {

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func setupRenderFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := `version: 1
+sources:
+  agents: agents
+  skills: skills
+  rules: rules
+  hooks: hooks
+  mcps: mcps
+targets:
+  - claude
+  - cursor
+`
+	mustWrite := func(p, body string) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(filepath.Join(dir, "agnostic.config.yaml"), cfg)
+	mustWrite(filepath.Join(dir, "rules", "no-console-log.md"), `---
+name: no-console-log
+description: No console.log in shipped code.
+globs: "**/*"
+alwaysApply: true
+---
+
+Do not commit console.log statements.
+`)
+	return dir
+}
+
+func TestRender_SingleTargetCursor(t *testing.T) {
+	dir := setupRenderFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"render", "rules/no-console-log.md", "--target", "cursor"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "# target: cursor") {
+		t.Errorf("expected target header, got:\n%s", got)
+	}
+	if !strings.Contains(got, ".cursor/rules/no-console-log.mdc") {
+		t.Errorf("expected cursor output path, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Do not commit console.log statements.") {
+		t.Errorf("expected rule body, got:\n%s", got)
+	}
+}
+
+func TestRender_MultiTarget(t *testing.T) {
+	dir := setupRenderFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"render", "rules/no-console-log.md", "--target", "claude,cursor"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "CLAUDE.md") {
+		t.Errorf("missing CLAUDE.md output: %s", got)
+	}
+	if !strings.Contains(got, ".cursor/rules/no-console-log.mdc") {
+		t.Errorf("missing cursor output: %s", got)
+	}
+}
+
+func TestRender_DefaultsToConfigTargets(t *testing.T) {
+	dir := setupRenderFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"render", "rules/no-console-log.md"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "# target: claude") || !strings.Contains(got, "# target: cursor") {
+		t.Errorf("expected both configured targets, got:\n%s", got)
+	}
+}
+
+func TestRender_SpecNotFound(t *testing.T) {
+	dir := setupRenderFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"render", "rules/missing.md"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got %v", err)
+	}
+}
+
+func TestRender_SpecOutsideSources(t *testing.T) {
+	dir := setupRenderFixture(t)
+	stray := filepath.Join(dir, "stray.md")
+	if err := os.WriteFile(stray, []byte("---\nname: stray\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"render", "stray.md"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not loaded as a spec") {
+		t.Fatalf("expected stray-file error, got %v", err)
+	}
+}
+
+func TestRender_DoesNotWriteToDisk(t *testing.T) {
+	dir := setupRenderFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"render", "rules/no-console-log.md", "--target", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); err == nil {
+		t.Error("render must not write CLAUDE.md to disk")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -68,6 +68,8 @@ func NewRootCmd(version string) *cobra.Command {
 		newRevertCmd(),
 		newPacksCmd(),
 		newStatusCmd(),
+		newNewCmd(),
+		newRenderCmd(),
 	)
 	root.InitDefaultCompletionCmd()
 	return root


### PR DESCRIPTION
## Summary

- `agnostic-ai new <kind> <name>` scaffolds one spec file under the configured source directory for that kind. Pre-fills frontmatter for `agent`, `skill`, `rule`, `hook`, and `mcp`. Errors if the file exists. Names must be lowercase slugs.
- `agnostic-ai render <spec> [--target <t>...]` prints what each chosen target would emit for that one spec, with no disk writes. Pairs with the existing `sync --dry-run` (which writes the world) and `init --demo` (one-shot).
- Output format: `# target: <name> — <output path>` followed by the file body. Multi-target via comma-separated `--target` or repeated flag. Defaults to `cfg.Targets`.
- Docs: new sections under `docs/user/cli-reference.md`.
- Tests: 11 new unit tests covering happy paths, error cases (missing spec, stray file outside sources, dup `new`, bad name/kind), and the no-disk-write guarantee.

Closes #31

## Test plan

- [x] `go test -race ./...` all green.
- [x] Manual smoke: `init` → `new rule x` → `render .agnostic-ai/rules/x.md --target claude,cursor` → emissions look right and no files were written.
- [x] `new` honors a custom `sources:` layout (test included).