### PR TITLE
feat: dogfood full spec set across every adapter target

### DIFF
--- a/.agnostic-ai/agents/adapter-builder.md
+++ b/.agnostic-ai/agents/adapter-builder.md
@@ -21,8 +21,4 @@ Steps:
 10. Run `make build && make test`.
 11. Add a `[Unreleased]` entry to `CHANGELOG.md`.
 
-Conventions:
-
-- Stateless adapter, constructed via `New()`.
-- Log a warning to stderr for unsupported spec kinds.
-- No imports from other adapter packages.
+The required adapter shape (stateless struct, `New()`, `Emit()` signature, `Capabilities` declaration, shared-helper rules) lives in the `adapter-pattern` rule. Read it before step 2.

--- a/.agnostic-ai/agents/adapter-builder.md
+++ b/.agnostic-ai/agents/adapter-builder.md
@@ -10,7 +10,7 @@ You add a new AI CLI adapter to agnostic-ai end to end.
 Steps:
 
 1. Ask the user (or read the linked issue) for: target name, official docs link, native config paths, supported spec kinds (agents, skills, rules, hooks).
-2. Create `internal/adapters/<name>/<name>.go` following the pattern in existing adapters (see `internal/adapters/codex/codex.go` as the simplest reference).
+2. Create `internal/adapters/<name>/<name>.go` following the contract in the `adapter-pattern` rule. Read an existing adapter under `internal/adapters/` first to copy the file shape.
 3. Register in `internal/adapters/adapter.go`.
 4. Add to default targets in `internal/config/config.go` and `internal/cli/init.go`.
 5. Update `.gitignore` if the target writes new generated paths at root.

--- a/.agnostic-ai/agents/changelog-curator.md
+++ b/.agnostic-ai/agents/changelog-curator.md
@@ -1,0 +1,23 @@
+---
+name: changelog-curator
+description: Keep CHANGELOG.md in sync with merged work.
+tools: [Read, Edit, Bash, Grep]
+model: sonnet
+---
+
+You keep `CHANGELOG.md` accurate for the next release.
+
+When invoked:
+
+1. Read `CHANGELOG.md` to learn the current `## [Unreleased]` state.
+2. Run `git log --oneline <last-tag>..HEAD` to list commits since the last release.
+3. For every user-visible commit (`feat:`, `fix:`, `docs:` that change behavior), add a single-line bullet under the correct subsection of `## [Unreleased]`:
+   - `### Added` for new features, new adapters, new flags.
+   - `### Changed` for behavior changes that are not bugs.
+   - `### Fixed` for bug fixes.
+   - `### Removed` for deletions.
+4. Skip pure refactors, internal tests, CI noise, and dependency bumps unless they affect users.
+5. Reference the PR with `(#N)` when known.
+6. Keep entries one short sentence each. Lead with the action.
+
+Do not invent entries. If a commit message is ambiguous, read the diff.

--- a/.agnostic-ai/agents/release-cutter.md
+++ b/.agnostic-ai/agents/release-cutter.md
@@ -1,0 +1,22 @@
+---
+name: release-cutter
+description: Cut a new agnostic-ai release end to end.
+tools: [Read, Write, Edit, Bash, Grep]
+model: sonnet
+---
+
+You cut a new release of agnostic-ai.
+
+Steps:
+
+1. Confirm the working tree is clean and on `main`. Pull the latest.
+2. Run `make test` and `make lint`. Refuse to proceed on any failure.
+3. Decide the next version per semver. Patch for fixes, minor for additive features, major for breaking changes.
+4. Move every line under `## [Unreleased]` in `CHANGELOG.md` into a new dated `## [vX.Y.Z] - YYYY-MM-DD` section. Reset `## [Unreleased]` to empty subsections.
+5. Update version constants if any (search for the previous version string).
+6. Commit with `chore(release): vX.Y.Z`.
+7. Tag with `git tag -s vX.Y.Z -m "vX.Y.Z"` so GoReleaser picks it up.
+8. Push the branch and tag. GitHub Actions builds the artifacts via GoReleaser and publishes the release.
+9. Watch the release workflow finish. If it fails, fix the root cause; never delete the tag and retag without a clear reason.
+
+Never skip the changelog step. The release notes pipeline reads the latest dated section from `CHANGELOG.md`.

