### PR TITLE
fix(release): guard RETURN trap against unbound tmp under set -u

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -64,7 +64,7 @@ compute_next_version() {
 # `var version = "..."` line.
 bump_version_in_file() {
   local file="$1" new="$2" tmp="$1.tmp"
-  trap 'rm -f "$tmp"' RETURN
+  trap 'rm -f "${tmp:-}"' RETURN
   awk -v new="$new" '
     /^var version =/ { print "var version = \"" new "\""; next }
     { print }
@@ -77,7 +77,7 @@ bump_version_in_file() {
 # Unreleased; dated headings drop them, matching docs and history.
 promote_changelog() {
   local file="$1" ver="$2" date="$3" tmp="$1.tmp"
-  trap 'rm -f "$tmp"' RETURN
+  trap 'rm -f "${tmp:-}"' RETURN
   grep -q '^## \[Unreleased\]' "$file" || { printf 'error: no [Unreleased] section in %s\n' "$file" >&2; return 1; }
   awk -v ver="$ver" -v date="$date" '
     !done && /^## \[Unreleased\]/ {


### PR DESCRIPTION
## Summary
- RETURN trap in `bump_version_in_file` / `promote_changelog` referenced `$tmp` raw; on bash 3.2 the trap fires after local scope is torn down, so `set -u` aborts with `tmp: unbound variable`.
- Surfaced during the v0.7.0 cut as a trailing non-zero exit *after* the release had already published (commit, tag, push, GoReleaser all succeeded).
- Fix: expand with `${tmp:-}` in both helpers. Behavior unchanged when `$tmp` is in scope.

## Test plan
- [x] `bashunit scripts/release_test.sh` → 33 passed / 58 assertions
- [ ] Next release cut completes with exit 0 end-to-end