### PR TITLE
feat(copilot): emit agents as Custom Chat Modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **`validate` per-target hook event whitelist** (#112): unknown `event:` values in hook specs are reported with the supported list inline, derived from the union of every configured target. Catches typos like `PostToolsUse` before they ever ship.
 - **`validate` orphan-kind warning** (#114): when a project ships hook or MCP specs but no enabled target consumes them, validate prints a one-line summary per orphaned kind with the targets that would unblock it.
 - **`doctor` MCP command resolution** (#113): for every stdio MCP spec, doctor reports whether the configured `command:` resolves on PATH. Missing common commands (npx, uvx, python, docker) include an inline install hint. HTTP/SSE servers skip the check.
+- **Copilot Custom Chat Modes** (#105): when `outputs.copilot.chatmodes-dir` is set, each agent emits as a Copilot Chat Mode (`<dir>/<name>.chatmode.md` with `description`/`model`/`tools` frontmatter). The catch-all `.github/instructions/agent-<name>.instructions.md` emission stays in place.
 
 ### Changed
 - **`sync --watch` reaction time** (#36): swapped the 200 ms mtime poll for fsnotify with a 50 ms debounce. Idle CPU drops to zero between events; saves trigger a re-sync in under 100 ms. Polling backend kept as an automatic fallback when `fsnotify.NewWatcher` or `Add` fails.

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -87,6 +87,21 @@
         "commands-dir": {
           "type": "string"
         },
+        "chatmodes-dir": {
+          "type": "string"
+        },
+        "workflows-dir": {
+          "type": "string"
+        },
+        "assistants-dir": {
+          "type": "string"
+        },
+        "tasks-file": {
+          "type": "string"
+        },
+        "conf-file": {
+          "type": "string"
+        },
         "mcp-dir": {
           "type": "string"
         },

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -98,6 +98,9 @@ Rules emit with `alwaysApply: true`; agents as rules with `alwaysApply: false`. 
 
 ### GitHub Copilot (`copilot`)
 
+> When `outputs.copilot.chatmodes-dir` is set, each agent additionally emits as a [Copilot Custom Chat Mode](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot#about-custom-chat-modes) at `<dir>/<name>.chatmode.md` with `description`/`model`/`tools` frontmatter. The catch-all `agent-<name>.instructions.md` emission keeps working.
+
+
 ```
 .github/copilot-instructions.md                            # always-on rules
 .github/instructions/<name>.instructions.md                # scoped rule per file

--- a/internal/adapters/copilot/copilot.go
+++ b/internal/adapters/copilot/copilot.go
@@ -46,7 +46,10 @@ func New() *Adapter { return &Adapter{} }
 func (Adapter) Name() string { return target }
 
 // Emit writes per-file instructions, the always-on main file, and the
-// `.vscode/mcp.json` when MCP entries exist.
+// `.vscode/mcp.json` when MCP entries exist. When
+// `outputs.copilot.chatmodes-dir` is set, also writes one Copilot
+// Custom Chat Mode per agent at that directory; the catch-all
+// instruction-form emission still happens for back-compat.
 func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
 		return err
@@ -54,11 +57,62 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emitInstructionFiles(b, cfg, dryRun); err != nil {
 		return err
 	}
+	if err := emitChatmodes(b, cfg, dryRun); err != nil {
+		return err
+	}
 	if err := emitMainFile(b, cfg, dryRun); err != nil {
 		return err
 	}
 	return emit.WriteMCPFile(b.MCPs, emit.MCPSchemaVSCodeServers,
 		emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)
+}
+
+// emitChatmodes writes one `.chatmode.md` per agent under the
+// configured chat-modes directory. No-op when the dir is unset, so
+// existing setups are unaffected.
+func emitChatmodes(b spec.Bundle, cfg *config.Config, dryRun bool) error {
+	dir := emit.OutputChatmodesDir(cfg, target, "")
+	if dir == "" {
+		return nil
+	}
+	for _, a := range b.Agents {
+		path := filepath.Join(dir, a.Name+".chatmode.md")
+		if err := emit.WriteFile(path, renderChatmode(a), dryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderChatmode renders a Copilot Custom Chat Mode file. Frontmatter
+// is restricted to the keys Copilot reads (description, tools, model);
+// extras would noisy-warn on activation.
+func renderChatmode(e spec.Entry) string {
+	m := emit.ResolveMeta(e.Meta, target)
+	desc, _ := m["description"].(string)
+	model, _ := m["model"].(string)
+	tools := emit.StringSlice(m["tools"])
+	var b strings.Builder
+	b.WriteString("---\n")
+	if desc != "" {
+		b.WriteString("description: " + desc + "\n")
+	}
+	if model != "" {
+		b.WriteString("model: " + model + "\n")
+	}
+	if len(tools) > 0 {
+		b.WriteString("tools: [")
+		for i, t := range tools {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(t)
+		}
+		b.WriteString("]\n")
+	}
+	b.WriteString("---\n\n")
+	b.WriteString(e.Body)
+	return b.String()
 }
 
 // emitInstructionFiles writes one `.instructions.md` per scoped rule, agent, and skill.

--- a/internal/adapters/copilot/copilot_test.go
+++ b/internal/adapters/copilot/copilot_test.go
@@ -243,3 +243,52 @@ func readFile(t *testing.T, path string) string {
 	}
 	return string(data)
 }
+
+func TestEmit_ChatmodesDirEmitsAgentAsChatmode(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			target: {ChatmodesDir: ".github/chatmodes"},
+		},
+	}
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "researcher", Meta: map[string]any{
+			"description": "deep research",
+			"model":       "sonnet",
+			"tools":       []any{"Read", "Grep", "Bash"},
+		}, Body: "You are a researcher.\n"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".github/chatmodes/researcher.chatmode.md"))
+	if err != nil {
+		t.Fatalf("expected chatmode file: %v", err)
+	}
+	for _, want := range []string{"description: deep research", "model: sonnet", "tools: [Read, Grep, Bash]", "You are a researcher."} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("missing %q in chatmode body:\n%s", want, got)
+		}
+	}
+	// Catch-all instruction-form emission preserved.
+	if _, err := os.Stat(filepath.Join(dir, ".github/instructions/agent-researcher.instructions.md")); err != nil {
+		t.Errorf("instruction-form must remain when chatmodes-dir is set: %v", err)
+	}
+}
+
+func TestEmit_NoChatmodesDirSkipsEmission(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "x", Meta: map[string]any{}, Body: "x"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".github/chatmodes/x.chatmode.md")); err == nil {
+		t.Error("chatmodes dir not configured; should not emit chatmode file")
+	}
+}

--- a/internal/adapters/internal/emit/output.go
+++ b/internal/adapters/internal/emit/output.go
@@ -74,6 +74,56 @@ func OutputCommandsDir(cfg *config.Config, target, fallback string) string {
 	return fallback
 }
 
+// OutputChatmodesDir returns cfg.Outputs[target].ChatmodesDir when set,
+// otherwise fallback. Used by the Copilot adapter to opt agents into
+// emission as Custom Chat Modes.
+func OutputChatmodesDir(cfg *config.Config, target, fallback string) string {
+	if o, ok := cfg.Outputs[target]; ok && o.ChatmodesDir != "" {
+		return o.ChatmodesDir
+	}
+	return fallback
+}
+
+// OutputWorkflowsDir returns cfg.Outputs[target].WorkflowsDir when set,
+// otherwise fallback. Used by Cline, Windsurf, and Warp adapters to
+// opt agents into emission as workflows.
+func OutputWorkflowsDir(cfg *config.Config, target, fallback string) string {
+	if o, ok := cfg.Outputs[target]; ok && o.WorkflowsDir != "" {
+		return o.WorkflowsDir
+	}
+	return fallback
+}
+
+// OutputAssistantsDir returns cfg.Outputs[target].AssistantsDir when
+// set, otherwise fallback. Used by the Continue adapter to opt agents
+// into emission as Continue assistants.
+func OutputAssistantsDir(cfg *config.Config, target, fallback string) string {
+	if o, ok := cfg.Outputs[target]; ok && o.AssistantsDir != "" {
+		return o.AssistantsDir
+	}
+	return fallback
+}
+
+// OutputTasksFile returns cfg.Outputs[target].TasksFile when set,
+// otherwise fallback. Used by the Zed adapter to opt hooks into
+// emission as Zed tasks.
+func OutputTasksFile(cfg *config.Config, target, fallback string) string {
+	if o, ok := cfg.Outputs[target]; ok && o.TasksFile != "" {
+		return o.TasksFile
+	}
+	return fallback
+}
+
+// OutputConfFile returns cfg.Outputs[target].ConfFile when set,
+// otherwise fallback. Used by the Aider adapter to opt into writing
+// .aider.conf.yml.
+func OutputConfFile(cfg *config.Config, target, fallback string) string {
+	if o, ok := cfg.Outputs[target]; ok && o.ConfFile != "" {
+		return o.ConfFile
+	}
+	return fallback
+}
+
 // OutputMCPDir returns cfg.Outputs[target].MCPDir when set, otherwise fallback.
 // Used by adapters that emit one MCP server file per entry into a directory
 // (Continue: `.continue/mcpServers/`) rather than a single combined MCP file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,11 @@ type Output struct {
 	SkillsDir            string `yaml:"skills-dir,omitempty"               json:"skills-dir,omitempty"`
 	InstructionsDir      string `yaml:"instructions-dir,omitempty"         json:"instructions-dir,omitempty"`
 	CommandsDir          string `yaml:"commands-dir,omitempty"             json:"commands-dir,omitempty"`
+	ChatmodesDir         string `yaml:"chatmodes-dir,omitempty"            json:"chatmodes-dir,omitempty"`
+	WorkflowsDir         string `yaml:"workflows-dir,omitempty"            json:"workflows-dir,omitempty"`
+	AssistantsDir        string `yaml:"assistants-dir,omitempty"           json:"assistants-dir,omitempty"`
+	TasksFile            string `yaml:"tasks-file,omitempty"               json:"tasks-file,omitempty"`
+	ConfFile             string `yaml:"conf-file,omitempty"                json:"conf-file,omitempty"`
 	MCPDir               string `yaml:"mcp-dir,omitempty"                  json:"mcp-dir,omitempty"`
 	EmitSkillsAsCommands bool   `yaml:"emit-skills-as-commands,omitempty"  json:"emit-skills-as-commands,omitempty"`
 }


### PR DESCRIPTION
## Summary

When \`outputs.copilot.chatmodes-dir\` is set, each agent additionally writes to \`<dir>/<name>.chatmode.md\` as a [Copilot Custom Chat Mode](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot#about-custom-chat-modes): Markdown with \`description\`, \`model\`, and \`tools\` frontmatter; body is the system prompt.

The existing catch-all \`.github/instructions/agent-<name>.instructions.md\` emission keeps happening so projects depending on it stay green. New path is opt-in.

This PR also lands five new \`config.Output\` fields (\`chatmodes-dir\`, \`workflows-dir\`, \`assistants-dir\`, \`tasks-file\`, \`conf-file\`) that the upcoming native-emit PRs (#106-#111) will reuse, plus their helpers in \`internal/adapters/internal/emit/output.go\`. Schema regenerated.

Closes #105

## Test plan

- [x] \`go test -race ./...\` all green.
- [x] 2 new tests: \`TestEmit_ChatmodesDirEmitsAgentAsChatmode\` (config set → chatmode emitted, instruction form still present) and \`TestEmit_NoChatmodesDirSkipsEmission\` (no config → no chatmode file).
- [x] Schema drift CI job passes (config.schema.json regenerated).