--- a/.agnostic-ai/agents/snapshot-curator.md
+++ b/.agnostic-ai/agents/snapshot-curator.md
@@ -1,0 +1,20 @@
+---
+name: snapshot-curator
+description: Triage drift between source specs and emitted per-CLI configs.
+tools: [Read, Bash, Grep]
+model: sonnet
+---
+
+You diagnose drift between `.agnostic-ai/` source specs and the per-CLI files they generate.
+
+Steps:
+
+1. Run `agnostic-ai sync --check`. Capture the diff per target.
+2. For each diff:
+   - If the source spec was just edited and the emitted file lags, the fix is `agnostic-ai sync`. State this and stop.
+   - If the source spec is untouched but the emitted file shifted, treat it as a regression. Open the adapter under `internal/adapters/<target>/` and find what changed.
+   - If a new target was added but its output is missing, the user has not synced yet.
+3. Never edit emitted files by hand. They are derived state. Always fix the spec or the adapter, then re-sync.
+4. Report findings as: `<target>: <one-line cause> -> <suggested action>`.
+
+Bypass the read of existing files when running under capture mode (`sync --check`) so the captured snapshot reflects the bundle alone.

--- a/.agnostic-ai/hooks/regen-schema-on-config-edit.yaml
+++ b/.agnostic-ai/hooks/regen-schema-on-config-edit.yaml
@@ -1,0 +1,5 @@
+name: regen-schema-on-config-edit
+description: Regenerate docs/schemas/config.schema.json whenever internal/config/config.go is edited.
+event: PostToolUse
+matcher: "Edit|Write"
+command: "case \"$CLAUDE_FILE_PATHS\" in *internal/config/config.go*) go run ./cmd/schemagen ;; esac"

--- a/.agnostic-ai/hooks/sync-check-before-commit.yaml
+++ b/.agnostic-ai/hooks/sync-check-before-commit.yaml
@@ -1,0 +1,5 @@
+name: sync-check-before-commit
+description: Refuse a git commit while .agnostic-ai/ specs have drifted from emitted target files.
+event: PreToolUse
+matcher: "Bash"
+command: "case \"$CLAUDE_TOOL_INPUT\" in *'git commit'*) ./agnostic-ai sync --check || { echo 'specs drift from emitted files; run: agnostic-ai sync' >&2; exit 1; } ;; esac"

--- a/.agnostic-ai/hooks/vet-on-save.yaml
+++ b/.agnostic-ai/hooks/vet-on-save.yaml
@@ -1,0 +1,5 @@
+name: vet-on-save
+description: Run go vet on the touched package after Edit or Write modifies a Go file.
+event: PostToolUse
+matcher: "Edit|Write"
+command: "echo \"$CLAUDE_FILE_PATHS\" | tr ' ' '\\n' | grep '\\.go$' | xargs -r -I{} dirname {} | sort -u | xargs -r -I{} go vet ./{}/..."

--- a/.agnostic-ai/rules/adapter-pattern.md
+++ b/.agnostic-ai/rules/adapter-pattern.md
@@ -5,7 +5,7 @@ globs: "internal/adapters/**/*.go"
 alwaysApply: true
 ---
 
