### PR TITLE
feat(init): add --preset for stack-flavored starter specs

### DIFF
--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -7,8 +7,9 @@ Read in this order.
 3. [Plugin protocol](plugin-protocol.md): JSON-over-stdio contract for out-of-tree adapter binaries.
 4. [Contributing](contributing.md): branch flow, commit style, test expectations.
 5. [Release process](release-process.md): how a tag becomes a release.
-6. [Decision log](decisions.md): historical record of design choices.
-7. [Roadmap](roadmap.md): planned directions (layered config, more adapters).
+6. [Contributing a preset](contributing-presets.md): adding a new `init --preset <name>` starter pack.
+7. [Decision log](decisions.md): historical record of design choices.
+8. [Roadmap](roadmap.md): planned directions (layered config, more adapters).
 
 ## House rules
 

--- a/docs/internal/contributing-presets.md
+++ b/docs/internal/contributing-presets.md
@@ -1,0 +1,59 @@
+# Contributing a preset
+
+Presets are stack-flavored starter spec packs that `init --preset
+<name>` writes into a fresh project. Today: `go`, `ts-react`, `python`.
+Adding more is a small, mechanical change.
+
+## Layout
+
+Each preset is a directory under `internal/cli/initdata/presets/<name>/`
+with the same shape as `.agnostic-ai/`:
+
+```
+internal/cli/initdata/presets/
+└── <name>/
+    ├── agents/...
+    ├── skills/...
+    ├── rules/...
+    ├── hooks/...
+    └── mcps/...
+```
+
+Only the kinds you need; empty subfolders are not required. Files use
+the same Markdown + YAML frontmatter format as user specs (see
+[Spec format](../user/spec-format.md)).
+
+## Step by step
+
+1. **Create the directory** under `internal/cli/initdata/presets/`.
+2. **Write specs** that capture house style, not project specifics.
+   Keep each spec short. Three good rules beat ten vague ones.
+3. **Add an entry to `presetExpectedFiles`** in
+   `internal/cli/init_preset_test.go` listing every file the preset
+   ships. The snapshot test guards against accidental drift.
+4. **Run the suite**: `go test ./internal/cli/ -run Preset`.
+5. **Open a PR** with subject `feat: add <name> init preset`.
+
+The `presetFS` `embed.FS` in `init.go` uses `all:initdata/presets`, so a
+new directory is picked up automatically by the next build. No
+registration list to maintain.
+
+## Style guidance
+
+- **Stack-shaped, not project-shaped.** A `python` preset says "use
+  type hints", not "use this team's mypy config".
+- **One topic per spec.** `python-style.md`, `pytest.md`, `typing.md`
+  — not one giant `python.md`.
+- **Globs.** Scope rules with `globs:` so they only fire on the
+  relevant file types.
+- **alwaysApply.** Default `true` for style/testing rules. Reserve
+  `false` for narrow scopes.
+
+## What to avoid
+
+- Tooling-specific output (CLAUDE.md, AGENTS.md). Adapters generate
+  those; presets seed sources.
+- Opinions a thoughtful contributor would push back on. Presets are a
+  starting point, not a manifesto.
+- External assets. Keep specs to text. The embedded filesystem ships
+  in the binary.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -22,12 +22,14 @@ agnostic-ai init                  # default base dir: .agnostic-ai/
 agnostic-ai init specs            # custom base: specs/{agents,skills,...}/
 agnostic-ai init .                # legacy root-level layout
 agnostic-ai init --demo           # seed each source folder with one example spec
