### PR TITLE
feat(cline): emit agents as Cline Workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Copilot Custom Chat Modes** (#105): when `outputs.copilot.chatmodes-dir` is set, each agent emits as a Copilot Chat Mode (`<dir>/<name>.chatmode.md` with `description`/`model`/`tools` frontmatter). The catch-all `.github/instructions/agent-<name>.instructions.md` emission stays in place.
 
 - **Cursor Custom Commands** (#104): when `outputs.cursor.commands-dir` is set, each agent emits as a Cursor Custom Command (Markdown with `description`/`model` frontmatter) at that path, in addition to the existing `.cursor/rules/<name>.mdc` rule form.
+- **Cline Workflows** (#106): when `outputs.cline.workflows-dir` is set, each agent emits as a Cline Workflow (`<dir>/<name>.md`, invokable in chat as `/<name>.md`). The italic description prefixes the body when present. The existing `.clinerules/agent-<name>.md` rule-form emission stays in place.
 
 ### Changed
 - **`sync --watch` reaction time** (#36): swapped the 200 ms mtime poll for fsnotify with a 50 ms debounce. Idle CPU drops to zero between events; saves trigger a re-sync in under 100 ms. Polling backend kept as an automatic fallback when `fsnotify.NewWatcher` or `Add` fails.

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -12,7 +12,7 @@ Each adapter emits in its tool's native format — separate files where the tool
 | **cursor**      | as `.mdc` (alwaysApply: false) | as `.mdc` (`skill-<name>.mdc`) | `.cursor/rules/*.mdc` | - | `.cursor/mcp.json` |
 | **copilot**     | `.github/instructions/agent-<name>.instructions.md` | `.github/instructions/skill-<name>.instructions.md` | `.github/instructions/<name>.instructions.md` + `.github/copilot-instructions.md` (always-on) | - | `.vscode/mcp.json` |
 | **aider**       | merged in `CONVENTIONS.md` | listed in `CONVENTIONS.md` | `CONVENTIONS.md` | - | - |
-| **cline**       | as `.md` rule       | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - |
+| **cline**       | as `.md` rule (+ `.clinerules/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - |
 | **windsurf**    | as `.md` rule       | as `.md` (`skill-<name>.md`) | `.windsurf/rules/*.md`   | -     | - |
 | **continue**    | as `.md` rule       | as `.md` (`skill-<name>.md`) | `.continue/rules/*.md`   | -     | `.continue/mcpServers/*.yaml` |
 | **amp**         | `.agents/commands/<name>.md` | listed in `AGENTS.md` (or `.agents/commands/skill-<name>.md` w/ opt-in) | `AGENTS.md` (nested per-dir by scope/globs) | - | `.amp/settings.json` (`amp.mcpServers`) |
@@ -132,9 +132,12 @@ Pair with `aider --read CONVENTIONS.md` or add to `.aider.conf.yml`.
 
 ```
 .clinerules/<name>.md
+.clinerules/workflows/<name>.md      # one per agent, only when workflows-dir is set
 ```
 
-Config key: `outputs.cline.rules-dir` (default `.clinerules`).
+Config keys: `outputs.cline.rules-dir` (default `.clinerules`), `outputs.cline.workflows-dir` (default empty — opt-in).
+
+When `outputs.cline.workflows-dir` is set, each agent additionally emits as a [Cline Workflow](https://docs.cline.bot/features/workflows): a Markdown file invokable from chat as `/<name>.md`. The italic description prefixes the body when present. The rule-form emission (`.clinerules/agent-<name>.md`) still happens, so existing setups keep working.
 
 ### Windsurf (`windsurf`)
 

--- a/internal/adapters/cline/cline.go
+++ b/internal/adapters/cline/cline.go
@@ -1,7 +1,14 @@
 // Package cline emits .clinerules/*.md for the Cline VSCode extension.
+//
+// Rules and agents emit as `.clinerules/*.md` (always-on). When
+// `outputs.cline.workflows-dir` is set, each agent additionally emits
+// as a Cline Workflow at `<dir>/<name>.md`, invokable in chat as
+// `/<name>.md` (Cline's slash-command surface for workflows).
 package cline
 
 import (
+	"path/filepath"
+
 	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
@@ -27,12 +34,46 @@ func New() *Adapter { return &Adapter{} }
 func (Adapter) Name() string { return target }
 
 // Emit writes one .md per rule and per agent into the rules directory.
+// When `outputs.cline.workflows-dir` is set, each agent additionally
+// emits as a Cline Workflow at `<dir>/<name>.md`; the existing
+// `.clinerules/agent-<name>.md` rule-form emission stays in place so
+// users that depend on it keep working.
 func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
 		return err
 	}
-	return emit.RulesDirectory(b, emit.RulesDirOpts{
+	if err := emit.RulesDirectory(b, emit.RulesDirOpts{
 		Dir:         emit.OutputRulesDir(cfg, target, defaultDir),
 		AgentPrefix: "agent-",
-	}, dryRun)
+	}, dryRun); err != nil {
+		return err
+	}
+	return emitWorkflows(b, cfg, dryRun)
+}
+
+// emitWorkflows writes one workflow per agent under the configured
+// workflows directory. No-op when the dir is unset.
+func emitWorkflows(b spec.Bundle, cfg *config.Config, dryRun bool) error {
+	dir := emit.OutputWorkflowsDir(cfg, target, "")
+	if dir == "" {
+		return nil
+	}
+	for _, a := range b.Agents {
+		path := filepath.Join(dir, a.Name+".md")
+		if err := emit.WriteFile(path, renderWorkflow(a), dryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderWorkflow returns the Markdown body for a Cline Workflow file.
+// Cline workflows are plain Markdown with no required frontmatter; the
+// description (when present) prefixes the body as an italic line so
+// users can see at a glance what the workflow does when listed.
+func renderWorkflow(e spec.Entry) string {
+	if d := e.Description(); d != "" {
+		return "_" + d + "_\n\n" + e.Body
+	}
+	return e.Body
 }

--- a/internal/adapters/cline/cline_test.go
+++ b/internal/adapters/cline/cline_test.go
@@ -3,6 +3,7 @@ package cline
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -45,5 +46,62 @@ func TestEmit_NestedScopeRoutesUnderSubdir(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "backend/api/.clinerules/auth.md")); err != nil {
 		t.Errorf("expected nested clinerules: %v", err)
+	}
+}
+
+func TestEmit_WorkflowsDirEmitsAgentsAsWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindAgent,
+			Name: "ship-it",
+			Meta: map[string]any{"description": "open and merge a PR"},
+			Body: "Run the release.",
+		},
+		{Kind: spec.KindRule, Name: "r1", Body: "rule body"},
+	}
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"cline": {WorkflowsDir: ".clinerules/workflows"},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+
+	wfPath := filepath.Join(dir, ".clinerules/workflows/ship-it.md")
+	got, err := os.ReadFile(wfPath)
+	if err != nil {
+		t.Fatalf("missing workflow: %v", err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "_open and merge a PR_") {
+		t.Errorf("workflow missing description italic: %q", body)
+	}
+	if !strings.Contains(body, "Run the release.") {
+		t.Errorf("workflow missing body: %q", body)
+	}
+
+	// Rule-form emission still happens for back-compat.
+	if _, err := os.Stat(filepath.Join(dir, ".clinerules/agent-ship-it.md")); err != nil {
+		t.Errorf("rule-form agent missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".clinerules/r1.md")); err != nil {
+		t.Errorf("rule missing: %v", err)
+	}
+}
+
+func TestEmit_NoWorkflowsDirNoEmit(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{{Kind: spec.KindAgent, Name: "ag1", Body: "agent"}}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".clinerules/workflows")); !os.IsNotExist(err) {
+		t.Errorf("expected no workflows dir; err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- New opt-in `outputs.cline.workflows-dir`: when set, each agent additionally emits as a [Cline Workflow](https://docs.cline.bot/features/workflows) at `<dir>/<name>.md`, invokable in chat as `/<name>.md`.
- Italic description prefixes the body when present.
- Existing `.clinerules/agent-<name>.md` rule-form emission preserved (back-compat).

Closes #106

## Test plan
- [x] `go test ./internal/adapters/cline/...`
- [x] `go test ./...`
- [x] `go run ./cmd/schemagen` clean (new key already in shared `Output` struct)