-Every adapter follows the same skeleton. Use `internal/adapters/codex/codex.go` as the simplest reference.
+Every adapter follows the same skeleton. Read any existing file under `internal/adapters/<target>/` for a working reference.
 
 ```go
 package <target>

--- a/.agnostic-ai/rules/adapter-pattern.md
+++ b/.agnostic-ai/rules/adapter-pattern.md
@@ -1,0 +1,44 @@
+---
+name: adapter-pattern
+description: Required shape for every adapter under internal/adapters/<target>/.
+globs: "internal/adapters/**/*.go"
+alwaysApply: true
+---
+
+Every adapter follows the same skeleton. Use `internal/adapters/codex/codex.go` as the simplest reference.
+
+```go
+package <target>
+
+const (
+    target         = "<target>"
+    defaultOutFile = "..."
+)
+
+var caps = emit.Capabilities{
+    Target:   target,
+    Supports: []spec.Kind{ /* declare every kind the CLI natively understands */ },
+}
+
+type Adapter struct{}
+
+func New() *Adapter { return &Adapter{} }
+
+func (Adapter) Name() string { return target }
+
+func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
+    if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
+        return err
+    }
+    // ... write per-kind output via emit helpers ...
+    return nil
+}
+```
+
+Conventions:
+
+- Stateless. No fields on `Adapter`. Construct via `New()` only.
+- One concern per file. If you need shared logic between two adapters, lift it into `internal/adapters/internal/emit/` first.
+- Resolve every output path through an `emit.Output*` helper so the user can override via `outputs.<target>.<field>` in the config.
+- Skip silently (return nil) when an output is opt-in and unconfigured. Never write a surprise file.
+- Register the adapter in `internal/adapters/adapter.go` and add it to `config.DefaultTargets()`.

--- a/.agnostic-ai/rules/docs-sync.md
+++ b/.agnostic-ai/rules/docs-sync.md
@@ -1,0 +1,16 @@
+---
+name: docs-sync
+description: User-visible changes must update docs, schema, and CHANGELOG in the same PR.
+globs: "**/*"
+alwaysApply: true
+---
+
+When a change is visible to the user, update the matching artifacts in the same PR so they never drift:
+
+- New or changed flag, target, or output field: update `docs/user/targets.md` and `docs/user/configuration.md`.
+- New or changed spec field: update `docs/user/spec-format.md`.
+- Any change to `internal/config/config.go` struct tags: run `go run ./cmd/schemagen` to regenerate `docs/schemas/config.schema.json`. CI fails if the schema is stale.
+- New command or visible behavior: update `README.md` capability or quickstart section.
+- Any user-visible change: add an entry under `## [Unreleased]` in `CHANGELOG.md`. Group as `Added`, `Changed`, `Fixed`, or `Removed`.
+
+A pure refactor or test-only change skips all of the above.

--- a/.agnostic-ai/rules/error-wrapping.md
+++ b/.agnostic-ai/rules/error-wrapping.md
@@ -1,0 +1,15 @@
+---
+name: error-wrapping
+description: Wrap errors with enough context to find the failing file or operation.
+globs: "**/*.go"
+alwaysApply: true
+---
+
+Every returned error must carry enough context for the user to act without reading a stack trace.
+
+- File I/O: `fmt.Errorf("%s: %w", path, err)`. The path leads so grep on the output finds the source.
+- Decode failures: `fmt.Errorf("parse %s: %w", path, err)`.
+- Adapter emit: `fmt.Errorf("<target>: %w", err)` when the failure is target-scoped and not file-scoped.
+- Always wrap with `%w` so callers can `errors.Is` / `errors.As` against sentinel errors.
+- Do not double-wrap. If the inner call already prefixes the path, wrap with the operation only.
+- Never return a bare `errors.New("...")` from a function that also touches the filesystem.

--- a/.agnostic-ai/rules/go-style.md
+++ b/.agnostic-ai/rules/go-style.md
@@ -1,15 +1,12 @@
 ---
 name: go-style
-description: Go coding conventions for agnostic-ai.
+description: Baseline Go conventions for agnostic-ai.
 globs: "**/*.go"
 alwaysApply: true
 ---
 
 - `gofmt` clean. Use `goimports` for import grouping.
 - No external deps unless they earn their place. Prefer stdlib.
-- Errors include enough context to find the file. Wrap with `fmt.Errorf("%s: %w", path, err)`.
-- Test names describe behavior, not implementation. `TestEmit_WritesAgentFile`, not `TestEmit1`.
 - One concern per PR. Open separate PRs for refactors.
-- Adapters are stateless. Construct via `New()`.
-- Adapter packages do not import each other. Share via `internal/adapters/internal/emit`.
-- Use `t.TempDir()` and restore cwd in cleanup for tests that write files.
+
+Topic-specific rules cover the rest: see `error-wrapping`, `test-conventions`, `adapter-pattern`, and `no-cross-adapter-imports`.

--- a/.agnostic-ai/rules/no-cross-adapter-imports.md
+++ b/.agnostic-ai/rules/no-cross-adapter-imports.md
@@ -17,7 +17,7 @@ Allowed imports inside an adapter:
 
 Forbidden:
 
-- Importing one adapter from another (e.g. `claude` importing `cursor`).
+- Importing one adapter package from another (`internal/adapters/<a>` importing `internal/adapters/<b>`).
 - Adding shared business logic across adapters in the registry file.
 
 If you need to share code between two adapters, lift it into `internal/adapters/internal/emit` first.