+agnostic-ai init --preset go      # seed idiomatic specs for a stack (go, ts-react, python)
 agnostic-ai init -i               # interactive: pick which targets land in config
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--demo` | Seed each source folder with one minimal example spec so a fresh project produces real output on the first `sync`. Existing files are never overwritten. |
+| `--preset <name>` | Seed stack-flavored starter specs. Available: `go`, `ts-react`, `python`. Composes with `--demo` and `-i`. Errors on unknown names with the available list. Existing files are never overwritten, so re-running against a partially populated tree is safe. |
 | `-i, --interactive` | Multi-select prompt to pick which targets land in `agnostic.config.yaml`. Accepts piped comma-separated input for non-TTY use (e.g. `echo "claude,codex" \| agnostic-ai init -i`). |
 
 The optional positional `[dir]` arg sets the base directory under which

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -22,8 +22,19 @@ const defaultBaseDir = ".agnostic-ai"
 //go:embed initdata/agents/* initdata/skills/* initdata/rules/* initdata/hooks/* initdata/mcps/*
 var demoFS embed.FS
 
+// presetFS holds stack-flavored starter spec packs. `init --preset go`
+// (or `--preset ts-react`, `--preset python`) seeds the project with the
+// preset's specs, in addition to whatever `--demo` would write. Each
+// preset lives at `initdata/presets/<name>/<kind>/...`.
+//
+//go:embed all:initdata/presets
+var presetFS embed.FS
+
+const presetRoot = "initdata/presets"
+
 func newInitCmd() *cobra.Command {
 	var demo, interactive bool
+	var preset string
 	cmd := &cobra.Command{
 		Use:   "init [dir]",
 		Short: "Scaffold an agnostic-ai project in the current directory.",
@@ -31,6 +42,7 @@ func newInitCmd() *cobra.Command {
 			"Default base dir is .agnostic-ai/. Pass a positional argument " +
 			"to override (use \".\" for the legacy root-level layout). " +
 			"Pass --demo to seed each source folder with a minimal example spec. " +
+			"Pass --preset <name> to seed idiomatic specs for a stack (go, ts-react, python). " +
 			"Pass -i / --interactive to pick which targets land in the config.",
 		Example: `  # Default: scaffold under .agnostic-ai/
   agnostic-ai init
@@ -40,6 +52,10 @@ func newInitCmd() *cobra.Command {
 
   # Seed each source folder with one minimal example spec
   agnostic-ai init --demo
+
+  # Seed idiomatic specs for a stack
+  agnostic-ai init --preset go
+  agnostic-ai init --preset ts-react
 
   # Legacy root-level layout (agents/, skills/, rules/, ... at project root)
   agnostic-ai init .
@@ -52,6 +68,11 @@ func newInitCmd() *cobra.Command {
 			if len(args) == 1 {
 				base = args[0]
 			}
+			if preset != "" {
+				if err := validatePresetName(preset); err != nil {
+					return err
+				}
+			}
 			targets := allTargetNames()
 			if interactive {
 				picked, err := selectTargets(cmd.InOrStdin(), cmd.ErrOrStderr())
@@ -60,14 +81,45 @@ func newInitCmd() *cobra.Command {
 				}
 				targets = picked
 			}
-			return scaffold(".", base, demo, targets)
+			return scaffold(".", base, demo, preset, targets)
 		},
 	}
 	cmd.Flags().BoolVar(&demo, "demo", false,
 		"Seed each source folder with a minimal example spec.")
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false,
 		"Prompt for which targets to enable instead of writing all.")
+	cmd.Flags().StringVar(&preset, "preset", "",
+		"Seed stack-flavored starter specs (go, ts-react, python). Composes with --demo and -i.")
+	_ = cmd.RegisterFlagCompletionFunc("preset", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return availablePresets(), cobra.ShellCompDirectiveNoFileComp
+	})
 	return cmd
