### PR TITLE
feat(windsurf): emit agents as Windsurf Workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Cursor Custom Commands** (#104): when `outputs.cursor.commands-dir` is set, each agent emits as a Cursor Custom Command (Markdown with `description`/`model` frontmatter) at that path, in addition to the existing `.cursor/rules/<name>.mdc` rule form.
 - **Cline Workflows** (#106): when `outputs.cline.workflows-dir` is set, each agent emits as a Cline Workflow (`<dir>/<name>.md`, invokable in chat as `/<name>.md`). The italic description prefixes the body when present. The existing `.clinerules/agent-<name>.md` rule-form emission stays in place.
+- **Windsurf Workflows** (#107): when `outputs.windsurf.workflows-dir` is set, each agent emits as a Windsurf Workflow (`<dir>/<name>.md` with `description` frontmatter), invokable in Cascade as `/<name>`. The existing `.windsurf/rules/agent-<name>.md` rule-form emission stays in place.
 
 ### Changed
 - **`sync --watch` reaction time** (#36): swapped the 200 ms mtime poll for fsnotify with a 50 ms debounce. Idle CPU drops to zero between events; saves trigger a re-sync in under 100 ms. Polling backend kept as an automatic fallback when `fsnotify.NewWatcher` or `Add` fails.

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -13,7 +13,7 @@ Each adapter emits in its tool's native format — separate files where the tool
 | **copilot**     | `.github/instructions/agent-<name>.instructions.md` | `.github/instructions/skill-<name>.instructions.md` | `.github/instructions/<name>.instructions.md` + `.github/copilot-instructions.md` (always-on) | - | `.vscode/mcp.json` |
 | **aider**       | merged in `CONVENTIONS.md` | listed in `CONVENTIONS.md` | `CONVENTIONS.md` | - | - |
 | **cline**       | as `.md` rule (+ `.clinerules/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - |
-| **windsurf**    | as `.md` rule       | as `.md` (`skill-<name>.md`) | `.windsurf/rules/*.md`   | -     | - |
+| **windsurf**    | as `.md` rule (+ `.windsurf/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.windsurf/rules/*.md`   | -     | - |
 | **continue**    | as `.md` rule       | as `.md` (`skill-<name>.md`) | `.continue/rules/*.md`   | -     | `.continue/mcpServers/*.yaml` |
 | **amp**         | `.agents/commands/<name>.md` | listed in `AGENTS.md` (or `.agents/commands/skill-<name>.md` w/ opt-in) | `AGENTS.md` (nested per-dir by scope/globs) | - | `.amp/settings.json` (`amp.mcpServers`) |
 | **zed**         | merged in `.rules` | listed in `.rules` | `.rules` | - | `.zed/settings.json` (`context_servers`) |
@@ -143,9 +143,12 @@ When `outputs.cline.workflows-dir` is set, each agent additionally emits as a [C
 
 ```
 .windsurf/rules/<name>.md
+.windsurf/workflows/<name>.md        # one per agent, only when workflows-dir is set
 ```
 
-Config key: `outputs.windsurf.rules-dir` (default `.windsurf/rules`).
+Config keys: `outputs.windsurf.rules-dir` (default `.windsurf/rules`), `outputs.windsurf.workflows-dir` (default empty — opt-in).
+
+When `outputs.windsurf.workflows-dir` is set, each agent additionally emits as a [Windsurf Workflow](https://docs.windsurf.com/windsurf/cascade/workflows): a Markdown file with `description` frontmatter, invokable in Cascade as `/<name>`. The rule-form emission (`.windsurf/rules/agent-<name>.md`) still happens, so existing setups keep working.
 
 ### Continue (`continue`)
 

--- a/internal/adapters/windsurf/windsurf.go
+++ b/internal/adapters/windsurf/windsurf.go
@@ -1,7 +1,15 @@
 // Package windsurf emits .windsurf/rules/*.md for the Windsurf editor.
+//
+// Rules and agents emit as `.windsurf/rules/*.md` (always-on). When
+// `outputs.windsurf.workflows-dir` is set, each agent additionally
+// emits as a Windsurf Workflow at `<dir>/<name>.md`, invokable in
+// Cascade chat as `/<name>`.
 package windsurf
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
@@ -27,12 +35,50 @@ func New() *Adapter { return &Adapter{} }
 func (Adapter) Name() string { return target }
 
 // Emit writes one .md per rule and per agent into the rules directory.
+// When `outputs.windsurf.workflows-dir` is set, each agent additionally
+// emits as a Windsurf Workflow at `<dir>/<name>.md`; the existing
+// `.windsurf/rules/agent-<name>.md` rule-form emission stays in place
+// so users that depend on it keep working.
 func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
 		return err
 	}
-	return emit.RulesDirectory(b, emit.RulesDirOpts{
+	if err := emit.RulesDirectory(b, emit.RulesDirOpts{
 		Dir:         emit.OutputRulesDir(cfg, target, defaultDir),
 		AgentPrefix: "agent-",
-	}, dryRun)
+	}, dryRun); err != nil {
+		return err
+	}
+	return emitWorkflows(b, cfg, dryRun)
+}
+
+// emitWorkflows writes one workflow per agent under the configured
+// workflows directory. No-op when the dir is unset.
+func emitWorkflows(b spec.Bundle, cfg *config.Config, dryRun bool) error {
+	dir := emit.OutputWorkflowsDir(cfg, target, "")
+	if dir == "" {
+		return nil
+	}
+	for _, a := range b.Agents {
+		path := filepath.Join(dir, a.Name+".md")
+		if err := emit.WriteFile(path, renderWorkflow(a), dryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderWorkflow renders a Windsurf Workflow file. Frontmatter holds
+// the `description` Cascade shows in the slash-command picker; the
+// body is the prompt the agent runs when the workflow is invoked.
+func renderWorkflow(e spec.Entry) string {
+	desc := e.Description()
+	var b strings.Builder
+	b.WriteString("---\n")
+	if desc != "" {
+		b.WriteString("description: " + desc + "\n")
+	}
+	b.WriteString("---\n\n")
+	b.WriteString(e.Body)
+	return b.String()
 }

--- a/internal/adapters/windsurf/windsurf_test.go
+++ b/internal/adapters/windsurf/windsurf_test.go
@@ -3,6 +3,7 @@ package windsurf
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -30,5 +31,62 @@ func TestEmit_WritesRulesAndAgents(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(dir, p)); err != nil {
 			t.Errorf("missing %s", p)
 		}
+	}
+}
+
+func TestEmit_WorkflowsDirEmitsAgentsAsWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindAgent,
+			Name: "ship-it",
+			Meta: map[string]any{"description": "open and merge a PR"},
+			Body: "Run the release.",
+		},
+		{Kind: spec.KindRule, Name: "r1", Body: "rule body"},
+	}
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"windsurf": {WorkflowsDir: ".windsurf/workflows"},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+
+	wfPath := filepath.Join(dir, ".windsurf/workflows/ship-it.md")
+	got, err := os.ReadFile(wfPath)
+	if err != nil {
+		t.Fatalf("missing workflow: %v", err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "description: open and merge a PR") {
+		t.Errorf("workflow missing description frontmatter: %q", body)
+	}
+	if !strings.Contains(body, "Run the release.") {
+		t.Errorf("workflow missing body: %q", body)
+	}
+
+	// Rule-form emission still happens for back-compat.
+	if _, err := os.Stat(filepath.Join(dir, ".windsurf/rules/agent-ship-it.md")); err != nil {
+		t.Errorf("rule-form agent missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".windsurf/rules/r1.md")); err != nil {
+		t.Errorf("rule missing: %v", err)
+	}
+}
+
+func TestEmit_NoWorkflowsDirNoEmit(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{{Kind: spec.KindAgent, Name: "ag1", Body: "agent"}}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".windsurf/workflows")); !os.IsNotExist(err) {
+		t.Errorf("expected no workflows dir; err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- New opt-in `outputs.windsurf.workflows-dir`: when set, each agent additionally emits as a [Windsurf Workflow](https://docs.windsurf.com/windsurf/cascade/workflows) at `<dir>/<name>.md`, invokable in Cascade as `/<name>`.
- `description` frontmatter populated from the agent's spec description.
- Existing `.windsurf/rules/agent-<name>.md` rule-form emission preserved (back-compat).

Closes #107

## Test plan
- [x] `go test ./internal/adapters/windsurf/...`
- [x] `go test ./...`
- [x] `go run ./cmd/schemagen` clean