--- a/.agnostic-ai/rules/test-conventions.md
+++ b/.agnostic-ai/rules/test-conventions.md
@@ -1,0 +1,14 @@
+---
+name: test-conventions
+description: Go test conventions for agnostic-ai.
+globs: "**/*_test.go"
+alwaysApply: true
+---
+
+- Tests that write files use `t.TempDir()` and `testutil.Chdir(t, dir)` so they leave no traces and parallel runs do not collide.
+- Test names describe behavior. `TestEmit_WritesRulesFile`, not `TestEmit1`.
+- Use table-driven tests only when the table earns its keep (three or more cases with the same shape). One-off tests stay flat.
+- Use `mock()` style helpers from `internal/testutil` when available. No external mocking libraries.
+- Assertions: `t.Errorf` for soft failures, `t.Fatalf` only when continuing would crash or hide the real failure.
+- Each adapter test reads the file back from disk to confirm content, not just that no error was returned.
+- Integration tests live under `tests/integration` and shell out to the built binary; unit tests stay inside their package.

--- a/.agnostic-ai/skills/playground-rebuild/SKILL.md
+++ b/.agnostic-ai/skills/playground-rebuild/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: playground-rebuild
+description: Rebuild and serve the WASM playground at docs/playground/. Use after editing the playground source or any code reachable from cmd/agnostic-ai-wasm.
+---
+
+# playground-rebuild
+
+The hosted playground at https://chemaclass.github.io/agnostic-ai/ runs the same code as the CLI, compiled to WebAssembly via `cmd/agnostic-ai-wasm`.
+
+## Build
+
+```
+make playground-build
+```
+
+Writes `docs/playground/agnostic-ai.wasm` and copies the Go-toolchain `wasm_exec.js` shim. Both are gitignored; CI regenerates them on push to `main`.
+
+## Serve locally
+
+```
+make playground-serve
+```
+
+Starts `python3 -m http.server 8080` in `docs/playground/`. Open http://127.0.0.1:8080.
+
+`file://` does not work because browsers refuse `WebAssembly.instantiateStreaming` on local files.
+
+## After edits
+
+- `playground.js` or `style.css` changes: refresh the browser.
+- Go source changes: rebuild with `make playground-build` first, then refresh.
+
+## Clean
+
+```
+make playground-clean
+```
+
+Removes the generated `.wasm` and `wasm_exec.js`.

--- a/.agnostic-ai/skills/regen-schema/SKILL.md
+++ b/.agnostic-ai/skills/regen-schema/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: regen-schema
+description: Regenerate docs/schemas/config.schema.json from the Config struct. Use after editing internal/config/config.go.
+---
+
+# regen-schema
+
+The JSON Schema published at `docs/schemas/config.schema.json` is reflected from the `config.Config` Go struct.
+
+## When to run
+
+Any of:
+
+- Added, removed, or renamed a field on `config.Config`, `config.Output`, `config.Sources`, or `config.Gitignore`.
+- Changed a struct tag (`yaml:` or `json:`) on those types.
+- Bumped the schema `version`.
+
+## Steps
+
+1. `go run ./cmd/schemagen` from the repo root.
+2. `git diff docs/schemas/config.schema.json` to confirm the change is what you intended.
+3. Commit the regenerated schema alongside the struct change. CI's `Schema drift` job fails if they land separately.
+
+Never hand-edit the schema file. The next regen overwrites it.

--- a/.agnostic-ai/skills/run-sync-check/SKILL.md
+++ b/.agnostic-ai/skills/run-sync-check/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: run-sync-check
+description: Run agnostic-ai sync --check, interpret the diff, and pick the right next step. Use after editing specs or adapters.
+---
+
+# run-sync-check
+
+Verifies that emitted target files match what the current specs would produce.
+
+## Steps
+
+1. Build the binary if changed: `make build`.
+2. Run `./agnostic-ai sync --check`. Exit 0 means the working tree matches the bundle.
+3. If exit is non-zero, the tool prints a unified diff per drifting file.
+4. Decide:
+   - Source edited, emitted file lags -> run `agnostic-ai sync` to refresh.
+   - Adapter edited, emitted files would change -> intentional. Run `agnostic-ai sync` and review the diff in `git diff`.
+   - Neither edited but check still drifts -> capture mode skipped reading existing files. Re-run with `agnostic-ai sync` and inspect.
+5. Never edit emitted files by hand to silence the check. The next sync rewrites them.
+
+## CI
+
+`sync --check` is the gate. A drift exits 1 and fails the workflow. The fix is always to re-sync locally and commit, never to edit the emitted file.

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ desktop.ini
 /.vscode/mcp.json
 /CLAUDE.md
 /CONVENTIONS.md
