### PR TITLE
feat: WebAssembly playground (cmd/agnostic-ai-wasm + docs/playground)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Build WASM playground
+        run: GOOS=js GOARCH=wasm go build -o /tmp/agnostic-ai.wasm ./cmd/agnostic-ai-wasm
+
   schema:
     name: Schema drift
     runs-on: ubuntu-latest

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,55 @@
+name: Playground
+
+# Builds the WebAssembly playground and publishes docs/playground/ to
+# GitHub Pages on every release tag and on demand. Manual dispatch lets
+# maintainers republish without cutting a release.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Build playground
+        run: make playground-build
+
+      - name: Report sizes
+        run: |
+          ls -lh docs/playground/
+          gzip -c docs/playground/agnostic-ai.wasm | wc -c | awk '{printf "wasm gzipped: %d bytes\n", $1}'
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/playground
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,9 @@ WARP.md
 # =============================================================================
 /.golangci-cache/
 /tmp/
+
+# =============================================================================
+# Playground build artifacts (rebuilt by `make playground-build` or CI)
+# =============================================================================
+/docs/playground/agnostic-ai.wasm
+/docs/playground/wasm_exec.js

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-race test-shell coverage coverage-html cover lint fmt vet install clean release
+.PHONY: build test test-race test-shell coverage coverage-html cover lint fmt vet install clean release playground-build playground-serve playground-clean
 
 BIN := agnostic-ai
 PKG := ./cmd/agnostic-ai
@@ -50,3 +50,22 @@ release:
 	GOOS=linux   GOARCH=arm64 go build -o dist/$(BIN)-linux-arm64   $(PKG)
 	GOOS=linux   GOARCH=amd64 go build -o dist/$(BIN)-linux-amd64   $(PKG)
 	GOOS=windows GOARCH=amd64 go build -o dist/$(BIN)-windows-amd64.exe $(PKG)
+
+# WASM playground (docs/playground/). Bundles the WebAssembly entry
+# point plus the Go-toolchain wasm_exec.js shim into the static page so
+# it can be served straight from GitHub Pages.
+PLAYGROUND_DIR := docs/playground
+
+playground-build:
+	GOOS=js GOARCH=wasm go build -trimpath -ldflags="-s -w" \
+		-o $(PLAYGROUND_DIR)/agnostic-ai.wasm ./cmd/agnostic-ai-wasm
+	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" $(PLAYGROUND_DIR)/wasm_exec.js
+	@printf "playground built. wasm size: "
+	@ls -lh $(PLAYGROUND_DIR)/agnostic-ai.wasm | awk '{print $$5}'
+
+playground-serve: playground-build
+	@echo "serving $(PLAYGROUND_DIR) at http://127.0.0.1:8080"
+	@cd $(PLAYGROUND_DIR) && python3 -m http.server 8080
+
+playground-clean:
+	rm -f $(PLAYGROUND_DIR)/agnostic-ai.wasm $(PLAYGROUND_DIR)/wasm_exec.js

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ modes. Catch drift earlier with a [pre-commit hook](docs/user/git-hooks.md)
 - **[Targets](docs/user/targets.md)** · what each adapter emits and where.
 - **[Configuration](docs/user/configuration.md)** · `agnostic.config.yaml` reference.
 - **[CLI reference](docs/user/cli-reference.md)** · every flag, every command.
+- **[Playground](docs/playground/)** · paste a spec in your browser, see what every adapter emits live (WASM, runs offline).
 - **[Examples](docs/examples/)** · drop-in templates.
 - **[Contributing](docs/internal/)** · architecture, adding adapters, release process.
 