+}
+
+// availablePresets returns the sorted list of preset names embedded in
+// the binary. Drives both tab completion and the unknown-preset error
+// message.
+func availablePresets() []string {
+	entries, err := presetFS.ReadDir(presetRoot)
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+func validatePresetName(name string) error {
+	for _, p := range availablePresets() {
+		if p == name {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown preset %q. Available: %s", name, strings.Join(availablePresets(), ", "))
 }
 
 // renderConfig builds agnostic.config.yaml with source paths nested
@@ -98,7 +150,7 @@ func renderConfig(base string, targets []string) string {
 // scaffold creates agnostic.config.yaml at root and the source-folder
 // tree under base. targets is written verbatim to the targets: block;
 // callers must supply at least one entry.
-func scaffold(root, base string, demo bool, targets []string) error {
+func scaffold(root, base string, demo bool, preset string, targets []string) error {
 	cfgPath := filepath.Join(root, "agnostic.config.yaml")
 	if _, err := os.Stat(cfgPath); err == nil {
 		return fmt.Errorf("agnostic.config.yaml already exists")
@@ -120,9 +172,17 @@ func scaffold(root, base string, demo bool, targets []string) error {
 			return err
 		}
 	}
+	if preset != "" {
+		if err := writePresetFiles(filepath.Join(root, base), preset); err != nil {
+			return err
+		}
+	}
 	summaryf("scaffold complete. edit %s then run `agnostic-ai sync`.\n", scaffoldHint(base, kinds))
 	if demo {
 		summaryf("seeded one example spec per source folder. delete or edit to taste.\n")
+	}
+	if preset != "" {
+		summaryf("seeded preset %q. review and tune the rules to match your house style.\n", preset)
 	}
 	summaryf("import existing AI CLI config with `agnostic-ai import <source>`.\n")
 	return nil
@@ -148,6 +208,41 @@ func writeDemoFiles(baseDir string) error {
 			return nil
 		}
 		data, err := demoFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
+		return nil
+	})
+}
+
+// writePresetFiles mirrors every file under initdata/presets/<name>
+// into baseDir, preserving the kind subfolder. Existing files are left
+// untouched, so layering --preset on top of --demo or an existing tree
+// never clobbers user content.
+func writePresetFiles(baseDir, name string) error {
+	root := presetRoot + "/" + name
+	return fs.WalkDir(presetFS, root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(baseDir, filepath.FromSlash(rel))
+		if _, err := os.Stat(dst); err == nil {
+			return nil
+		}
+		data, err := presetFS.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("read embedded %s: %w", path, err)
 		}

--- a/internal/cli/init_preset_test.go
+++ b/internal/cli/init_preset_test.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// presetExpectedFiles enumerates the files each preset must emit. When
+// a preset adds or removes a spec, update this list — the snapshot
+// guards against silently shipping the wrong content to new adopters.
+var presetExpectedFiles = map[string][]string{
+	"go": {
+		"rules/go-errors.md",
+		"rules/go-style.md",
+		"rules/go-testing.md",
+	},
+	"ts-react": {
+		"rules/react.md",
+		"rules/testing.md",
+		"rules/typescript.md",
+		"skills/component-scaffold.md",
+	},
+	"python": {
+		"rules/pytest.md",
+		"rules/python-style.md",
+		"rules/typing.md",
+	},
+}
+
+func TestInit_PresetGoSeeds(t *testing.T) {
+	assertPresetSeeds(t, "go")
+}
+
+func TestInit_PresetTSReactSeeds(t *testing.T) {
+	assertPresetSeeds(t, "ts-react")
+}
+
+func TestInit_PresetPythonSeeds(t *testing.T) {
+	assertPresetSeeds(t, "python")
+}
+
+func assertPresetSeeds(t *testing.T, preset string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := scaffold(dir, "", false, preset, allTargetNames()); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	got := walkFiles(t, filepath.Join(dir, ".agnostic-ai"))
+	want := presetExpectedFiles[preset]
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("preset %q file list mismatch\n want: %v\n  got: %v", preset, want, got)
+	}
+	for _, rel := range got {
+		body, err := os.ReadFile(filepath.Join(dir, ".agnostic-ai", rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), "name:") {
+			t.Errorf("%s: missing frontmatter `name:` field", rel)
+		}
+	}
+}
+
+func TestInit_PresetUnknownErrors(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"init", "--preset", "wat"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown preset")
+	}
+	if !strings.Contains(err.Error(), "unknown preset") {
+		t.Errorf("error should name the issue: got %v", err)
+	}
+	if !strings.Contains(err.Error(), "go") || !strings.Contains(err.Error(), "ts-react") || !strings.Contains(err.Error(), "python") {
+		t.Errorf("error should list available presets: got %v", err)
+	}
+}
+
+func TestInit_PresetComposesWithDemo(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffold(dir, "", true, "go", allTargetNames()); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	got := walkFiles(t, filepath.Join(dir, ".agnostic-ai"))
+	mustContain := []string{
+		"rules/conventional-commits.md", // from --demo
+		"rules/go-style.md",             // from --preset go
+	}
+	for _, p := range mustContain {
+		found := false
+		for _, g := range got {
+			if g == p {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %s in seeded files; got %v", p, got)
+		}
+	}
+}
+
+func TestInit_PresetDoesNotOverwriteExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	rulesDir := filepath.Join(dir, ".agnostic-ai", "rules")
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(rulesDir, "go-style.md")
+	preserved := []byte("---\nname: go-style\n---\nUSER WROTE THIS\n")
+	if err := os.WriteFile(existing, preserved, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// scaffold errors when agnostic.config.yaml exists, so call
+	// writePresetFiles directly to test the no-clobber guarantee.
+	if err := writePresetFiles(filepath.Join(dir, ".agnostic-ai"), "go"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(preserved) {
+		t.Error("preset overwrote a pre-existing user file")
+	}
+}
+
+func TestAvailablePresets_ListsEmbedded(t *testing.T) {
+	got := availablePresets()
+	for _, want := range []string{"go", "ts-react", "python"} {
+		found := false
+		for _, g := range got {
+			if g == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("availablePresets missing %q; got %v", want, got)
+		}
+	}
+}
+
+// walkFiles returns relative paths (forward slashes) of every file
+// under root, sorted, suitable for snapshot comparison.
+func walkFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestScaffold_DefaultBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, allTargetNames()); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames()); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
@@ -30,7 +30,7 @@ func TestScaffold_DefaultBaseDir(t *testing.T) {
 
 func TestScaffold_CustomBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "specs", false, allTargetNames()); err != nil {
+	if err := scaffold(dir, "specs", false, "", allTargetNames()); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
@@ -49,7 +49,7 @@ func TestScaffold_CustomBaseDir(t *testing.T) {
 
 func TestScaffold_BaseDirDot_WritesAtRoot(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, ".", false, allTargetNames()); err != nil {
+	if err := scaffold(dir, ".", false, "", allTargetNames()); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
@@ -68,7 +68,7 @@ func TestScaffold_BaseDirDot_WritesAtRoot(t *testing.T) {
 
 func TestScaffold_NestedBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, filepath.Join("config", "ai"), false, allTargetNames()); err != nil {
+	if err := scaffold(dir, filepath.Join("config", "ai"), false, "", allTargetNames()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "config", "ai", "agents")); err != nil {
@@ -127,7 +127,7 @@ func TestInitCmd_RejectsExtraArgs(t *testing.T) {
 
 func TestScaffold_Demo_SeedsOneFilePerKind(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", true, allTargetNames()); err != nil {
+	if err := scaffold(dir, "", true, "", allTargetNames()); err != nil {
 		t.Fatal(err)
 	}
 	wantFiles := map[string]string{
@@ -159,7 +159,7 @@ func TestScaffold_Demo_DoesNotOverwriteExistingFiles(t *testing.T) {
 	if err := os.WriteFile(custom, []byte("user content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", true, allTargetNames()); err != nil {
+	if err := scaffold(dir, "", true, "", allTargetNames()); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(custom)
@@ -173,7 +173,7 @@ func TestScaffold_Demo_DoesNotOverwriteExistingFiles(t *testing.T) {
 
 func TestScaffold_NoDemo_LeavesFoldersEmpty(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, allTargetNames()); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames()); err != nil {
 		t.Fatal(err)
 	}
 	for _, kind := range []string{"agents", "skills", "rules", "hooks", "mcps"} {
@@ -208,7 +208,7 @@ func TestScaffold_RefusesIfConfigExists(t *testing.T) {
 		[]byte("version: 1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", false, allTargetNames()); err == nil {
+	if err := scaffold(dir, "", false, "", allTargetNames()); err == nil {
 		t.Error("expected error when config already exists")
 	}
 }

--- a/internal/cli/initdata/presets/go/rules/go-errors.md
+++ b/internal/cli/initdata/presets/go/rules/go-errors.md
@@ -1,0 +1,12 @@
+---
+name: go-errors
+description: Error handling discipline for Go code.
+globs: "**/*.go"
+alwaysApply: true
+---
+
+- Wrap returned errors with context that names the operation: `fmt.Errorf("read %s: %w", path, err)`.
+- Sentinel errors are exported as `ErrXxx`. Compare with `errors.Is`.
+- Custom error types satisfy the `error` interface and are checked with `errors.As`.
+- Do not log and return the same error; pick one. Logging hides the call site.
+- `panic` is for programmer error only (impossible state). User-facing failures return errors.

--- a/internal/cli/initdata/presets/go/rules/go-style.md
+++ b/internal/cli/initdata/presets/go/rules/go-style.md
@@ -1,0 +1,13 @@
+---
+name: go-style
+description: Idiomatic Go style and formatting.
+globs: "**/*.go"
+alwaysApply: true
+---
+
+- `gofmt` clean. Run `goimports` for grouped imports.
+- Prefer the standard library. New external dependencies need a justification in the PR.
+- Errors carry enough context to find the file: `fmt.Errorf("%s: %w", path, err)`.
+- Lower-case package names, no underscores, no plurals.
+- Exported identifiers carry doc comments that begin with the identifier name.
+- Receivers are short (1-2 letters), consistent across methods on the same type.

--- a/internal/cli/initdata/presets/go/rules/go-testing.md
+++ b/internal/cli/initdata/presets/go/rules/go-testing.md
@@ -1,0 +1,13 @@
+---
+name: go-testing
+description: Go test conventions for this project.
+globs: "**/*_test.go"
+alwaysApply: true
+---
+
+- Test names describe behavior, not implementation: `TestEmit_WritesAgentFile`, not `TestEmit1`.
+- Use `t.TempDir()` for filesystem fixtures and restore working directory in cleanup when tests `chdir`.
+- Mark helper functions with `t.Helper()` so failures point at the call site.
+- Prefer table-driven tests when more than two cases share the same setup; one-off cases stay flat.
+- Use `t.Run(name, ...)` so subtests are addressable with `-run name/case`.
+- No global state. No `init()` for test setup. No network calls without a `// requires network` comment and a build tag.

--- a/internal/cli/initdata/presets/python/rules/pytest.md
+++ b/internal/cli/initdata/presets/python/rules/pytest.md
@@ -1,0 +1,13 @@
+---
+name: pytest
+description: pytest conventions.
+globs: "**/test_*.py"
+alwaysApply: true
+---
+
+- File names start with `test_`. Test functions start with `test_`.
+- Use fixtures (`@pytest.fixture`) over `setUp`/`tearDown`. Scope fixtures as narrowly as the test allows.
+- Parametrize with `@pytest.mark.parametrize` instead of looping inside a test.
+- Assert with plain `assert`, never `unittest.TestCase.assertEqual`. pytest's introspection beats both.
+- Use `tmp_path` (built-in fixture) for filesystem tests. Never write to the project root.
+- Skip with reason: `pytest.skip("reason")`. Mark expected failures with `@pytest.mark.xfail(reason=...)`.

--- a/internal/cli/initdata/presets/python/rules/python-style.md
+++ b/internal/cli/initdata/presets/python/rules/python-style.md
@@ -1,0 +1,13 @@
+---
+name: python-style
+description: Pythonic style and formatting.
+globs: "**/*.py"
+alwaysApply: true
+---
+
+- PEP 8 with `ruff` (or `black` + `flake8`). Format on save.
+- Type hints on every public function. `from __future__ import annotations` in libraries that target older runtimes.
+- Prefer dataclasses (`@dataclass(slots=True)` when stability matters) over plain classes for value types.
+- F-strings over `%` and `.format()`. No bare `except:`; catch specific exceptions.
+- Pathlib over `os.path` for new code. `pathlib.Path` is the obvious type for filesystem paths.
+- Imports sorted by `ruff`/`isort`: standard library, third-party, local.

--- a/internal/cli/initdata/presets/python/rules/typing.md
+++ b/internal/cli/initdata/presets/python/rules/typing.md
@@ -1,0 +1,13 @@
+---
+name: typing
+description: Type-checking discipline (mypy / pyright).
+globs: "**/*.py"
+alwaysApply: true
+---
+
+- Run `mypy --strict` (or `pyright` in strict mode) in CI. New code must pass.
+- Public functions and class attributes carry annotations. Private helpers may infer.
+- Use `typing.Final` for module-level constants meant not to be reassigned.
+- Avoid `Any` at module boundaries. Prefer `object`, `TypedDict`, or a `Protocol` for structural typing.
+- `Optional[X]` is `X | None`. Pick one form per project; do not mix.
+- For runtime-only validation, pair static types with `pydantic` or `attrs` rather than handwritten guards.

--- a/internal/cli/initdata/presets/ts-react/rules/react.md
+++ b/internal/cli/initdata/presets/ts-react/rules/react.md
@@ -1,0 +1,13 @@
+---
+name: react
+description: React component conventions.
+globs: "**/*.{tsx,jsx}"
+alwaysApply: true
+---
+
+- Function components only. No class components in new code.
+- One component per file. File name matches the component (`Button.tsx` exports `Button`).
+- Hooks at the top of the body. No conditional hook calls. No hooks inside loops.
+- Props typed as a named `Props` type, not inline. Optional props get explicit defaults.
+- Inline event handlers OK for simple cases; extract when they grow past three lines.
+- Server-bound data lives in a query/state hook (TanStack Query, SWR, Redux); components are presentational.

--- a/internal/cli/initdata/presets/ts-react/rules/testing.md
+++ b/internal/cli/initdata/presets/ts-react/rules/testing.md
@@ -1,0 +1,12 @@
+---
+name: testing
+description: Test conventions for TypeScript + React.
+globs: "**/*.{test,spec}.{ts,tsx}"
+alwaysApply: true
+---
+
+- Vitest or Jest, one runner per repo. Do not mix.
+- Component tests use `@testing-library/react`. Query by accessible role, not by `data-testid`, unless the role is genuinely missing.
+- Avoid snapshot tests for components that change often; assert on the parts you care about.
+- Mock at the network boundary (MSW), not at the module boundary. Module mocks rot.
+- One `describe` per file maximum; nested `describe` is a smell.

--- a/internal/cli/initdata/presets/ts-react/rules/typescript.md
+++ b/internal/cli/initdata/presets/ts-react/rules/typescript.md
@@ -1,0 +1,13 @@
+---
+name: typescript
+description: TypeScript style with strict typing.
+globs: "**/*.{ts,tsx}"
+alwaysApply: true
+---
+
+- `strict: true` in `tsconfig.json`. No implicit `any`, no implicit `this`.
+- Prefer `unknown` over `any` for boundary values; narrow before use.
+- Use `type` for unions and aliases, `interface` for object shapes meant to be extended.
+- Avoid `enum`; use union of string literals (`type Status = "open" | "closed"`).
+- Imports use the project's path aliases when configured; do not write deep relative paths.
+- Public functions carry explicit return types so refactors do not silently widen the surface.

--- a/internal/cli/initdata/presets/ts-react/skills/component-scaffold.md
+++ b/internal/cli/initdata/presets/ts-react/skills/component-scaffold.md
@@ -1,0 +1,19 @@
+---
+name: component-scaffold
+description: Scaffold a new React component file with the project's naming and import conventions. Trigger when the user says "create a component" or "new component".
+---
+
+# Component scaffold
+
+Creates a single `.tsx` file under `src/components/<Name>/` with:
+
+1. A named `Props` type (no inline prop types).
+2. A function component with explicit return type.
+3. Co-located styles file when the project uses CSS modules.
+
+## Steps
+
+1. Ask for the component name (PascalCase).
+2. Ask whether the component owns state or is purely presentational.
+3. Write the file using the project's path-alias imports.
+4. If a barrel `index.ts` exists in the parent folder, append the export.


### PR DESCRIPTION
## Summary

- New `init --preset <name>` flag seeds idiomatic specs for a stack. Ships with `go`, `ts-react`, `python`.
- Presets live under `internal/cli/initdata/presets/<name>/`, embedded via `//go:embed all:initdata/presets`. Adding more is just dropping a directory and updating one snapshot list.
- Composes with `--demo` and `-i`. Existing files are never overwritten, so re-running on a partially-populated tree is safe.
- Unknown preset errors with the available list. Tab completion registered for the flag.
- New contributor doc at `docs/internal/contributing-presets.md`. CLI reference updated.
- Snapshot test per preset (`presetExpectedFiles`) plus tests for unknown-preset, --demo composition, and the no-clobber guarantee.

Closes #47

## Test plan

- [x] `go test -race ./...` all green.
- [x] Manual smoke: `init --preset go`, `init --preset ts-react --demo`, `init --preset wat` (errors as expected).
- [x] Tab completion: `init --preset <TAB>` returns the three names (in zsh).