### PR TITLE
feat(continue): emit agents as Continue local Assistants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Cursor Custom Commands** (#104): when `outputs.cursor.commands-dir` is set, each agent emits as a Cursor Custom Command (Markdown with `description`/`model` frontmatter) at that path, in addition to the existing `.cursor/rules/<name>.mdc` rule form.
 - **Cline Workflows** (#106): when `outputs.cline.workflows-dir` is set, each agent emits as a Cline Workflow (`<dir>/<name>.md`, invokable in chat as `/<name>.md`). The italic description prefixes the body when present. The existing `.clinerules/agent-<name>.md` rule-form emission stays in place.
 - **Windsurf Workflows** (#107): when `outputs.windsurf.workflows-dir` is set, each agent emits as a Windsurf Workflow (`<dir>/<name>.md` with `description` frontmatter), invokable in Cascade as `/<name>`. The existing `.windsurf/rules/agent-<name>.md` rule-form emission stays in place.
+- **Continue local Assistants** (#108): when `outputs.continue.assistants-dir` is set, each agent emits as a Continue local Assistant YAML (`<dir>/<name>.yaml`, schema `v1`, agent body wrapped as a single named prompt). The existing `.continue/rules/agent-<name>.md` rule-form emission stays in place.
 
 ### Changed
 - **`sync --watch` reaction time** (#36): swapped the 200 ms mtime poll for fsnotify with a 50 ms debounce. Idle CPU drops to zero between events; saves trigger a re-sync in under 100 ms. Polling backend kept as an automatic fallback when `fsnotify.NewWatcher` or `Add` fails.

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -14,7 +14,7 @@ Each adapter emits in its tool's native format — separate files where the tool
 | **aider**       | merged in `CONVENTIONS.md` | listed in `CONVENTIONS.md` | `CONVENTIONS.md` | - | - |
 | **cline**       | as `.md` rule (+ `.clinerules/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - |
 | **windsurf**    | as `.md` rule (+ `.windsurf/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.windsurf/rules/*.md`   | -     | - |
-| **continue**    | as `.md` rule       | as `.md` (`skill-<name>.md`) | `.continue/rules/*.md`   | -     | `.continue/mcpServers/*.yaml` |
+| **continue**    | as `.md` rule (+ `.continue/assistants/<name>.yaml` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.continue/rules/*.md`   | -     | `.continue/mcpServers/*.yaml` |
 | **amp**         | `.agents/commands/<name>.md` | listed in `AGENTS.md` (or `.agents/commands/skill-<name>.md` w/ opt-in) | `AGENTS.md` (nested per-dir by scope/globs) | - | `.amp/settings.json` (`amp.mcpServers`) |
 | **zed**         | merged in `.rules` | listed in `.rules` | `.rules` | - | `.zed/settings.json` (`context_servers`) |
 | **warp**        | inlined in `AGENTS.md` | listed in `AGENTS.md` | `AGENTS.md` (nested per-dir by scope/globs) | - | `.warp/.mcp.json` |
@@ -155,11 +155,14 @@ When `outputs.windsurf.workflows-dir` is set, each agent additionally emits as a
 ```
 .continue/rules/<name>.md
 .continue/mcpServers/<name>.yaml       # one per MCP entry
+.continue/assistants/<name>.yaml       # one per agent, only when assistants-dir is set
 ```
 
-Config keys: `outputs.continue.rules-dir` (default `.continue/rules`), `outputs.continue.mcp-dir` (default `.continue/mcpServers`).
+Config keys: `outputs.continue.rules-dir` (default `.continue/rules`), `outputs.continue.mcp-dir` (default `.continue/mcpServers`), `outputs.continue.assistants-dir` (default empty — opt-in).
 
 Continue picks up each YAML under `.continue/mcpServers/` as a single MCP server config. Stdio servers emit `command`/`args`/`env`; HTTP / SSE / streamable-http variants emit `type`/`url`/`headers`.
+
+When `outputs.continue.assistants-dir` is set, each agent additionally emits as a [Continue local Assistant](https://docs.continue.dev/hub/assistants/intro) YAML at `<dir>/<name>.yaml` (`schema: v1`, `version: 0.0.1` by default). The agent body wraps as a single named prompt so Continue surfaces it in the assistant picker. Models and rules are intentionally omitted so the user's defaults apply. The rule-form emission (`.continue/rules/agent-<name>.md`) still happens, so existing setups keep working.
 
 ### Amp (`amp`)
 

--- a/internal/adapters/continueai/continueai.go
+++ b/internal/adapters/continueai/continueai.go
@@ -35,7 +35,9 @@ func New() *Adapter { return &Adapter{} }
 func (Adapter) Name() string { return target }
 
 // Emit writes one .md per rule and per agent into the rules directory,
-// plus one .yaml per MCP entry under `.continue/mcpServers/`.
+// plus one .yaml per MCP entry under `.continue/mcpServers/`. When
+// `outputs.continue.assistants-dir` is set, each agent additionally
+// emits as a Continue local Assistant YAML at `<dir>/<name>.yaml`.
 func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
 		return err
@@ -46,7 +48,66 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	}, dryRun); err != nil {
 		return err
 	}
+	if err := emitAssistants(b, cfg, dryRun); err != nil {
+		return err
+	}
 	return emitMCPServers(b.MCPs, emit.OutputMCPDir(cfg, target, defaultMCPDir), dryRun)
+}
+
+// emitAssistants writes one Continue Assistant YAML per agent into the
+// configured assistants dir. No-op when the dir is unset.
+func emitAssistants(b spec.Bundle, cfg *config.Config, dryRun bool) error {
+	dir := emit.OutputAssistantsDir(cfg, target, "")
+	if dir == "" {
+		return nil
+	}
+	for _, a := range b.Agents {
+		doc, err := assistantYAML(a)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(dir, a.Name+".yaml")
+		if err := emit.WriteFile(path, doc, dryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// assistantYAML renders one agent as a Continue local Assistant per the
+// hub assistants schema (v1). The agent body becomes a single named
+// prompt; fields like models or `rules:` are intentionally omitted so
+// Continue inherits the user's configured defaults.
+func assistantYAML(e spec.Entry) (string, error) {
+	m := emit.ResolveMeta(e.Meta, target)
+	desc, _ := m["description"].(string)
+	version, _ := m["version"].(string)
+	if version == "" {
+		version = "0.0.1"
+	}
+
+	doc := map[string]any{
+		"name":    e.Name,
+		"version": version,
+		"schema":  "v1",
+	}
+	if desc != "" {
+		doc["description"] = desc
+	}
+	prompt := map[string]any{
+		"name":   e.Name,
+		"prompt": e.Body,
+	}
+	if desc != "" {
+		prompt["description"] = desc
+	}
+	doc["prompts"] = []any{prompt}
+
+	raw, err := yaml.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("marshal assistant %s: %w", e.Name, err)
+	}
+	return string(raw), nil
 }
 
 // emitMCPServers writes one YAML per MCP entry. Continue's loader picks

--- a/internal/adapters/continueai/continueai_test.go
+++ b/internal/adapters/continueai/continueai_test.go
@@ -113,6 +113,52 @@ func TestEmit_MCP_DirOverride(t *testing.T) {
 	}
 }
 
+func TestEmit_AssistantsDirEmitsAgentsAsAssistants(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindAgent,
+			Name: "ship-it",
+			Meta: map[string]any{"description": "open and merge a PR"},
+			Body: "Run the release.",
+		},
+	}
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"continue": {AssistantsDir: ".continue/assistants"},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".continue/assistants/ship-it.yaml"))
+	for _, want := range []string{
+		"name: ship-it",
+		"version: 0.0.1",
+		"schema: v1",
+		"description: open and merge a PR",
+		"prompts:",
+		"Run the release.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %s", want, got)
+		}
+	}
+}
+
+func TestEmit_NoAssistantsDirNoEmit(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{{Kind: spec.KindAgent, Name: "ag1", Body: "x"}}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".continue/assistants")); !os.IsNotExist(err) {
+		t.Errorf("expected no assistants dir; err=%v", err)
+	}
+}
+
 func TestEmit_MCP_NoFilesWhenNoEntries(t *testing.T) {
 	dir := testutil.TempCwd(t)
 


### PR DESCRIPTION
## Summary
- New opt-in `outputs.continue.assistants-dir`: when set, each agent additionally emits as a [Continue local Assistant](https://docs.continue.dev/hub/assistants/intro) YAML at `<dir>/<name>.yaml`.
- `schema: v1`, `version: 0.0.1` by default; agent body wrapped as a single named prompt.
- Models and rules intentionally omitted so the user's defaults apply.
- Existing `.continue/rules/agent-<name>.md` rule-form emission preserved (back-compat).

Closes #108

## Test plan
- [x] `go test ./internal/adapters/continueai/...`
- [x] `go test ./...`
- [x] `go run ./cmd/schemagen` clean