--- a/cmd/agnostic-ai-wasm/main.go
+++ b/cmd/agnostic-ai-wasm/main.go
@@ -1,0 +1,201 @@
+// Command agnostic-ai-wasm is the WebAssembly entry point used by the
+// in-browser playground. It exposes a single global function,
+// `agnosticAIRender`, that takes one spec body plus a list of targets
+// and returns each adapter's emitted output as a JSON-friendly object.
+//
+// The binary is built with `GOOS=js GOARCH=wasm` and shipped alongside
+// the static playground at docs/playground/. The full adapter registry
+// is linked in, so the playground reflects every target the released
+// CLI supports.
+//
+//go:build js && wasm
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"syscall/js"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+func main() {
+	js.Global().Set("agnosticAIRender", js.FuncOf(render))
+	js.Global().Set("agnosticAITargets", js.FuncOf(listTargets))
+	// Park the goroutine; closing it would invalidate the exported
+	// JS callbacks and break the playground after the first call.
+	select {}
+}
+
+// render is the JS-callable entry point.
+//
+// Args (positional):
+//
+//	0: kind (string)        — one of agent, skill, rule, hook, mcp.
+//	1: body (string)        — full spec source (frontmatter + body).
+//	2: targets (Array<string>) — adapter names to emit.
+//
+// Returns a JS object:
+//
+//	{
+//	  files: [{ target, path, content }],
+//	  errors: [{ target, message }]
+//	}
+func render(_ js.Value, args []js.Value) any {
+	if len(args) != 3 {
+		return jsError(fmt.Errorf("expected 3 args (kind, body, targets), got %d", len(args)))
+	}
+	kindRaw := args[0].String()
+	body := args[1].String()
+	targetsArg := args[2]
+
+	kind, err := normalizeKind(kindRaw)
+	if err != nil {
+		return jsError(err)
+	}
+	targets := jsStringArray(targetsArg)
+	if len(targets) == 0 {
+		return jsError(fmt.Errorf("at least one target required"))
+	}
+
+	entry, err := parseEntry(kind, body)
+	if err != nil {
+		return jsError(err)
+	}
+	if entry.Name == "" {
+		// Adapters use Name as a slug for per-file outputs; falling
+		// back here keeps the playground useful even when the user is
+		// still drafting frontmatter.
+		entry.Name = "untitled"
+		if entry.Meta == nil {
+			entry.Meta = map[string]any{}
+		}
+		entry.Meta["name"] = entry.Name
+	}
+
+	bundle := singleEntryBundleWASM(entry)
+	cfg := defaultPlaygroundConfig(targets)
+
+	files := []any{}
+	errs := []any{}
+	for _, t := range targets {
+		adapter, err := adapters.Resolve(t)
+		if err != nil {
+			errs = append(errs, jsErrorEntry(t, err))
+			continue
+		}
+		adapters.StartCapture()
+		err = adapter.Emit(bundle, cfg, false)
+		captured := adapters.StopCapture()
+		if err != nil {
+			errs = append(errs, jsErrorEntry(t, err))
+			continue
+		}
+		for _, f := range captured {
+			files = append(files, map[string]any{
+				"target":  t,
+				"path":    f.Path,
+				"content": f.Content,
+			})
+		}
+	}
+	return js.ValueOf(map[string]any{
+		"files":  files,
+		"errors": errs,
+	})
+}
+
+func listTargets(_ js.Value, _ []js.Value) any {
+	names := adapters.Names()
+	out := make([]any, 0, len(names))
+	for _, n := range names {
+		out = append(out, n)
+	}
+	return js.ValueOf(out)
+}
+
+func parseEntry(kind spec.Kind, body string) (spec.Entry, error) {
+	switch kind {
+	case spec.KindHook, spec.KindMCP:
+		return spec.ParseYAMLBytes(kind, []byte(body))
+	default:
+		return spec.ParseMarkdownBytes(kind, []byte(body))
+	}
+}
+
+func normalizeKind(raw string) (spec.Kind, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "agent":
+		return spec.KindAgent, nil
+	case "skill":
+		return spec.KindSkill, nil
+	case "rule":
+		return spec.KindRule, nil
+	case "hook":
+		return spec.KindHook, nil
+	case "mcp":
+		return spec.KindMCP, nil
+	}
+	return "", fmt.Errorf("unknown kind %q (expected agent, skill, rule, hook, mcp)", raw)
+}
+
+func singleEntryBundleWASM(e spec.Entry) spec.Bundle {
+	var b spec.Bundle
+	switch e.Kind {
+	case spec.KindAgent:
+		b.Agents = []spec.Entry{e}
+	case spec.KindSkill:
+		b.Skills = []spec.Entry{e}
+	case spec.KindRule:
+		b.Rules = []spec.Entry{e}
+	case spec.KindHook:
+		b.Hooks = []spec.Entry{e}
+	case spec.KindMCP:
+		b.MCPs = []spec.Entry{e}
+	}
+	return b
+}
+
+// defaultPlaygroundConfig fills in source paths and target list using
+// the same defaults the CLI uses on a fresh `init`. Adapters need a
+// non-nil cfg with these fields populated.
+func defaultPlaygroundConfig(targets []string) *config.Config {
+	return &config.Config{
+		Version: 1,
+		Sources: config.Sources{
+			Agents: ".agnostic-ai/agents",
+			Skills: ".agnostic-ai/skills",
+			Rules:  ".agnostic-ai/rules",
+			Hooks:  ".agnostic-ai/hooks",
+			MCPs:   ".agnostic-ai/mcps",
+		},
+		Targets:       targets,
+		OnUnsupported: "warn",
+	}
+}
+
+func jsStringArray(v js.Value) []string {
+	if v.Type() != js.TypeObject {
+		return nil
+	}
+	n := v.Length()
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = v.Index(i).String()
+	}
+	return out
+}
+
+func jsError(err error) any {
+	return js.ValueOf(map[string]any{
+		"files":  []any{},
+		"errors": []any{map[string]any{"target": "", "message": err.Error()}},
+	})
+}
+
+func jsErrorEntry(target string, err error) any {
+	return map[string]any{"target": target, "message": err.Error()}
+}

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -1,0 +1,50 @@
+# Playground
+
+In-browser playground for agnostic-ai. Paste a spec, pick targets, see
+each adapter's emission live. Runs entirely client-side via WebAssembly,
+so the page costs zero server resources and works on any static host.
+
+## Try it
+
+The published page lives at GitHub Pages once the `Playground` workflow
+runs (manual dispatch or release tag). The URL appears in the run
+summary.
+
+## Run locally
+
+```bash
+make playground-build       # compiles the WASM and copies wasm_exec.js
+make playground-serve       # builds, then serves on http://127.0.0.1:8080
+```
+
+`file://` protocol does **not** work — browsers refuse to fetch the
+`.wasm` from a `file://` page. Use the `playground-serve` target or any
+static HTTP server pointed at `docs/playground/`.
+
+## What's in this directory
+
+| File | Purpose |
+|------|---------|
+| `index.html` | Two-pane UI: spec input on the left, emitted outputs on the right. |
+| `style.css` | Layout + dark/light theme. |
+| `playground.js` | Wires up the textarea, target checkboxes, tabs; debounces input. |
+| `wasm_exec.js` | Go toolchain shim. Generated; gitignored. |
+| `agnostic-ai.wasm` | Built from `cmd/agnostic-ai-wasm`. Generated; gitignored. |
+
+## How it works
+
+`cmd/agnostic-ai-wasm/main.go` exposes two globals to JavaScript:
+
+- `agnosticAIRender(kind, body, targets)` returns
+  `{ files: [{target, path, content}], errors: [{target, message}] }`.
+- `agnosticAITargets()` returns the list of every adapter linked into
+  the binary, so the UI can build the target picker dynamically.
+
+Adapters run under capture mode (`adapters.StartCapture()`), so no
+filesystem operations occur — perfect for the WASM sandbox.
+
+## Build size
+
+The current Go-toolchain WASM build clocks in around 5 MB raw, ~1.4 MB
+gzipped. GitHub Pages serves with `Content-Encoding: gzip` automatically,
+so visitors see the gzipped size on the wire.

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>agnostic-ai playground</title>
+    <meta
+      name="description"
+      content="Paste an agnostic-ai spec, pick targets, see what each AI CLI gets — runs entirely in your browser via WebAssembly."
+    />
+    <link rel="stylesheet" href="style.css" />
+    <script src="wasm_exec.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>agnostic-ai playground</h1>
+      <p class="lede">
+        Paste an
+        <a href="https://github.com/Chemaclass/agnostic-ai">agnostic-ai</a> spec
+        on the left, pick targets, and see exactly what each AI CLI receives.
+        Runs entirely in your browser. No server, no upload.
+      </p>
+    </header>
+
+    <main id="app" hidden>
+      <section class="input">
+        <div class="input-controls">
+          <label>
+            Kind
+            <select id="kind">
+              <option value="rule" selected>rule</option>
+              <option value="agent">agent</option>
+              <option value="skill">skill</option>
+              <option value="hook">hook</option>
+              <option value="mcp">mcp</option>
+            </select>
+          </label>
+          <fieldset id="targets" class="targets">
+            <legend>Targets</legend>
+          </fieldset>
+        </div>
+        <textarea
+          id="source"
+          spellcheck="false"
+          aria-label="Spec source"
+        ></textarea>
+      </section>
+      <section class="output">
+        <div class="tabs" id="tabs" role="tablist"></div>
+        <pre id="content" tabindex="0"></pre>
+      </section>
+    </main>
+
+    <p id="status">Loading WebAssembly module (~5 MB, ~1.4 MB gzipped)…</p>
+
+    <footer>
+      <p>
+        Source: <a href="https://github.com/Chemaclass/agnostic-ai">Chemaclass/agnostic-ai</a>
+        ·
+        Reflects the build at deploy time; rebuild on each release.
+      </p>
+    </footer>
+
+    <script src="playground.js"></script>
+  </body>
+</html>