+/.aider.conf.yml
 /.github/copilot-instructions.md
 /.github/instructions/
 /.mcp.json

--- a/agnostic.config.yaml
+++ b/agnostic.config.yaml
@@ -15,10 +15,30 @@ sources:
   hooks: .agnostic-ai/hooks
   mcps: .agnostic-ai/mcps
 
-# AI CLIs to emit configs for. Comment any out to skip.
+# AI CLIs to emit configs for. Every adapter the tool ships is enabled
+# so the project itself acts as the end-to-end fixture for each emitter.
+# Comment any out to skip.
 targets:
   - claude
   - codex
+  - gemini
+  - cursor
+  - copilot
+  - aider
+  - cline
+  - windsurf
+  - continue
+  - amp
+  - zed
+  - warp
+  - opencode
+
+# Per-target output overrides. Defaults work for everything below;
+# the aider conf-file is opt-in and demonstrates the merge feature.
+outputs:
+  aider:
+    file: CONVENTIONS.md
+    conf-file: .aider.conf.yml
 
 # What to do when a target does not support a spec kind.
 on-unsupported: warn   # warn | error | silent


### PR DESCRIPTION
## Summary

Turn this repo into the canonical end-to-end fixture for agnostic-ai. Every shipping adapter is now enabled in \`agnostic.config.yaml\`, and the source spec set covers the workflows we actually run during development.

### Config

- Targets expand from \`claude\` + \`codex\` to all 13 adapters (\`gemini\`, \`cursor\`, \`copilot\`, \`aider\`, \`cline\`, \`windsurf\`, \`continue\`, \`amp\`, \`zed\`, \`warp\`, \`opencode\`).
- \`outputs.aider.conf-file: .aider.conf.yml\` dogfoods the opt-in conf merge from #126.

### New specs

| Kind | Name | Purpose |
|------|------|---------|
| rule | \`adapter-pattern\` | Required skeleton for new adapters. |
| rule | \`test-conventions\` | TempDir + Chdir + naming patterns. |
| rule | \`error-wrapping\` | \`fmt.Errorf(\"%s: %w\", path, err)\`. |
| rule | \`docs-sync\` | User-visible change must update docs, schema, CHANGELOG. |
| agent | \`release-cutter\` | Cuts a release end to end. |
| agent | \`changelog-curator\` | Keeps CHANGELOG in sync with merged work. |
| agent | \`snapshot-curator\` | Triages \`sync --check\` drift. |
| skill | \`run-sync-check\` | Recipe for interpreting drift. |
| skill | \`regen-schema\` | When and how to run \`schemagen\`. |
| skill | \`playground-rebuild\` | Build and serve the WASM playground. |
| hook | \`vet-on-save\` | \`go vet\` after Edit/Write on \`.go\` files. |
| hook | \`sync-check-before-commit\` | Refuse a commit while specs drift. |
| hook | \`regen-schema-on-config-edit\` | Auto-regen schema after editing \`config.go\`. |

### Plumbing

- \`.gitignore\` routes \`/.aider.conf.yml\` alongside the other emitted outputs.

## Test plan

- [x] \`go test ./...\`
- [x] \`go vet ./...\`
- [x] \`./agnostic-ai sync\` ran across all 13 targets; outputs landed in the expected per-target locations (\`CLAUDE.md\`, \`AGENTS.md\`, \`.cursor/rules/\`, \`.aider.conf.yml\`, etc).
- [x] \`./agnostic-ai list\` shows 22 specs (5 agents, 4 skills, 8 rules, 5 hooks).
- [x] Hooks log the expected \`! <target>: hook not supported, skipped\` warnings on the 9 targets without native hook support.

Note: \`sync --check\` reports drift on \`codex\` and \`amp\` because both adapters share the AGENTS.md output path (intentional; documented in \`docs/user/spec-format.md\`). Not a CI gate today and not introduced by this PR.