### PR TITLE
feat(cursor): emit agents as Cursor Custom Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **VS Code extension** (#44): first-party extension at `editors/vscode/` (v0.1.0). Schema validation for `agnostic.config.yaml`, command palette entries (`Sync`, `Sync — check for drift`, `Doctor — auto-fix`, `Status`, `Render current spec to a target`), codelens above each spec with one `Render to <target>` action per configured target, and a status bar item polling `sync --check --json` for the current drift count. Shells out to the user's installed `agnostic-ai`; ships no bundled binary.
 - **Pre-commit hook recipes** (#39): new `docs/user/git-hooks.md` with copy-paste configs for `pre-commit` (Python), `lefthook`, and `husky` + `lint-staged`. Each runs `agnostic-ai sync --check` only when a spec or `agnostic.config.yaml` is staged. Linked from the README CI section.
 
+- **Cursor Custom Commands** (#104): when `outputs.cursor.commands-dir` is set, each agent emits as a Cursor Custom Command (Markdown with `description`/`model` frontmatter) at that path, in addition to the existing `.cursor/rules/<name>.mdc` rule form.
+
 ### Changed
 - **`sync --watch` reaction time** (#36): swapped the 200 ms mtime poll for fsnotify with a 50 ms debounce. Idle CPU drops to zero between events; saves trigger a re-sync in under 100 ms. Polling backend kept as an automatic fallback when `fsnotify.NewWatcher` or `Add` fails.
 - **Code of Conduct contact**: `conduct@chemaclass.dev` → `agnostic-ai@chemaclass.es`.

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -90,11 +90,14 @@ When MCP and/or hook entries are present, the adapter writes (or updates) `.gemi
 
 ```
 .cursor/rules/<name>.mdc
+.cursor/commands/<name>.md           # one per agent, only when commands-dir is set
 ```
 
-Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.cursor.mcp-file` (default `.cursor/mcp.json`).
+Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.cursor.commands-dir` (default empty — opt-in), `outputs.cursor.mcp-file` (default `.cursor/mcp.json`).
 
 Rules emit with `alwaysApply: true`; agents as rules with `alwaysApply: false`. Override in spec frontmatter.
+
+When `outputs.cursor.commands-dir` is set, each agent additionally emits as a [Cursor Custom Command](https://docs.cursor.com/agent/custom-commands): a Markdown file with optional `description` and `model` frontmatter. The rule-form emission (`.cursor/rules/<name>.mdc`) still happens, so existing setups keep working.
 
 ### GitHub Copilot (`copilot`)
 

--- a/internal/adapters/cursor/cursor.go
+++ b/internal/adapters/cursor/cursor.go
@@ -35,7 +35,10 @@ func New() *Adapter { return &Adapter{} }
 func (Adapter) Name() string { return target }
 
 // Emit writes one .mdc per rule, agent, and skill, plus an
-// `.cursor/mcp.json` when MCP entries exist.
+// `.cursor/mcp.json` when MCP entries exist. When
+// `outputs.cursor.commands-dir` is set, also writes one Cursor Custom
+// Command per agent at that directory; the rule-form emission still
+// happens so users that depend on it keep working.
 func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
 		return err
@@ -49,7 +52,36 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	}, dryRun); err != nil {
 		return err
 	}
+	if commandsDir := emit.OutputCommandsDir(cfg, target, ""); commandsDir != "" {
+		for _, a := range b.Agents {
+			path := commandsDir + "/" + a.Name + ".md"
+			if err := emit.WriteFile(path, command(a), dryRun); err != nil {
+				return err
+			}
+		}
+	}
 	return emit.WriteMCPFile(b.MCPs, emit.MCPSchemaServersMap, emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)
+}
+
+// command renders a Cursor Custom Command file. The Cursor docs
+// describe these as Markdown with optional frontmatter (`description`,
+// `model`); the body is the prompt the IDE sends when the user invokes
+// the command.
+func command(e spec.Entry) string {
+	m := emit.ResolveMeta(e.Meta, target)
+	desc, _ := m["description"].(string)
+	model, _ := m["model"].(string)
+	var b strings.Builder
+	b.WriteString("---\n")
+	if desc != "" {
+		b.WriteString("description: " + desc + "\n")
+	}
+	if model != "" {
+		b.WriteString("model: " + model + "\n")
+	}
+	b.WriteString("---\n\n")
+	b.WriteString(e.Body)
+	return b.String()
 }
 
 func mdc(e spec.Entry, alwaysApplyDefault bool) string {

--- a/internal/adapters/cursor/cursor_test.go
+++ b/internal/adapters/cursor/cursor_test.go
@@ -123,3 +123,56 @@ func TestEmit_SkillWritesMdcFile(t *testing.T) {
 		t.Errorf("skill should default alwaysApply=false: %s", got)
 	}
 }
+
+func TestEmit_CommandsDirEmitsAgentAsCommand(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			target: {CommandsDir: ".cursor/commands"},
+		},
+	}
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "code-reviewer", Meta: map[string]any{
+			"description": "reviews code",
+			"model":       "sonnet-4-6",
+		}, Body: "Body of the prompt.\n"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	commandPath := filepath.Join(dir, ".cursor/commands/code-reviewer.md")
+	got, err := os.ReadFile(commandPath)
+	if err != nil {
+		t.Fatalf("expected command file at %s: %v", commandPath, err)
+	}
+	if !strings.Contains(string(got), "description: reviews code") {
+		t.Errorf("missing description in command: %s", got)
+	}
+	if !strings.Contains(string(got), "model: sonnet-4-6") {
+		t.Errorf("missing model in command: %s", got)
+	}
+	if !strings.Contains(string(got), "Body of the prompt.") {
+		t.Errorf("missing body in command: %s", got)
+	}
+	// Rule-form emission must still happen (back-compat).
+	if _, err := os.Stat(filepath.Join(dir, ".cursor/rules/code-reviewer.mdc")); err != nil {
+		t.Errorf("rule-form emission must remain when commands-dir is set: %v", err)
+	}
+}
+
+func TestEmit_NoCommandsDirSkipsCommandEmission(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "agent1", Meta: map[string]any{}, Body: "x"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".cursor/commands/agent1.md")); err == nil {
+		t.Error("commands dir not configured; should not emit command file")
+	}
+}


### PR DESCRIPTION
## Summary

When \`outputs.cursor.commands-dir\` is set, each agent additionally writes to \`<commands-dir>/<name>.md\` as a [Cursor Custom Command](https://docs.cursor.com/agent/custom-commands): Markdown with optional \`description\` and \`model\` frontmatter, body becomes the prompt.

The existing \`.cursor/rules/<name>.mdc\` rule-form emission keeps happening, so users on the current layout don't see surprises. New path is opt-in via the config knob.

Closes #104

## Test plan

- [x] \`go test -race ./...\` all green.
- [x] 2 new tests: \`TestEmit_CommandsDirEmitsAgentAsCommand\` (config set → command file emitted, rule form still present) and \`TestEmit_NoCommandsDirSkipsCommandEmission\` (no config → no command file).
- [x] \`docs/user/targets.md\` and \`CHANGELOG.md\` updated.