--- a/docs/playground/playground.js
+++ b/docs/playground/playground.js
@@ -1,0 +1,167 @@
+"use strict";
+
+const SAMPLE = `---
+name: conventional-commits
+description: Always use Conventional Commits format.
+globs: "**/*"
+alwaysApply: true
+---
+
+Use Conventional Commits for every commit:
+
+- \`feat:\` new feature
+- \`fix:\` bug fix
+- \`docs:\` documentation only
+- \`refactor:\` code change without feature/fix
+- \`test:\` tests only
+- \`chore:\` build, deps, CI
+
+Subject line under 72 chars. Body explains why, not what.
+`;
+
+const DEFAULT_TARGETS = ["claude", "codex", "cursor", "gemini"];
+
+const $ = (id) => document.getElementById(id);
+const status = $("status");
+const app = $("app");
+const source = $("source");
+const kind = $("kind");
+const targetsBox = $("targets");
+const tabsBox = $("tabs");
+const content = $("content");
+
+let renderResults = [];
+let currentTarget = null;
+
+function setStatus(msg, isError) {
+  if (msg == null) {
+    status.hidden = true;
+    return;
+  }
+  status.hidden = false;
+  status.textContent = msg;
+  status.classList.toggle("error", !!isError);
+}
+
+function buildTargetCheckboxes(allTargets) {
+  targetsBox.querySelectorAll("label").forEach((n) => n.remove());
+  allTargets.forEach((name) => {
+    const id = `target-${name}`;
+    const label = document.createElement("label");
+    label.htmlFor = id;
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.id = id;
+    cb.value = name;
+    cb.checked = DEFAULT_TARGETS.includes(name);
+    cb.addEventListener("change", scheduleRender);
+    label.append(cb, document.createTextNode(name));
+    targetsBox.append(label);
+  });
+}
+
+function selectedTargets() {
+  return Array.from(
+    targetsBox.querySelectorAll('input[type="checkbox"]:checked'),
+  ).map((cb) => cb.value);
+}
+
+function renderTabs() {
+  tabsBox.innerHTML = "";
+  const byTarget = new Map();
+  renderResults.forEach((f) => {
+    if (!byTarget.has(f.target)) byTarget.set(f.target, []);
+    byTarget.get(f.target).push(f);
+  });
+  if (byTarget.size === 0) {
+    content.textContent = "";
+    return;
+  }
+  const targets = Array.from(byTarget.keys()).sort();
+  if (!targets.includes(currentTarget)) currentTarget = targets[0];
+  targets.forEach((t) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.role = "tab";
+    btn.textContent = t;
+    btn.setAttribute("aria-selected", t === currentTarget);
+    btn.addEventListener("click", () => {
+      currentTarget = t;
+      renderTabs();
+    });
+    tabsBox.append(btn);
+  });
+  const files = byTarget.get(currentTarget) || [];
+  content.textContent = files
+    .map((f) => `# ${f.path}\n${f.content}`)
+    .join("\n\n");
+}
+
+let pending = 0;
+function scheduleRender() {
+  const seq = ++pending;
+  setTimeout(() => {
+    if (seq !== pending) return;
+    runRender();
+  }, 80);
+}
+
+function runRender() {
+  const targets = selectedTargets();
+  if (targets.length === 0) {
+    renderResults = [];
+    setStatus("Pick at least one target.");
+    renderTabs();
+    return;
+  }
+  let result;
+  try {
+    result = window.agnosticAIRender(kind.value, source.value, targets);
+  } catch (e) {
+    setStatus(`render failed: ${e.message || e}`, true);
+    return;
+  }
+  if (result.errors && result.errors.length) {
+    const lines = result.errors
+      .map((e) => `${e.target || "(input)"}: ${e.message}`)
+      .join(" · ");
+    setStatus(lines, true);
+  } else {
+    setStatus(null);
+  }
+  renderResults = result.files || [];
+  renderTabs();
+}
+
+async function init() {
+  const go = new Go();
+  let module;
+  try {
+    const resp = await fetch("agnostic-ai.wasm");
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    if (WebAssembly.instantiateStreaming) {
+      module = await WebAssembly.instantiateStreaming(resp, go.importObject);
+    } else {
+      const bytes = await resp.arrayBuffer();
+      module = await WebAssembly.instantiate(bytes, go.importObject);
+    }
+  } catch (e) {
+    setStatus(
+      `failed to load WebAssembly: ${e.message || e}. Run \`make playground-build && make playground-serve\` locally to bundle and serve the page over HTTP (file:// won't work).`,
+      true,
+    );
+    return;
+  }
+  go.run(module.instance);
+
+  const allTargets = window.agnosticAITargets().sort();
+  buildTargetCheckboxes(allTargets);
+  source.value = SAMPLE;
+  source.addEventListener("input", scheduleRender);
+  kind.addEventListener("change", scheduleRender);
+  app.hidden = false;
+  setStatus(null);
+  runRender();
+}
+
+init();

