### PR TITLE
feat(cli): add explain for reverse spec provenance

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -144,6 +144,40 @@ slugs (`[a-z0-9][a-z0-9-]*`); the same form Cursor and Cline expect.
 Honors `sources:` from `agnostic.config.yaml`, so a project that puts
 specs under `specs/` lands files there automatically.
 
+## explain
+
+Reverse provenance: list every output file and section that one spec
+contributes to. Pairs with the `<!-- source: ... -->` forward markers
+adapters write into merged documents.
+
+```bash
+agnostic-ai explain rules/conventional-commits.md
+agnostic-ai explain rules/conventional-commits.md --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Stable schema for editor extensions and scripts. |
+
+Output groups contributions by configured target (the ones in
+`agnostic.config.yaml`) and a separate "would emit if enabled" list for
+adapters that exist but are not currently activated. Each entry tags
+itself as `(full file)` (the spec owns the file) or
+`(section "<name>")` (the spec contributes one section to a merged
+document). Writes nothing to disk.
+
+JSON envelope:
+
+```json
+{
+  "version": "1",
+  "command": "explain",
+  "spec": { "kind": "rule", "name": "...", "path": "..." },
+  "contributions":         [{ "target": "...", "path": "...", "section": "...", "mode": "full|section" }],
+  "would_emit_if_enabled": [{ "target": "...", "path": "...", "section": "...", "mode": "full|section" }]
+}
+```
+
 ## render
 
 Print the emission for a single spec to stdout, per target. Iterate on

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// contribution describes one downstream output that a single source
+// spec contributes to.
+type contribution struct {
+	Target  string `json:"target"`
+	Path    string `json:"path"`
+	Section string `json:"section,omitempty"`
+	Mode    string `json:"mode"` // "full" or "section"
+}
+
+// explainOutput is the JSON envelope for `explain --json`.
+type explainOutput struct {
+	Version       string         `json:"version"`
+	Command       string         `json:"command"`
+	Spec          explainSpecRef `json:"spec"`
+	Contributions []contribution `json:"contributions"`
+	// WouldEmitIfEnabled lists outputs from adapters that are NOT in the
+	// project's configured targets. Helps authors anticipate the impact
+	// of enabling a new target without having to edit and re-sync.
+	WouldEmitIfEnabled []contribution `json:"would_emit_if_enabled"`
+}
+
+type explainSpecRef struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+func newExplainCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "explain <spec>",
+		Short: "List every output file and section a spec contributes to.",
+		Long: "Reverse provenance: takes one spec and shows where it lands in " +
+			"each target's emission. Pairs with the `<!-- source: ... -->` " +
+			"forward markers adapters write into merged documents.",
+		Example: `  # Human-readable
+  agnostic-ai explain rules/conventional-commits.md
+
+  # Machine-readable, for editor extensions or scripts
+  agnostic-ai explain rules/conventional-commits.md --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, bundle, err := loadProject(".")
+			if err != nil {
+				return err
+			}
+			entry, err := findSpecEntry(args[0], bundle)
+			if err != nil {
+				return err
+			}
+			configured, extra, err := computeContributions(entry, bundle, cfg)
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				if configured == nil {
+					configured = []contribution{}
+				}
+				if extra == nil {
+					extra = []contribution{}
+				}
+				return emitExplainJSON(cmd, explainOutput{
+					Version: "1",
+					Command: "explain",
+					Spec: explainSpecRef{
+						Kind: string(entry.Kind),
+						Name: entry.Name,
+						Path: filepath.ToSlash(entry.Path),
+					},
+					Contributions:      configured,
+					WouldEmitIfEnabled: extra,
+				})
+			}
+			out := cmd.OutOrStdout()
+			_, _ = fmt.Fprintf(out, "%s →\n", filepath.ToSlash(entry.Path))
+			if len(configured) == 0 {
+				_, _ = fmt.Fprintln(out, "  (no configured target emits output for this spec)")
+			}
+			for _, c := range configured {
+				_, _ = fmt.Fprintf(out, "  %s\n", formatContribution(c))
+			}
+			if len(extra) > 0 {
+				_, _ = fmt.Fprintln(out, "")
+				_, _ = fmt.Fprintln(out, "would emit if enabled:")
+				for _, c := range extra {
+					_, _ = fmt.Fprintf(out, "  %s\n", formatContribution(c))
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for editor extensions and scripts.")
+	return cmd
+}
+
+func formatContribution(c contribution) string {
+	path := filepath.ToSlash(c.Path)
+	if c.Mode == "full" {
+		return fmt.Sprintf("[%s] %s (full file)", c.Target, path)
+	}
+	if c.Section != "" {
+		return fmt.Sprintf("[%s] %s (section %q)", c.Target, path, c.Section)
+	}
+	return fmt.Sprintf("[%s] %s (partial)", c.Target, path)
+}
+
+// computeContributions classifies each emitted file as either fully
+// owned by the spec or as one section among many. Returns two slices:
+// contributions from configured targets and contributions from
+// not-configured-but-built-in adapters.
+//
+// Strategy: render every adapter twice — once with the full bundle,
+// once with the bundle minus the spec — and compare. If the path
+// disappears, the spec owns the file; if the content shrinks, the spec
+// contributes a section. Avoids parsing each adapter's output format.
+func computeContributions(e spec.Entry, b spec.Bundle, cfg *config.Config) ([]contribution, []contribution, error) {
+	// Silence per-adapter capability warnings while we render every
+	// adapter twice. Without this, hooks/MCPs would emit "X not
+	// supported" lines repeatedly even though they're informational.
+	adapters.SetWarner(io.Discard)
+	defer adapters.SetWarner(os.Stderr)
+
+	withoutSpec := bundleWithout(b, e)
+	configuredSet := make(map[string]struct{}, len(cfg.Targets))
+	for _, t := range cfg.Targets {
+		configuredSet[t] = struct{}{}
+	}
+
+	var configured, extra []contribution
+	for _, name := range adapters.Names() {
+		adapter, err := adapters.Resolve(name)
+		if err != nil {
+			continue
+		}
+		full, err := captureEmit(adapter, b, cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", name, err)
+		}
+		minus, err := captureEmit(adapter, withoutSpec, cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", name, err)
+		}
+		minusByPath := make(map[string]string, len(minus))
+		for _, f := range minus {
+			minusByPath[f.Path] = f.Content
+		}
+		for _, f := range full {
+			before, present := minusByPath[f.Path]
+			switch {
+			case !present:
+				addContribution(&configured, &extra, configuredSet, contribution{
+					Target: name, Path: f.Path, Mode: "full",
+				})
+			case before != f.Content:
+				addContribution(&configured, &extra, configuredSet, contribution{
+					Target: name, Path: f.Path, Section: e.Name, Mode: "section",
+				})
+			}
+		}
+	}
+	sortContribs(configured)
+	sortContribs(extra)
+	return configured, extra, nil
+}
+
+func addContribution(configured, extra *[]contribution, configuredSet map[string]struct{}, c contribution) {
+	if _, ok := configuredSet[c.Target]; ok {
+		*configured = append(*configured, c)
+		return
+	}
+	*extra = append(*extra, c)
+}
+
+func sortContribs(c []contribution) {
+	sort.SliceStable(c, func(i, j int) bool {
+		if c[i].Target != c[j].Target {
+			return c[i].Target < c[j].Target
+		}
+		return c[i].Path < c[j].Path
+	})
+}
+
+// bundleWithout returns a copy of b with the given entry removed.
+// Identity is by Path, which is unique within a bundle.
+func bundleWithout(b spec.Bundle, e spec.Entry) spec.Bundle {
+	return spec.Bundle{
+		Agents: filterEntries(b.Agents, e.Path),
+		Skills: filterEntries(b.Skills, e.Path),
+		Rules:  filterEntries(b.Rules, e.Path),
+		Hooks:  filterEntries(b.Hooks, e.Path),
+		MCPs:   filterEntries(b.MCPs, e.Path),
+	}
+}
+
+func filterEntries(entries []spec.Entry, excludePath string) []spec.Entry {
+	out := make([]spec.Entry, 0, len(entries))
+	for _, e := range entries {
+		if e.Path == excludePath {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// emitExplainJSON serializes an explainOutput with stable indentation.
+// `explain` carries a different envelope than sync/revert/doctor (which
+// share jsonOutput), so it gets its own emitter.
+func emitExplainJSON(cmd *cobra.Command, v explainOutput) error {
+	for i := range v.Contributions {
+		v.Contributions[i].Path = filepath.ToSlash(v.Contributions[i].Path)
+	}
+	for i := range v.WouldEmitIfEnabled {
+		v.WouldEmitIfEnabled[i].Path = filepath.ToSlash(v.WouldEmitIfEnabled[i].Path)
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -1,0 +1,208 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func setupExplainFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := `version: 1
+sources:
+  agents: agents
+  skills: skills
+  rules: rules
+  hooks: hooks
+  mcps: mcps
+targets:
+  - claude
+  - codex
+`
+	mustWrite := func(p, body string) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(filepath.Join(dir, "agnostic.config.yaml"), cfg)
+	mustWrite(filepath.Join(dir, "rules", "no-console-log.md"), `---
+name: no-console-log
+description: No console.log in shipped code.
+globs: "**/*"
+alwaysApply: true
+---
+
+Do not commit console.log statements.
+`)
+	// Add a sibling rule so contributions are clearly section-level
+	// rather than full-file in shared docs like AGENTS.md.
+	mustWrite(filepath.Join(dir, "rules", "other.md"), `---
+name: other
+description: Sibling rule.
+---
+
+Sibling body.
+`)
+	return dir
+}
+
+func TestExplain_HumanOutputListsConfiguredAndExtras(t *testing.T) {
+	dir := setupExplainFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "rules/no-console-log.md"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "rules/no-console-log.md →") {
+		t.Errorf("missing header arrow: %s", got)
+	}
+	if !strings.Contains(got, "[claude] CLAUDE.md") {
+		t.Errorf("expected configured claude contribution: %s", got)
+	}
+	if !strings.Contains(got, "[codex] AGENTS.md") {
+		t.Errorf("expected configured codex contribution: %s", got)
+	}
+	if !strings.Contains(got, "would emit if enabled:") {
+		t.Errorf("expected extras header for non-configured targets: %s", got)
+	}
+	if !strings.Contains(got, "[cursor]") {
+		t.Errorf("expected cursor in would-emit-if-enabled: %s", got)
+	}
+}
+
+func TestExplain_FullFileForUniqueTargets(t *testing.T) {
+	dir := setupExplainFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "rules/no-console-log.md"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	// Cursor writes one .mdc file per rule; removing the spec drops that
+	// file entirely, so the contribution should be classified as "full".
+	if !strings.Contains(got, ".cursor/rules/no-console-log.mdc (full file)") {
+		t.Errorf("expected full-file classification for cursor mdc: %s", got)
+	}
+}
+
+func TestExplain_JSONOutputSchema(t *testing.T) {
+	dir := setupExplainFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "rules/no-console-log.md", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got explainOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if got.Version != "1" {
+		t.Errorf("version: want 1, got %q", got.Version)
+	}
+	if got.Command != "explain" {
+		t.Errorf("command: want explain, got %q", got.Command)
+	}
+	if got.Spec.Kind != "rule" || got.Spec.Name != "no-console-log" {
+		t.Errorf("spec ref wrong: %+v", got.Spec)
+	}
+	if len(got.Contributions) == 0 {
+		t.Errorf("expected at least one configured contribution")
+	}
+	if len(got.WouldEmitIfEnabled) == 0 {
+		t.Errorf("expected at least one would-emit-if-enabled entry")
+	}
+	for _, c := range got.Contributions {
+		if c.Mode != "full" && c.Mode != "section" {
+			t.Errorf("unexpected mode %q in %+v", c.Mode, c)
+		}
+	}
+}
+
+func TestExplain_DoesNotWriteToDisk(t *testing.T) {
+	dir := setupExplainFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "rules/no-console-log.md"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); err == nil {
+		t.Error("explain must not write CLAUDE.md to disk")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); err == nil {
+		t.Error("explain must not write AGENTS.md to disk")
+	}
+}
+
+func TestExplain_SpecNotFound(t *testing.T) {
+	dir := setupExplainFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"explain", "rules/missing.md"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got %v", err)
+	}
+}
+
+func TestExplain_AgentSpec(t *testing.T) {
+	dir := setupExplainFixture(t)
+	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentBody := `---
+name: code-reviewer
+description: Reviews diffs.
+tools: [Read, Grep]
+---
+You review code.
+`
+	if err := os.WriteFile(filepath.Join(dir, "agents", "code-reviewer.md"), []byte(agentBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "agents/code-reviewer.md"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, ".claude/agents/code-reviewer.md (full file)") {
+		t.Errorf("expected claude per-agent file as full contribution: %s", got)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -70,6 +70,7 @@ func NewRootCmd(version string) *cobra.Command {
 		newStatusCmd(),
 		newNewCmd(),
 		newRenderCmd(),
+		newExplainCmd(),
 	)
 	root.InitDefaultCompletionCmd()
 	return root


### PR DESCRIPTION
## Summary

- `agnostic-ai explain <spec>` lists every downstream file and section a single source spec contributes to (rule, agent, skill, hook, MCP).
- Groups output by **configured targets** (in `agnostic.config.yaml`) and **would-emit-if-enabled** (built-in adapters not currently activated), so authors can see the impact of toggling a target without editing config.
- Each entry is tagged `(full file)` or `(section "<name>")`; the classifier diffs `bundle` vs `bundle - {spec}` per adapter, so it stays correct as adapters evolve grouping rules.
- `--json` emits a stable schema (versioned envelope) for editor extensions and scripts.
- Silences adapter capability warnings during the dual-render pass to keep output clean.
- Docs section added to `docs/user/cli-reference.md`.

Closes #40

## Test plan

- [x] `go test -race ./...` all green.
- [x] 6 new tests cover human + JSON output, full-file vs section classification, no-disk-write guarantee, missing spec, and an agent-spec scenario.
- [x] Manual smoke on this repo: `explain .agnostic-ai/rules/conventional-commits.md` and `explain .agnostic-ai/agents/code-reviewer.md` produce expected, complete output.