--- a/docs/playground/style.css
+++ b/docs/playground/style.css
@@ -1,0 +1,194 @@
+:root {
+  --bg: #0d1117;
+  --bg-panel: #161b22;
+  --fg: #c9d1d9;
+  --fg-muted: #8b949e;
+  --accent: #58a6ff;
+  --border: #30363d;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #ffffff;
+    --bg-panel: #f6f8fa;
+    --fg: #1f2328;
+    --fg-muted: #57606a;
+    --accent: #0969da;
+    --border: #d0d7de;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 24px 32px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.lede {
+  margin: 6px 0 0;
+  color: var(--fg-muted);
+  max-width: 780px;
+}
+
+main {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--border);
+  min-height: 0;
+}
+
+.input,
+.output {
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.input-controls {
+  padding: 12px 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.input-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--fg-muted);
+}
+
+.targets {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  background: var(--bg-panel);
+}
+
+.targets legend {
+  padding: 0 6px;
+  color: var(--fg-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.targets label {
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+select {
+  background: var(--bg-panel);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font: inherit;
+}
+
+textarea {
+  flex: 1;
+  width: 100%;
+  resize: none;
+  border: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 13px/1.5 var(--mono);
+  padding: 16px;
+  outline: none;
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel);
+  min-height: 44px;
+}
+
+.tabs button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  padding: 4px 10px;
+  font: 12px var(--mono);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.tabs button[aria-selected="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+}
+
+#content {
+  flex: 1;
+  margin: 0;
+  padding: 16px;
+  white-space: pre-wrap;
+  overflow: auto;
+  font: 13px/1.5 var(--mono);
+  color: var(--fg);
+  background: var(--bg);
+}
+
+#status {
+  padding: 12px 32px;
+  margin: 0;
+  color: var(--fg-muted);
+  font-style: italic;
+  border-bottom: 1px solid var(--border);
+}
+
+#status[hidden] {
+  display: none;
+}
+
+#status.error {
+  color: #f85149;
+  font-style: normal;
+}
+
+footer {
+  padding: 16px 32px;
+  color: var(--fg-muted);
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+}

--- a/internal/spec/parse_bytes_test.go
+++ b/internal/spec/parse_bytes_test.go
@@ -1,0 +1,81 @@
+package spec
+
+import "testing"
+
+func TestParseMarkdownBytes_RuleWithFrontmatter(t *testing.T) {
+	body := []byte("---\nname: my-rule\ndescription: short\nglobs: \"**/*\"\nalwaysApply: true\n---\n\nrule body line one.\n")
+	e, err := ParseMarkdownBytes(KindRule, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Kind != KindRule {
+		t.Errorf("kind: want rule, got %s", e.Kind)
+	}
+	if e.Name != "my-rule" {
+		t.Errorf("name: want my-rule, got %q", e.Name)
+	}
+	if e.Description() != "short" {
+		t.Errorf("description: want short, got %q", e.Description())
+	}
+	if e.Body != "rule body line one.\n" {
+		t.Errorf("body: %q", e.Body)
+	}
+}
+
+func TestParseMarkdownBytes_NoFrontmatter(t *testing.T) {
+	e, err := ParseMarkdownBytes(KindRule, []byte("just body, no frontmatter\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Name != "" {
+		t.Errorf("expected empty name when frontmatter missing, got %q", e.Name)
+	}
+	if e.Body != "just body, no frontmatter\n" {
+		t.Errorf("body roundtrip failed: %q", e.Body)
+	}
+}
+
+func TestParseMarkdownBytes_CRLF(t *testing.T) {
+	body := []byte("---\r\nname: crlf\r\n---\r\nbody\r\n")
+	e, err := ParseMarkdownBytes(KindRule, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Name != "crlf" {
+		t.Errorf("CRLF frontmatter not parsed: %q", e.Name)
+	}
+}
+
+func TestParseMarkdownBytes_MalformedYAMLErrors(t *testing.T) {
+	body := []byte("---\nname: ok\nbroken: [unterminated\n---\nbody\n")
+	if _, err := ParseMarkdownBytes(KindRule, body); err == nil {
+		t.Error("expected error for malformed YAML in frontmatter")
+	}
+}
+
+func TestParseYAMLBytes_HookFields(t *testing.T) {
+	body := []byte("name: fmt-hook\nevent: PostToolUse\ncommand: \"echo\"\n")
+	e, err := ParseYAMLBytes(KindHook, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Kind != KindHook {
+		t.Errorf("kind: want hook, got %s", e.Kind)
+	}
+	if e.Name != "fmt-hook" {
+		t.Errorf("name: want fmt-hook, got %q", e.Name)
+	}
+	if got := e.Meta["event"]; got != "PostToolUse" {
+		t.Errorf("event field lost in parse: %v", got)
+	}
+}
+
+func TestParseYAMLBytes_EmptyDocument(t *testing.T) {
+	e, err := ParseYAMLBytes(KindMCP, []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Meta == nil {
+		t.Error("Meta must never be nil after parse, even for empty input")
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -302,6 +302,44 @@ func walkDir(dir, ext string, kind Kind, parse func(string) (Entry, error)) ([]E
 	return entries, nil
 }
 
+// ParseMarkdownBytes parses an in-memory spec document and returns the
+// resulting Entry. Used by callers that have a spec body in hand and
+// no on-disk path (e.g. the WASM playground) — Path is left empty so
+// adapters that emit per-file outputs fall back to the entry's Name.
+//
+// The data must be UTF-8 with optional `---` frontmatter on top.
+func ParseMarkdownBytes(kind Kind, data []byte) (Entry, error) {
+	meta, body, err := splitFrontmatter(normalizeLineEndings(data))
+	if err != nil {
+		return Entry{}, err
+	}
+	name, _ := meta["name"].(string)
+	return Entry{
+		Kind: kind,
+		Name: name,
+		Meta: meta,
+		Body: body,
+	}, nil
+}
+
+// ParseYAMLBytes parses an in-memory hook or MCP spec (pure YAML, no
+// frontmatter) and returns the Entry.
+func ParseYAMLBytes(kind Kind, data []byte) (Entry, error) {
+	var meta map[string]any
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return Entry{}, err
+	}
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	name, _ := meta["name"].(string)
+	return Entry{
+		Kind: kind,
+		Name: name,
+		Meta: meta,
+	}, nil
+}
+
 func parseMarkdown(path string) (Entry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
## Summary

- New `cmd/agnostic-ai-wasm` builds the spec parser plus the full adapter registry as a WebAssembly module. Exposes two JS globals: `agnosticAIRender(kind, body, targets)` and `agnosticAITargets()`.
- `docs/playground/` is a static, single-page UI: paste a spec, pick targets, see what every adapter would emit. Tabs per target with the full file body.
- New `Playground` GitHub workflow publishes `docs/playground/` to GitHub Pages on release tags and on manual dispatch (`workflow_dispatch`). CI also smoke-builds the WASM on every PR to catch breakage.
- New `internal/spec.ParseMarkdownBytes` and `ParseYAMLBytes` for in-memory parsing without filesystem IO. Tested independently.
- `Makefile` adds `playground-build`, `playground-serve`, `playground-clean`. WASM artifact is gitignored.

Closes #43

## Build size

- Raw: ~5 MB
- Gzip: **~1.4 MB** ← under the 2 MB acceptance criterion. (Pages serves with `Content-Encoding: gzip` so visitors see the gzipped figure.)

## Test plan

- [x] `go test -race ./...` all green (8 new spec parser tests).
- [x] `make playground-build` produces working `agnostic-ai.wasm` + `wasm_exec.js`.
- [x] `make playground-serve` opens the page; pasting `rules/conventional-commits.md` shows correct output for every supported target.
- [x] CI build job covers `GOOS=js GOARCH=wasm`.
- [ ] After merge: manually dispatch the `Playground` workflow once to verify the Pages deploy step (requires `pages: write` permission, only available post-merge).