### PR TITLE
feat(import): per-target importers and AGNOSTIC_AI.md mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `import claude` now prefers `.claude/rules/*.md` (each file → one rule, byte-identical copy) over slicing `CLAUDE.md`. Slicing only runs when `.claude/rules/` is absent.
 - `import claude` mirrors `CLAUDE.md` to `AGNOSTIC_AI.md` at the project root so projects keep a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
 - `import codex` mirrors the root `AGENTS.md` to `AGNOSTIC_AI.md`, matching the `import claude` behavior.
+- `import aider`: read `CONVENTIONS.md` (slice on `## ` headings) and mirror it to `AGNOSTIC_AI.md`.
+- `import amp`: read `AGENTS.md` rules, `.agents/commands/*.md` agents, and `amp.mcpServers` entries from `.amp/settings.json`; mirror `AGENTS.md`.
+- `import warp`: read `AGENTS.md` rules, `.warp/workflows/*.yaml` agents (description + tags preserved in frontmatter), and `.warp/.mcp.json` `mcpServers`; mirror `AGENTS.md`.
+- `import gemini`: read root and nested `GEMINI.md` (nested files infer `globs: <scope>/**`), `.gemini/commands/*.toml` agents, and `mcpServers` + `hooks` from `.gemini/settings.json`; mirror root `GEMINI.md`.
+- `import copilot`: prefer `.github/instructions/*.instructions.md` over slicing `.github/copilot-instructions.md`; `agent-*` / `skill-*` filename prefixes route to the matching source dir, and a leading italic paragraph lifts into `description:` frontmatter. Chat modes become agents; `.vscode/mcp.json` becomes MCP specs. Mirror `.github/copilot-instructions.md`.
+- `import opencode`: slice `.opencode/AGENTS.md` for rules, copy `.opencode/commands/*.md` as agents, and translate `opencode.json` `mcp` entries (`command` array → `command` + `args`, `environment` → `env`, `type` dropped). Mirror `.opencode/AGENTS.md`.
+- `import zed`: slice `.rules` for rules, `.zed/tasks.json` → hooks (synthetic `event: OnDemand`), `.zed/settings.json` `context_servers` → MCP specs. Mirror `.rules`.
 
 ### Changed
 - `agnostic-ai init` now opens the target picker by default when stdin is a TTY (previously required `-i` / `--interactive`). Non-TTY stdin parses a piped comma-separated list, or silently falls back to every supported target when no data arrives. The opt-out flag is now `--all` / `-a`; `-i` / `--interactive` is removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
-- Playground UX refresh: branded header, sample picker per kind, target chips, per-target file selector with Copy/Download buttons, theme toggle (system/light/dark), preference persistence via localStorage, mobile single-column layout.
-- Source URL shown in `--help` (Long description) and `--version` output.
-- `import claude` now prefers `.claude/rules/*.md` (each file → one rule, byte-identical copy) over slicing `CLAUDE.md`. Slicing only runs when `.claude/rules/` is absent.
-- `import claude` mirrors `CLAUDE.md` to `AGNOSTIC_AI.md` at the project root so projects keep a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
-- `import codex` mirrors the root `AGENTS.md` to `AGNOSTIC_AI.md`, matching the `import claude` behavior.
-- `import aider`: read `CONVENTIONS.md` (slice on `## ` headings) and mirror it to `AGNOSTIC_AI.md`.
-- `import amp`: read `AGENTS.md` rules, `.agents/commands/*.md` agents, and `amp.mcpServers` entries from `.amp/settings.json`; mirror `AGENTS.md`.
-- `import warp`: read `AGENTS.md` rules, `.warp/workflows/*.yaml` agents (description + tags preserved in frontmatter), and `.warp/.mcp.json` `mcpServers`; mirror `AGENTS.md`.
-- `import gemini`: read root and nested `GEMINI.md` (nested files infer `globs: <scope>/**`), `.gemini/commands/*.toml` agents, and `mcpServers` + `hooks` from `.gemini/settings.json`; mirror root `GEMINI.md`.
-- `import copilot`: prefer `.github/instructions/*.instructions.md` over slicing `.github/copilot-instructions.md`; `agent-*` / `skill-*` filename prefixes route to the matching source dir, and a leading italic paragraph lifts into `description:` frontmatter. Chat modes become agents; `.vscode/mcp.json` becomes MCP specs. Mirror `.github/copilot-instructions.md`.
-- `import opencode`: slice `.opencode/AGENTS.md` for rules, copy `.opencode/commands/*.md` as agents, and translate `opencode.json` `mcp` entries (`command` array → `command` + `args`, `environment` → `env`, `type` dropped). Mirror `.opencode/AGENTS.md`.
-- `import zed`: slice `.rules` for rules, `.zed/tasks.json` → hooks (synthetic `event: OnDemand`), `.zed/settings.json` `context_servers` → MCP specs. Mirror `.rules`.
+- Playground UX refresh: target chips, per-target file selector, theme toggle, mobile layout.
+- Source URL in `--help` and `--version`.
+- `import` for **aider, amp, warp, gemini, copilot, opencode, zed** — full kind coverage where the target supports it.
+- Every importer mirrors the target's main file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`, `.rules`) to `AGNOSTIC_AI.md`. Last import wins.
+- `import claude` prefers `.claude/rules/*.md` over slicing `CLAUDE.md`.
+- `import copilot` lifts a leading italic paragraph into `description:` frontmatter and routes `agent-*` / `skill-*` instruction files to the matching source dir.
 
 ### Changed
-- `agnostic-ai init` now opens the target picker by default when stdin is a TTY (previously required `-i` / `--interactive`). Non-TTY stdin parses a piped comma-separated list, or silently falls back to every supported target when no data arrives. The opt-out flag is now `--all` / `-a`; `-i` / `--interactive` is removed.
+- `agnostic-ai init` prompts for targets by default on a TTY. Pipe a comma-separated list, or pass `--all` / `-a` to skip the picker. `-i` / `--interactive` removed.
 
 ### Fixed
-- `import claude` no longer drops preamble before the first `##` heading (saved as a separate rule) and no longer splits rules on `##` lines that live inside fenced code blocks.
-- `agnostic-ai.yaml` schema: `outputs`, `sources`, `targets`, `on-unsupported`, and `gitignore` are now optional (only `version` is required). Editors no longer flag a minimal config as invalid.
+- `import claude` keeps preamble before the first `##` and ignores `##` lines inside fenced code blocks.
+- `agnostic-ai.yaml`: only `version` is required. Editors no longer flag a minimal config.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 - Playground UX refresh: branded header, sample picker per kind, target chips, per-target file selector with Copy/Download buttons, theme toggle (system/light/dark), preference persistence via localStorage, mobile single-column layout.
 - Source URL shown in `--help` (Long description) and `--version` output.
+- `import claude` now prefers `.claude/rules/*.md` (each file → one rule, byte-identical copy) over slicing `CLAUDE.md`. Slicing only runs when `.claude/rules/` is absent.
+- `import claude` mirrors `CLAUDE.md` to `AGNOSTIC_AI.md` at the project root so projects keep a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
 
 ### Changed
 - `agnostic-ai init` now opens the target picker by default when stdin is a TTY (previously required `-i` / `--interactive`). Non-TTY stdin parses a piped comma-separated list, or silently falls back to every supported target when no data arrives. The opt-out flag is now `--all` / `-a`; `-i` / `--interactive` is removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Source URL shown in `--help` (Long description) and `--version` output.
 - `import claude` now prefers `.claude/rules/*.md` (each file → one rule, byte-identical copy) over slicing `CLAUDE.md`. Slicing only runs when `.claude/rules/` is absent.
 - `import claude` mirrors `CLAUDE.md` to `AGNOSTIC_AI.md` at the project root so projects keep a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
+- `import codex` mirrors the root `AGENTS.md` to `AGNOSTIC_AI.md`, matching the `import claude` behavior.
 
 ### Changed
 - `agnostic-ai init` now opens the target picker by default when stdin is a TTY (previously required `-i` / `--interactive`). Non-TTY stdin parses a piped comma-separated list, or silently falls back to every supported target when no data arrives. The opt-out flag is now `--all` / `-a`; `-i` / `--interactive` is removed.

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Or grab a prebuilt binary from the [latest release](https://github.com/Chemaclas
 ## Quickstart
 
 ```bash
-agnostic-ai init                  # scaffold .agnostic-ai/{agents,skills,rules,hooks,mcps}/
-agnostic-ai init -i               # same, but pick which targets land in agnostic-ai.yaml
+agnostic-ai init                  # scaffold .agnostic-ai/{agents,skills,rules,hooks,mcps}/ — prompts for targets on a TTY
+agnostic-ai init --all            # same, but skip the prompt and enable every supported target
 agnostic-ai init --demo           # same, plus one example spec per folder to learn from
 agnostic-ai sync                  # emit native config for every target
 agnostic-ai sync --dry-run        # preview without writing
@@ -153,6 +153,8 @@ Already have `.cursor/rules` or `AGENTS.md`? Pull them in:
 ```bash
 agnostic-ai import cursor         # also: codex, claude, cline, windsurf, continue
 ```
+
+`import claude` prefers `.claude/rules/*.md` (each file → one rule, byte-identical) and falls back to slicing `CLAUDE.md` on `## headings` only when that directory is absent. It also mirrors `CLAUDE.md` to a project-root `AGNOSTIC_AI.md` so you keep a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
 
 ## CI gate
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -18,19 +18,20 @@ agnostic-ai [command] [flags]
 Scaffold a project: `agnostic-ai.yaml` plus empty `agents/`, `skills/`, `rules/`, `hooks/`, `mcps/`. Errors if `agnostic-ai.yaml` exists.
 
 ```bash
-agnostic-ai init                  # default base dir: .agnostic-ai/
+agnostic-ai init                  # default: prompt for targets when stdin is a TTY, base dir .agnostic-ai/
+agnostic-ai init --all            # skip the prompt, enable every supported target
 agnostic-ai init specs            # custom base: specs/{agents,skills,...}/
 agnostic-ai init .                # legacy root-level layout
 agnostic-ai init --demo           # seed each source folder with one example spec
 agnostic-ai init --preset go      # seed idiomatic specs for a stack (go, ts-react, python)
-agnostic-ai init -i               # interactive: pick which targets land in config
+echo "claude,codex" | agnostic-ai init   # non-TTY: pipe a comma-separated target list
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--demo` | Seed each source folder with one minimal example spec so a fresh project produces real output on the first `sync`. Existing files are never overwritten. |
-| `--preset <name>` | Seed stack-flavored starter specs. Available: `go`, `ts-react`, `python`. Composes with `--demo` and `-i`. Errors on unknown names with the available list. Existing files are never overwritten, so re-running against a partially populated tree is safe. |
-| `-i, --interactive` | Multi-select prompt to pick which targets land in `agnostic-ai.yaml`. Accepts piped comma-separated input for non-TTY use (e.g. `echo "claude,codex" \| agnostic-ai init -i`). |
+| `--preset <name>` | Seed stack-flavored starter specs. Available: `go`, `ts-react`, `python`. Composes with `--demo` and `--all`. Errors on unknown names with the available list. Existing files are never overwritten, so re-running against a partially populated tree is safe. |
+| `-a, --all` | Skip the target picker and enable every supported target in `agnostic-ai.yaml`. Useful for CI or scripted scaffolds. By default, `init` runs a multi-select prompt when stdin is a TTY, parses a piped comma-separated list when stdin is a pipe, and falls back to all targets when stdin is closed. |
 
 The optional positional `[dir]` arg sets the base directory under which
 the source folders are created. The generated `agnostic-ai.yaml`
@@ -61,11 +62,15 @@ filename. Run after `init`, in the same project root.
 
 | Source | Becomes |
 |--------|---------|
-| `CLAUDE.md` (split on `## headings`) | `<rules>/<slug>.md` per section |
-| `CLAUDE.md` (no headings) | single `<rules>/<projectname>.md` |
+| `.claude/rules/*.md` (preferred) | `<rules>/<name>.md` (byte-identical copy) |
+| `CLAUDE.md` (split on `## headings`) | `<rules>/<slug>.md` per section — only when `.claude/rules/` is absent |
+| `CLAUDE.md` (no headings) | single `<rules>/<projectname>.md` — only when `.claude/rules/` is absent |
+| `CLAUDE.md` (any form) | `AGNOSTIC_AI.md` at project root (byte-identical copy) |
 | `.claude/agents/*.md` | `<agents>/<name>.md` (byte-identical copy) |
 | `.claude/skills/<name>/SKILL.md` | `<skills>/<name>/SKILL.md` |
 | `.claude/settings.json` hooks | `<hooks>/<event>-<group>-<index>.yaml` |
+
+When `.claude/rules/` exists, slicing `CLAUDE.md` is skipped entirely (even if the directory is empty) so the on-disk rules layout is the single source of truth for rule files. `AGNOSTIC_AI.md` is still written from `CLAUDE.md` so the project keeps a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
 
 `import codex` walks the project for `AGENTS.md` files at any depth:
 
@@ -247,7 +252,7 @@ the config still lists every supported target, `sync` opens an
 interactive multi-select to narrow the list. The selection is persisted
 to `agnostic-ai.yaml` so future syncs skip the prompt.
 
-- **TTY:** multi-select widget (same UI as `init -i`).
+- **TTY:** multi-select widget (same UI as `init`'s default prompt).
 - **Piped stdin:** `echo "claude,codex" | agnostic-ai sync` selects + persists without a prompt.
 - **Non-TTY with no piped data (CI):** silent fallback — emits every configured target. CI runs keep working without changes.
 - **Bypass:** pass `--all`, `-t`, `--only`, or `--except` to skip the picker for one run.

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -23,7 +23,10 @@ var rulesDirImporters = map[string]string{
 // importSources lists every source the import command accepts, used in
 // help text and error messages.
 func importSources() string {
-	names := []string{"claude", "codex", "cursor"}
+	names := []string{
+		"aider", "amp", "claude", "codex", "copilot",
+		"cursor", "gemini", "opencode", "warp", "zed",
+	}
 	for k := range rulesDirImporters {
 		names = append(names, k)
 	}
@@ -65,6 +68,20 @@ func runImport(root, source string, src config.Sources) error {
 		return importFromCodex(root, src)
 	case "cursor":
 		return importFromCursor(root, src)
+	case "aider":
+		return importFromAider(root, src)
+	case "amp":
+		return importFromAmp(root, src)
+	case "warp":
+		return importFromWarp(root, src)
+	case "gemini":
+		return importFromGemini(root, src)
+	case "copilot":
+		return importFromCopilot(root, src)
+	case "opencode":
+		return importFromOpencode(root, src)
+	case "zed":
+		return importFromZed(root, src)
 	}
 	if srcDir, ok := rulesDirImporters[source]; ok {
 		return importFromRulesDir(root, source, srcDir, src)

--- a/internal/cli/import_aider.go
+++ b/internal/cli/import_aider.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"path/filepath"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const aiderMainFile = "CONVENTIONS.md"
+
+// importFromAider reads an existing Aider project (CONVENTIONS.md plus
+// optional .aider.conf.yml) under root and writes specs into the
+// configured source directories.
+func importFromAider(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules); err != nil {
+		return err
+	}
+	n, err := sliceMainFileByH2(root, aiderMainFile, filepath.Join(root, src.Rules))
+	if err != nil {
+		return err
+	}
+	if err := mirrorMainFile(root, aiderMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules\n", n)
+	return nil
+}

--- a/internal/cli/import_aider_test.go
+++ b/internal/cli/import_aider_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportFromAider_NoConventionsMd(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromAider(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(dir, "rules"))
+	if len(entries) != 0 {
+		t.Errorf("expected empty rules/, got %d entries", len(entries))
+	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when CONVENTIONS.md absent: %v", err)
+	}
+}
+
+func TestImportFromAider_MirrorsConventionsMd(t *testing.T) {
+	dir := t.TempDir()
+	body := "# Conventions\n\nTop-level.\n\n## go-style\n\ngofmt clean.\n"
+	writeFile(t, filepath.Join(dir, aiderMainFile), body)
+	if err := importFromAider(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical to CONVENTIONS.md. got %q", got)
+	}
+}
+
+func TestImportFromAider_SlicesH2(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, aiderMainFile), "## go-style\n\ngofmt clean.\n\n## commits\n\nConventional commits.\n")
+	if err := importFromAider(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"go-style", "commits"} {
+		data, err := os.ReadFile(filepath.Join(dir, "rules", name+".md"))
+		if err != nil {
+			t.Fatalf("missing rules/%s.md: %v", name, err)
+		}
+		if !strings.Contains(string(data), "name: "+name) {
+			t.Errorf("expected name: %s in %s", name, data)
+		}
+	}
+}

--- a/internal/cli/import_amp.go
+++ b/internal/cli/import_amp.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"path/filepath"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const (
+	ampMainFile     = "AGENTS.md"
+	ampCommandsDir  = ".agents/commands"
+	ampSettingsKey  = "amp.mcpServers"
+	ampSettingsFile = ".amp/settings.json"
+)
+
+// importFromAmp reads an existing Sourcegraph Amp project (AGENTS.md,
+// `.agents/commands/`, `.amp/settings.json`) under root and writes
+// specs into the configured source directories.
+func importFromAmp(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Agents, src.MCPs); err != nil {
+		return err
+	}
+	rules, err := importAmpRules(root, filepath.Join(root, src.Rules))
+	if err != nil {
+		return err
+	}
+	agents, err := importAmpCommands(root, filepath.Join(root, src.Agents))
+	if err != nil {
+		return err
+	}
+	mcps, err := importAmpMCP(root, filepath.Join(root, src.MCPs))
+	if err != nil {
+		return err
+	}
+	if err := mirrorMainFile(root, ampMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)
+	return nil
+}
+
+// importAmpRules slices AGENTS.md by `## ` headings. Amp has no native
+// rules directory, so the main file is always the source.
+func importAmpRules(root, dstDir string) (int, error) {
+	return sliceMainFileByH2(root, ampMainFile, dstDir)
+}
+
+// importAmpCommands copies `.agents/commands/*.md` byte-for-byte into
+// the agents source dir. Each command file becomes one agent.
+func importAmpCommands(root, dstDir string) (int, error) {
+	src := filepath.Join(root, ampCommandsDir)
+	if !dirExists(src) {
+		return 0, nil
+	}
+	return copyMarkdownDir(src, dstDir)
+}
+
+// importAmpMCP reads `.amp/settings.json` and writes one yaml per
+// `amp.mcpServers.<name>` entry into <dstDir>/<name>.yaml.
+func importAmpMCP(root, dstDir string) (int, error) {
+	return importJSONMCPMap(filepath.Join(root, ampSettingsFile), ampSettingsKey, dstDir)
+}

--- a/internal/cli/import_amp_test.go
+++ b/internal/cli/import_amp_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportFromAmp_NoSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromAmp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when AGENTS.md absent: %v", err)
+	}
+}
+
+func TestImportFromAmp_MirrorsAgentsMd(t *testing.T) {
+	dir := t.TempDir()
+	body := "# AGENTS.md\n\n## rule-a\n\nbody.\n"
+	writeFile(t, filepath.Join(dir, ampMainFile), body)
+	if err := importFromAmp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical to AGENTS.md. got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "rule-a.md")); err != nil {
+		t.Errorf("missing sliced rule rule-a.md: %v", err)
+	}
+}
+
+func TestImportFromAmp_PrefersCommandsDir(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nname: reviewer\n---\n\nReview diffs.\n"
+	writeFile(t, filepath.Join(dir, ampCommandsDir, "reviewer.md"), body)
+	if err := importFromAmp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "agents", "reviewer.md"))
+	if err != nil {
+		t.Fatalf("missing agents/reviewer.md: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("agent not byte-identical. got %q", got)
+	}
+}
+
+func TestImportFromAmp_ImportsMCPServers(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "amp.mcpServers": {
+    "fs": {"command": "fs-server", "args": ["--root", "."]}
+  }
+}`
+	writeFile(t, filepath.Join(dir, ampSettingsFile), settings)
+	if err := importFromAmp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "mcps", "fs.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/fs.yaml: %v", err)
+	}
+	for _, want := range []string{"name: fs", "command: fs-server"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("expected %q in %s", want, data)
+		}
+	}
+}

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -6,15 +6,21 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
 )
 
-// AgnosticMainFile is the project-root "main instructions" file
-// agnostic-ai mirrors during import. Sits alongside CLAUDE.md /
-// AGENTS.md / GEMINI.md and holds a verbatim copy of the source CLI's
-// top-level instructions.
-const AgnosticMainFile = "AGNOSTIC_AI.md"
+const (
+	// claudeDir is the per-project Claude Code config directory.
+	claudeDir = ".claude"
+	// claudeMainFile is the project-root Claude Code instructions file.
+	claudeMainFile = "CLAUDE.md"
+	// agnosticMainFile is the project-root CLI-agnostic instructions
+	// file. Sits alongside CLAUDE.md / AGENTS.md / GEMINI.md and holds
+	// a verbatim copy of the source CLI's top-level instructions.
+	agnosticMainFile = "AGNOSTIC_AI.md"
+)
 
 type importCounts struct{ rules, agents, skills, hooks int }
 
@@ -40,7 +46,7 @@ func importFromClaude(root string, src config.Sources) error {
 	if c.hooks, err = importClaudeHooks(root, filepath.Join(root, src.Hooks)); err != nil {
 		return err
 	}
-	if err := copyClaudeMainFile(root); err != nil {
+	if err := mirrorClaudeMainFile(root); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks\n",
@@ -48,12 +54,20 @@ func importFromClaude(root string, src config.Sources) error {
 	return nil
 }
 
-// copyClaudeMainFile mirrors CLAUDE.md to <root>/AGNOSTIC_AI.md
-// byte-for-byte so projects keep a CLI-agnostic top-level
-// instructions file alongside CLAUDE.md / AGENTS.md / GEMINI.md.
-// No-op when CLAUDE.md is absent.
-func copyClaudeMainFile(root string) error {
-	src := filepath.Join(root, "CLAUDE.md")
+// mirrorClaudeMainFile copies <root>/CLAUDE.md byte-for-byte to
+// <root>/AGNOSTIC_AI.md. No-op when CLAUDE.md is absent.
+func mirrorClaudeMainFile(root string) error {
+	src := filepath.Join(root, claudeMainFile)
+	dst := filepath.Join(root, agnosticMainFile)
+	if err := copyFileIfExists(src, dst); err != nil {
+		return fmt.Errorf("mirror %s: %w", claudeMainFile, err)
+	}
+	return nil
+}
+
+// copyFileIfExists copies src to dst byte-for-byte. Returns nil when
+// src is absent; surfaces every other read/write error.
+func copyFileIfExists(src, dst string) error {
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil
@@ -61,11 +75,33 @@ func copyClaudeMainFile(root string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", src, err)
 	}
-	dst := filepath.Join(root, AgnosticMainFile)
 	if err := os.WriteFile(dst, data, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", dst, err)
 	}
 	return nil
+}
+
+// copyMarkdownDir copies every top-level *.md file from srcDir into
+// dstDir byte-for-byte. Subdirectories and non-.md entries are
+// skipped. Caller must ensure srcDir exists.
+func copyMarkdownDir(srcDir, dstDir string) (int, error) {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", srcDir, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		src := filepath.Join(srcDir, e.Name())
+		dst := filepath.Join(dstDir, e.Name())
+		if err := copyFileIfExists(src, dst); err != nil {
+			return count, err
+		}
+		count++
+	}
+	return count, nil
 }
 
 // mkdirAllSources creates each non-empty source directory under root.

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -54,13 +54,21 @@ func importFromClaude(root string, src config.Sources) error {
 	return nil
 }
 
-// mirrorClaudeMainFile copies <root>/CLAUDE.md byte-for-byte to
-// <root>/AGNOSTIC_AI.md. No-op when CLAUDE.md is absent.
+// mirrorClaudeMainFile mirrors <root>/CLAUDE.md to <root>/AGNOSTIC_AI.md.
 func mirrorClaudeMainFile(root string) error {
-	src := filepath.Join(root, claudeMainFile)
+	return mirrorMainFile(root, claudeMainFile)
+}
+
+// mirrorMainFile copies <root>/<srcName> byte-for-byte to
+// <root>/AGNOSTIC_AI.md. No-op when the source is absent. Each importer
+// calls this with the target's own top-level instructions filename so
+// the project keeps a CLI-agnostic copy alongside the native file.
+// Later imports overwrite earlier mirrors (last-import wins).
+func mirrorMainFile(root, srcName string) error {
+	src := filepath.Join(root, srcName)
 	dst := filepath.Join(root, agnosticMainFile)
 	if err := copyFileIfExists(src, dst); err != nil {
-		return fmt.Errorf("mirror %s: %w", claudeMainFile, err)
+		return fmt.Errorf("mirror %s: %w", srcName, err)
 	}
 	return nil
 }

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -1,12 +1,20 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
 )
+
+// AgnosticMainFile is the project-root "main instructions" file
+// agnostic-ai mirrors during import. Sits alongside CLAUDE.md /
+// AGENTS.md / GEMINI.md and holds a verbatim copy of the source CLI's
+// top-level instructions.
+const AgnosticMainFile = "AGNOSTIC_AI.md"
 
 type importCounts struct{ rules, agents, skills, hooks int }
 
@@ -32,8 +40,31 @@ func importFromClaude(root string, src config.Sources) error {
 	if c.hooks, err = importClaudeHooks(root, filepath.Join(root, src.Hooks)); err != nil {
 		return err
 	}
+	if err := copyClaudeMainFile(root); err != nil {
+		return err
+	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks\n",
 		c.rules, c.agents, c.skills, c.hooks)
+	return nil
+}
+
+// copyClaudeMainFile mirrors CLAUDE.md to <root>/AGNOSTIC_AI.md
+// byte-for-byte so projects keep a CLI-agnostic top-level
+// instructions file alongside CLAUDE.md / AGENTS.md / GEMINI.md.
+// No-op when CLAUDE.md is absent.
+func copyClaudeMainFile(root string) error {
+	src := filepath.Join(root, "CLAUDE.md")
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+	dst := filepath.Join(root, AgnosticMainFile)
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
 	return nil
 }
 

--- a/internal/cli/import_claude_hooks.go
+++ b/internal/cli/import_claude_hooks.go
@@ -30,7 +30,7 @@ type claudeSettings struct {
 // importClaudeHooks reads .claude/settings.json and writes one yaml per
 // hook command into <dstDir>/<event>-<group>-<index>.yaml.
 func importClaudeHooks(root, dstDir string) (int, error) {
-	src := filepath.Join(root, ".claude", "settings.json")
+	src := filepath.Join(root, claudeDir, "settings.json")
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
 		return 0, nil

--- a/internal/cli/import_claude_rules.go
+++ b/internal/cli/import_claude_rules.go
@@ -11,15 +11,24 @@ import (
 )
 
 // importClaudeRules imports rules from a Claude Code project. Prefers
-// `.claude/rules/*.md` when present (each file becomes one rule,
-// byte-identical copy). Falls back to splitting CLAUDE.md on `## `
-// headings into one rule per section. Without headings it writes a
-// single rule named after the project directory.
+// `.claude/rules/*.md` (each file becomes one rule, byte-identical
+// copy). Falls back to slicing CLAUDE.md on `## ` headings when the
+// directory is absent. Without headings the slicer writes a single
+// rule named after the project directory.
 func importClaudeRules(root, dstDir string) (int, error) {
-	if n, ok, err := importClaudeRulesDir(root, dstDir); ok || err != nil {
-		return n, err
+	rulesDir := filepath.Join(root, claudeDir, "rules")
+	if dirExists(rulesDir) {
+		return copyMarkdownDir(rulesDir, dstDir)
 	}
-	src := filepath.Join(root, "CLAUDE.md")
+	return sliceClaudeMainFile(root, dstDir)
+}
+
+// sliceClaudeMainFile splits <root>/CLAUDE.md on `## ` headings into
+// one rule file per section in dstDir. Without headings it writes a
+// single rule named after the project directory. No-op when CLAUDE.md
+// is absent or empty.
+func sliceClaudeMainFile(root, dstDir string) (int, error) {
+	src := filepath.Join(root, claudeMainFile)
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
 		return 0, nil
@@ -41,11 +50,12 @@ func importClaudeRules(root, dstDir string) (int, error) {
 		}
 		return 1, nil
 	}
-	count := 0
+
 	used := map[string]int{}
 	for _, s := range sections {
 		used[s.slug] = 1
 	}
+	count := 0
 	if preamble != "" {
 		slug := preambleSlug(preamble, used)
 		path := filepath.Join(dstDir, slug+".md")
@@ -57,43 +67,11 @@ func importClaudeRules(root, dstDir string) (int, error) {
 	for _, s := range sections {
 		path := filepath.Join(dstDir, s.slug+".md")
 		if err := writeRule(path, s.slug, s.body); err != nil {
-			return 0, err
+			return count, err
 		}
 		count++
 	}
 	return count, nil
-}
-
-// importClaudeRulesDir copies each `.claude/rules/*.md` byte-for-byte
-// to dstDir. Returns (count, true, nil) when the directory exists,
-// regardless of how many .md files it contains. Returns
-// (0, false, nil) when the directory is absent so the caller can fall
-// back to slicing CLAUDE.md.
-func importClaudeRulesDir(root, dstDir string) (int, bool, error) {
-	src := filepath.Join(root, ".claude", "rules")
-	entries, err := os.ReadDir(src)
-	if errors.Is(err, fs.ErrNotExist) {
-		return 0, false, nil
-	}
-	if err != nil {
-		return 0, true, fmt.Errorf("read %s: %w", src, err)
-	}
-	count := 0
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(src, e.Name()))
-		if err != nil {
-			return count, true, fmt.Errorf("read rule %s: %w", e.Name(), err)
-		}
-		dst := filepath.Join(dstDir, e.Name())
-		if err := os.WriteFile(dst, data, 0o644); err != nil {
-			return count, true, fmt.Errorf("write %s: %w", dst, err)
-		}
-		count++
-	}
-	return count, true, nil
 }
 
 var h1HeadingRE = regexp.MustCompile(`(?m)^#[ \t]+(.+?)[ \t]*$`)

--- a/internal/cli/import_claude_rules.go
+++ b/internal/cli/import_claude_rules.go
@@ -1,9 +1,7 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,58 +18,7 @@ func importClaudeRules(root, dstDir string) (int, error) {
 	if dirExists(rulesDir) {
 		return copyMarkdownDir(rulesDir, dstDir)
 	}
-	return sliceClaudeMainFile(root, dstDir)
-}
-
-// sliceClaudeMainFile splits <root>/CLAUDE.md on `## ` headings into
-// one rule file per section in dstDir. Without headings it writes a
-// single rule named after the project directory. No-op when CLAUDE.md
-// is absent or empty.
-func sliceClaudeMainFile(root, dstDir string) (int, error) {
-	src := filepath.Join(root, claudeMainFile)
-	data, err := os.ReadFile(src)
-	if errors.Is(err, fs.ErrNotExist) {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, fmt.Errorf("read %s: %w", src, err)
-	}
-
-	preamble, sections := splitH2Sections(string(data))
-	if len(sections) == 0 {
-		body := strings.TrimSpace(string(data))
-		if body == "" {
-			return 0, nil
-		}
-		name := projectSlug(root)
-		path := filepath.Join(dstDir, name+".md")
-		if err := writeRule(path, name, body); err != nil {
-			return 0, err
-		}
-		return 1, nil
-	}
-
-	used := map[string]int{}
-	for _, s := range sections {
-		used[s.slug] = 1
-	}
-	count := 0
-	if preamble != "" {
-		slug := preambleSlug(preamble, used)
-		path := filepath.Join(dstDir, slug+".md")
-		if err := writeRule(path, slug, preamble); err != nil {
-			return 0, err
-		}
-		count++
-	}
-	for _, s := range sections {
-		path := filepath.Join(dstDir, s.slug+".md")
-		if err := writeRule(path, s.slug, s.body); err != nil {
-			return count, err
-		}
-		count++
-	}
-	return count, nil
+	return sliceMainFileByH2(root, claudeMainFile, dstDir)
 }
 
 var h1HeadingRE = regexp.MustCompile(`(?m)^#[ \t]+(.+?)[ \t]*$`)

--- a/internal/cli/import_claude_rules.go
+++ b/internal/cli/import_claude_rules.go
@@ -10,10 +10,15 @@ import (
 	"strings"
 )
 
-// importClaudeRules splits CLAUDE.md on `## ` headings into one rule file
-// per section in dstDir. Without headings it writes a single rule named
-// after the project directory.
+// importClaudeRules imports rules from a Claude Code project. Prefers
+// `.claude/rules/*.md` when present (each file becomes one rule,
+// byte-identical copy). Falls back to splitting CLAUDE.md on `## `
+// headings into one rule per section. Without headings it writes a
+// single rule named after the project directory.
 func importClaudeRules(root, dstDir string) (int, error) {
+	if n, ok, err := importClaudeRulesDir(root, dstDir); ok || err != nil {
+		return n, err
+	}
 	src := filepath.Join(root, "CLAUDE.md")
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -57,6 +62,38 @@ func importClaudeRules(root, dstDir string) (int, error) {
 		count++
 	}
 	return count, nil
+}
+
+// importClaudeRulesDir copies each `.claude/rules/*.md` byte-for-byte
+// to dstDir. Returns (count, true, nil) when the directory exists,
+// regardless of how many .md files it contains. Returns
+// (0, false, nil) when the directory is absent so the caller can fall
+// back to slicing CLAUDE.md.
+func importClaudeRulesDir(root, dstDir string) (int, bool, error) {
+	src := filepath.Join(root, ".claude", "rules")
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, true, fmt.Errorf("read %s: %w", src, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			return count, true, fmt.Errorf("read rule %s: %w", e.Name(), err)
+		}
+		dst := filepath.Join(dstDir, e.Name())
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return count, true, fmt.Errorf("write %s: %w", dst, err)
+		}
+		count++
+	}
+	return count, true, nil
 }
 
 var h1HeadingRE = regexp.MustCompile(`(?m)^#[ \t]+(.+?)[ \t]*$`)

--- a/internal/cli/import_claude_skills.go
+++ b/internal/cli/import_claude_skills.go
@@ -6,41 +6,21 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // importClaudeAgents copies .claude/agents/*.md byte-for-byte to dstDir.
 func importClaudeAgents(root, dstDir string) (int, error) {
-	src := filepath.Join(root, ".claude", "agents")
-	entries, err := os.ReadDir(src)
-	if errors.Is(err, fs.ErrNotExist) {
+	src := filepath.Join(root, claudeDir, "agents")
+	if !dirExists(src) {
 		return 0, nil
 	}
-	if err != nil {
-		return 0, fmt.Errorf("read %s: %w", src, err)
-	}
-	count := 0
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(src, e.Name()))
-		if err != nil {
-			return count, fmt.Errorf("read agent %s: %w", e.Name(), err)
-		}
-		dst := filepath.Join(dstDir, e.Name())
-		if err := os.WriteFile(dst, data, 0o644); err != nil {
-			return count, fmt.Errorf("write %s: %w", dst, err)
-		}
-		count++
-	}
-	return count, nil
+	return copyMarkdownDir(src, dstDir)
 }
 
 // importClaudeSkills copies each .claude/skills/<name>/SKILL.md to
 // <dstDir>/<name>/SKILL.md. Other files inside the skill dir are ignored.
 func importClaudeSkills(root, dstDir string) (int, error) {
-	src := filepath.Join(root, ".claude", "skills")
+	src := filepath.Join(root, claudeDir, "skills")
 	entries, err := os.ReadDir(src)
 	if errors.Is(err, fs.ErrNotExist) {
 		return 0, nil

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -74,6 +74,72 @@ func TestImportFromClaude_MonolithicRules(t *testing.T) {
 	}
 }
 
+func TestImportFromClaude_PrefersClaudeRulesDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "## sliced\n\nFrom CLAUDE.md\n")
+	ruleBody := "---\nname: go-style\n---\n\ngofmt clean.\n"
+	writeFile(t, filepath.Join(dir, ".claude", "rules", "go-style.md"), ruleBody)
+	writeFile(t, filepath.Join(dir, ".claude", "rules", "tests.md"), "tests body\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "rules", "go-style.md"))
+	if err != nil {
+		t.Fatalf("missing rules/go-style.md: %v", err)
+	}
+	if string(got) != ruleBody {
+		t.Errorf("rule not byte-identical. got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "tests.md")); err != nil {
+		t.Errorf("missing rules/tests.md: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "sliced.md")); !os.IsNotExist(err) {
+		t.Errorf("CLAUDE.md should not have been sliced when .claude/rules exists: %v", err)
+	}
+}
+
+func TestImportFromClaude_EmptyClaudeRulesDirSkipsSlicing(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "## sliced\n\nFrom CLAUDE.md\n")
+	if err := os.MkdirAll(filepath.Join(dir, ".claude", "rules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "sliced.md")); !os.IsNotExist(err) {
+		t.Errorf("empty .claude/rules should still suppress slicing: %v", err)
+	}
+}
+
+func TestImportFromClaude_WritesAgnosticMainFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "# Project\n\nTop-level instructions.\n\n## conventional-commits\n\nUse feat:.\n"
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), body)
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, AgnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", AgnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical to CLAUDE.md. got %q", got)
+	}
+}
+
+func TestImportFromClaude_NoAgnosticMainFileWhenClaudeMdMissing(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, AgnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when CLAUDE.md absent: %v", err)
+	}
+}
+
 func TestImportFromClaude_NoClaudeMd(t *testing.T) {
 	dir := t.TempDir()
 	if err := importFromClaude(dir, rootSources()); err != nil {

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -114,28 +114,28 @@ func TestImportFromClaude_EmptyClaudeRulesDirSkipsSlicing(t *testing.T) {
 	}
 }
 
-func TestImportFromClaude_WritesAgnosticMainFile(t *testing.T) {
+func TestImportFromClaude_WritesagnosticMainFile(t *testing.T) {
 	dir := t.TempDir()
 	body := "# Project\n\nTop-level instructions.\n\n## conventional-commits\n\nUse feat:.\n"
 	writeFile(t, filepath.Join(dir, "CLAUDE.md"), body)
 	if err := importFromClaude(dir, rootSources()); err != nil {
 		t.Fatal(err)
 	}
-	got, err := os.ReadFile(filepath.Join(dir, AgnosticMainFile))
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
 	if err != nil {
-		t.Fatalf("missing %s: %v", AgnosticMainFile, err)
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
 	}
 	if string(got) != body {
 		t.Errorf("AGNOSTIC_AI.md not byte-identical to CLAUDE.md. got %q", got)
 	}
 }
 
-func TestImportFromClaude_NoAgnosticMainFileWhenClaudeMdMissing(t *testing.T) {
+func TestImportFromClaude_NoagnosticMainFileWhenClaudeMdMissing(t *testing.T) {
 	dir := t.TempDir()
 	if err := importFromClaude(dir, rootSources()); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, AgnosticMainFile)); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
 		t.Errorf("expected no AGNOSTIC_AI.md when CLAUDE.md absent: %v", err)
 	}
 }

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -23,6 +23,9 @@ func importFromCodex(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
+	if err := mirrorMainFile(root, "AGENTS.md"); err != nil {
+		return err
+	}
 	summaryf("imported %d rules\n", n)
 	return nil
 }

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -18,6 +18,25 @@ func TestImportFromCodex_NoAgentsMd(t *testing.T) {
 	if len(entries) != 0 {
 		t.Errorf("expected empty rules/, got %d entries", len(entries))
 	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when AGENTS.md absent: %v", err)
+	}
+}
+
+func TestImportFromCodex_MirrorsRootAgentsMd(t *testing.T) {
+	dir := t.TempDir()
+	body := "# Project\n\nTop-level instructions.\n\n## go-style\n\ngofmt clean.\n"
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), body)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical to AGENTS.md. got %q", got)
+	}
 }
 
 func TestImportFromCodex_HandWrittenSplitsByH2(t *testing.T) {

--- a/internal/cli/import_copilot.go
+++ b/internal/cli/import_copilot.go
@@ -1,0 +1,238 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+var (
+	copilotMainFile        = filepath.Join(".github", "copilot-instructions.md")
+	copilotInstructionsDir = filepath.Join(".github", "instructions")
+	copilotChatmodesDir    = filepath.Join(".github", "chatmodes")
+	copilotMCPFile         = filepath.Join(".vscode", "mcp.json")
+)
+
+const (
+	copilotInstructionSuffix = ".instructions.md"
+	copilotChatmodeSuffix    = ".chatmode.md"
+)
+
+// importFromCopilot reads an existing GitHub Copilot project
+// (`.github/copilot-instructions.md`, `.github/instructions/`,
+// `.github/chatmodes/`, `.vscode/mcp.json`) under root and writes
+// specs into the configured source directories.
+func importFromCopilot(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Agents, src.Skills, src.MCPs); err != nil {
+		return err
+	}
+	counts, err := importCopilotRules(root, src)
+	if err != nil {
+		return err
+	}
+	chatmodes, err := importCopilotChatmodes(root, filepath.Join(root, src.Agents))
+	if err != nil {
+		return err
+	}
+	mcps, err := importCopilotMCP(root, filepath.Join(root, src.MCPs))
+	if err != nil {
+		return err
+	}
+	if err := mirrorMainFile(root, copilotMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d agents, %d skills, %d mcps\n",
+		counts.rules, counts.agents+chatmodes, counts.skills, mcps)
+	return nil
+}
+
+type copilotCounts struct{ rules, agents, skills int }
+
+// importCopilotRules prefers `.github/instructions/*.instructions.md`
+// (one file becomes one rule, agent, or skill depending on filename
+// prefix; `applyTo:` frontmatter translates to `globs:`). Falls back
+// to slicing `.github/copilot-instructions.md` on `## ` headings when
+// no instructions dir exists.
+func importCopilotRules(root string, src config.Sources) (copilotCounts, error) {
+	var c copilotCounts
+	instrDir := filepath.Join(root, copilotInstructionsDir)
+	if dirExists(instrDir) {
+		return importCopilotInstructions(instrDir, root, src)
+	}
+	n, err := sliceMainFileByH2(root, copilotMainFile, filepath.Join(root, src.Rules))
+	if err != nil {
+		return c, err
+	}
+	c.rules = n
+	return c, nil
+}
+
+// importCopilotInstructions reads every *.instructions.md under src
+// and routes it by filename prefix:
+//   - `agent-<name>.instructions.md` → <agents>/<name>.md
+//   - `skill-<name>.instructions.md` → <skills>/<name>.md
+//   - `<name>.instructions.md`       → <rules>/<name>.md
+//
+// `applyTo` (Copilot's path glob) translates to `globs`. The catch-all
+// `**` is dropped since it carries no scope.
+func importCopilotInstructions(src, root string, sources config.Sources) (copilotCounts, error) {
+	var c copilotCounts
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return c, nil
+	}
+	if err != nil {
+		return c, fmt.Errorf("read %s: %w", src, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), copilotInstructionSuffix) {
+			continue
+		}
+		full := filepath.Join(src, e.Name())
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return c, fmt.Errorf("read %s: %w", full, err)
+		}
+		base := strings.TrimSuffix(e.Name(), copilotInstructionSuffix)
+		kind, name := classifyRulesDirFile(base + ".md")
+		dstDir := pickKindDir(kind, sources)
+		translated, err := translateCopilotInstruction(name, data)
+		if err != nil {
+			return c, fmt.Errorf("translate %s: %w", e.Name(), err)
+		}
+		out := filepath.Join(root, dstDir, name+".md")
+		if err := os.WriteFile(out, translated, 0o644); err != nil {
+			return c, fmt.Errorf("write %s: %w", out, err)
+		}
+		switch kind {
+		case "agents":
+			c.agents++
+		case "skills":
+			c.skills++
+		default:
+			c.rules++
+		}
+	}
+	return c, nil
+}
+
+// translateCopilotInstruction rewrites a Copilot `.instructions.md`
+// file as an agnostic rule. `applyTo:` becomes `globs:` (the catch-all
+// `**` is dropped). A `name:` field is injected from the filename when
+// absent. A leading single-line italic paragraph (the form the emitter
+// writes for `description:`) is lifted out of the body into the
+// `description:` frontmatter so a round-trip is loss-free.
+func translateCopilotInstruction(name string, data []byte) ([]byte, error) {
+	meta, body := splitMdcFrontmatter(data)
+	if _, ok := meta["name"]; !ok {
+		meta["name"] = name
+	}
+	if applyTo, ok := meta["applyTo"].(string); ok {
+		delete(meta, "applyTo")
+		if applyTo != "" && applyTo != "**" {
+			if _, exists := meta["globs"]; !exists {
+				meta["globs"] = applyTo
+			}
+		}
+	}
+	if desc, stripped, ok := extractLeadingItalic(body); ok {
+		if _, exists := meta["description"]; !exists {
+			meta["description"] = desc
+		}
+		body = stripped
+	}
+	var fm strings.Builder
+	enc := yaml.NewEncoder(&fm)
+	enc.SetIndent(2)
+	if err := enc.Encode(meta); err != nil {
+		return nil, fmt.Errorf("marshal frontmatter: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("close encoder: %w", err)
+	}
+	var out strings.Builder
+	out.WriteString("---\n")
+	out.WriteString(fm.String())
+	out.WriteString("---\n\n")
+	out.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		out.WriteString("\n")
+	}
+	return []byte(out.String()), nil
+}
+
+// importCopilotChatmodes reads `.github/chatmodes/*.chatmode.md` and
+// writes one agent spec per chatmode into dstDir.
+func importCopilotChatmodes(root, dstDir string) (int, error) {
+	src := filepath.Join(root, copilotChatmodesDir)
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), copilotChatmodeSuffix) {
+			continue
+		}
+		full := filepath.Join(src, e.Name())
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return count, fmt.Errorf("read %s: %w", full, err)
+		}
+		name := strings.TrimSuffix(e.Name(), copilotChatmodeSuffix)
+		meta, body := splitMdcFrontmatter(data)
+		if _, ok := meta["name"]; !ok {
+			meta["name"] = name
+		}
+		translated, err := writeFrontmatter(meta, body)
+		if err != nil {
+			return count, fmt.Errorf("translate %s: %w", e.Name(), err)
+		}
+		out := filepath.Join(dstDir, name+".md")
+		if err := os.WriteFile(out, translated, 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", out, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// writeFrontmatter re-marshals meta + body as a markdown file with
+// `---` frontmatter delimiters. Generic helper for translated specs
+// where keys are not known up front.
+func writeFrontmatter(meta map[string]any, body string) ([]byte, error) {
+	var fm strings.Builder
+	enc := yaml.NewEncoder(&fm)
+	enc.SetIndent(2)
+	if err := enc.Encode(meta); err != nil {
+		return nil, fmt.Errorf("marshal frontmatter: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("close encoder: %w", err)
+	}
+	var out strings.Builder
+	out.WriteString("---\n")
+	out.WriteString(fm.String())
+	out.WriteString("---\n\n")
+	out.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		out.WriteString("\n")
+	}
+	return []byte(out.String()), nil
+}
+
+// importCopilotMCP reads `.vscode/mcp.json` (VS Code's MCP shape:
+// `{servers: {name: {...}}}`) and writes one yaml per server.
+func importCopilotMCP(root, dstDir string) (int, error) {
+	return importJSONMCPMap(filepath.Join(root, copilotMCPFile), "servers", dstDir)
+}

--- a/internal/cli/import_copilot_test.go
+++ b/internal/cli/import_copilot_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportFromCopilot_NoSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when copilot-instructions absent: %v", err)
+	}
+}
+
+func TestImportFromCopilot_MirrorsMainFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "# Copilot\n\n## rule-a\n\nbody.\n"
+	writeFile(t, filepath.Join(dir, copilotMainFile), body)
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical. got %q", got)
+	}
+}
+
+func TestImportFromCopilot_PrefersInstructionsDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, copilotMainFile), "## sliced\n\nfrom main.\n")
+	writeFile(t, filepath.Join(dir, copilotInstructionsDir, "go-style.instructions.md"),
+		"---\napplyTo: \"**/*.go\"\n---\n\ngofmt clean.\n")
+
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "rules", "go-style.md"))
+	if err != nil {
+		t.Fatalf("missing rules/go-style.md: %v", err)
+	}
+	out := string(got)
+	for _, want := range []string{"name: go-style", "globs: '**/*.go'", "gofmt clean."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in:\n%s", want, out)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "sliced.md")); !os.IsNotExist(err) {
+		t.Errorf("main file should not be sliced when instructions dir exists: %v", err)
+	}
+}
+
+func TestImportFromCopilot_DropsCatchAllApplyTo(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, copilotInstructionsDir, "rule-a.instructions.md"),
+		"---\napplyTo: \"**\"\n---\n\nbody.\n")
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "rules", "rule-a.md"))
+	if strings.Contains(string(got), "globs:") {
+		t.Errorf("catch-all ** should not become globs:\n%s", got)
+	}
+	if strings.Contains(string(got), "applyTo") {
+		t.Errorf("applyTo should be translated, got:\n%s", got)
+	}
+}
+
+func TestImportFromCopilot_ChatmodesBecomeAgents(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, copilotChatmodesDir, "reviewer.chatmode.md"),
+		"---\ndescription: Review diffs\nmodel: gpt-4\n---\n\nReview diffs.\n")
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "agents", "reviewer.md"))
+	if err != nil {
+		t.Fatalf("missing agents/reviewer.md: %v", err)
+	}
+	for _, want := range []string{"name: reviewer", "description: Review diffs", "Review diffs."} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("expected %q in agent file:\n%s", want, got)
+		}
+	}
+}
+
+func TestImportFromCopilot_AgentAndSkillPrefixesRoute(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, copilotInstructionsDir, "agent-reviewer.instructions.md"),
+		"---\napplyTo: \"**\"\n---\n\nReview diffs.\n")
+	writeFile(t, filepath.Join(dir, copilotInstructionsDir, "skill-yaml-validator.instructions.md"),
+		"---\napplyTo: \"**\"\n---\n\nValidate yaml.\n")
+	writeFile(t, filepath.Join(dir, copilotInstructionsDir, "go-style.instructions.md"),
+		"---\napplyTo: \"**/*.go\"\n---\n\ngofmt clean.\n")
+
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "agents", "reviewer.md")); err != nil {
+		t.Errorf("agent-* should land in agents/: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "skills", "yaml-validator.md")); err != nil {
+		t.Errorf("skill-* should land in skills/: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "go-style.md")); err != nil {
+		t.Errorf("plain instruction should land in rules/: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "agent-reviewer.md")); !os.IsNotExist(err) {
+		t.Errorf("agent-* should NOT land in rules/: %v", err)
+	}
+}
+
+func TestImportFromCopilot_ItalicDescriptionMovesToFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, copilotInstructionsDir, "rule-a.instructions.md"),
+		"---\napplyTo: \"**\"\n---\n\n_The reason in italics_\n\nBody text.\n")
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "rules", "rule-a.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "description: The reason in italics") {
+		t.Errorf("expected description lifted into frontmatter:\n%s", out)
+	}
+	if strings.Contains(out, "_The reason in italics_") {
+		t.Errorf("italic line should be stripped from body:\n%s", out)
+	}
+}
+
+func TestImportFromCopilot_ImportsMCP(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "servers": {
+    "fs": {"command": "fs-server"}
+  }
+}`
+	writeFile(t, filepath.Join(dir, copilotMCPFile), settings)
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "mcps", "fs.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/fs.yaml: %v", err)
+	}
+	if !strings.Contains(string(got), "command: fs-server") {
+		t.Errorf("expected command in mcp: %s", got)
+	}
+}

--- a/internal/cli/import_gemini.go
+++ b/internal/cli/import_gemini.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const (
+	geminiMainFile    = "GEMINI.md"
+	geminiCommandsDir = ".gemini/commands"
+	geminiSettings    = ".gemini/settings.json"
+)
+
+// importFromGemini reads an existing Gemini CLI project (root GEMINI.md
+// plus any nested <dir>/GEMINI.md, `.gemini/commands/`,
+// `.gemini/settings.json`) under root and writes specs into the
+// configured source directories.
+func importFromGemini(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Agents, src.Hooks, src.MCPs); err != nil {
+		return err
+	}
+	rules, err := importGeminiRules(root, filepath.Join(root, src.Rules), src)
+	if err != nil {
+		return err
+	}
+	agents, err := importGeminiCommands(root, filepath.Join(root, src.Agents))
+	if err != nil {
+		return err
+	}
+	mcps, hooks, err := importGeminiSettings(root, filepath.Join(root, src.MCPs), filepath.Join(root, src.Hooks))
+	if err != nil {
+		return err
+	}
+	if err := mirrorMainFile(root, geminiMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d agents, %d mcps, %d hooks\n", rules, agents, mcps, hooks)
+	return nil
+}
+
+// importGeminiRules walks the project for GEMINI.md files and writes
+// one rule per ## section into dstDir. Rules from <dir>/GEMINI.md
+// inherit `globs: <dir>/**`, mirroring the codex importer. Slug
+// collisions across files are deduplicated.
+func importGeminiRules(root, dstDir string, src config.Sources) (int, error) {
+	files, err := findHierarchicalMainFiles(root, geminiMainFile, src)
+	if err != nil {
+		return 0, err
+	}
+	if len(files) == 0 {
+		return 0, nil
+	}
+	used := map[string]int{}
+	count := 0
+	for _, f := range files {
+		data, err := os.ReadFile(f.path)
+		if err != nil {
+			return count, fmt.Errorf("read %s: %w", f.path, err)
+		}
+		_, sections := splitH2Sections(string(data))
+		if len(sections) == 0 {
+			body := strings.TrimSpace(string(data))
+			if body == "" {
+				continue
+			}
+			name := dedupSlug(used, projectSlug(root))
+			if err := writeScopedRule(dstDir, name, f.globs, body); err != nil {
+				return count, err
+			}
+			count++
+			continue
+		}
+		for _, s := range sections {
+			name := dedupSlug(used, s.slug)
+			if err := writeScopedRule(dstDir, name, f.globs, s.body); err != nil {
+				return count, err
+			}
+			count++
+		}
+	}
+	return count, nil
+}
+
+// importGeminiCommands reads `.gemini/commands/*.toml` and writes one
+// agent spec per command into dstDir. The `prompt` field becomes the
+// agent body; `description` is preserved in frontmatter.
+func importGeminiCommands(root, dstDir string) (int, error) {
+	src := filepath.Join(root, geminiCommandsDir)
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		full := filepath.Join(src, e.Name())
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return count, fmt.Errorf("read %s: %w", full, err)
+		}
+		desc, body := parseGeminiCommandTOML(string(data))
+		name := strings.TrimSuffix(e.Name(), ".toml")
+		out := filepath.Join(dstDir, name+".md")
+		if err := writeAgentMD(out, name, desc, nil, body); err != nil {
+			return count, err
+		}
+		count++
+	}
+	return count, nil
+}
+
+// parseGeminiCommandTOML extracts `description` and `prompt` from a
+// minimal subset of TOML that matches what the gemini emitter writes:
+// quoted string for description, triple-quoted multiline for prompt.
+// Tolerant of either order. Anything else passes through as the body
+// raw text if `prompt` is missing.
+func parseGeminiCommandTOML(s string) (description, body string) {
+	description = extractTOMLString(s, "description")
+	body = extractTOMLMultiline(s, "prompt")
+	if body == "" {
+		body = strings.TrimSpace(s)
+	}
+	return description, body
+}
+
+// extractTOMLString finds `key = "value"` and returns value. Empty if
+// not present. Does not handle escapes; gemini emitter does not write
+// them. The key boundary is enforced so a search for `description`
+// does not match `description-extra`.
+func extractTOMLString(s, key string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, key) {
+			continue
+		}
+		after := line[len(key):]
+		if after == "" || (after[0] != '=' && after[0] != ' ' && after[0] != '\t') {
+			continue
+		}
+		rest := strings.TrimSpace(after)
+		rest = strings.TrimPrefix(rest, "=")
+		rest = strings.TrimSpace(rest)
+		if strings.HasPrefix(rest, "\"") && strings.HasSuffix(rest, "\"") && len(rest) >= 2 {
+			return rest[1 : len(rest)-1]
+		}
+	}
+	return ""
+}
+
+// extractTOMLMultiline finds `key = """\n...\n"""` and returns the
+// inner block. Returns empty if not present.
+func extractTOMLMultiline(s, key string) string {
+	open := key + " = \"\"\""
+	i := strings.Index(s, open)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(open):]
+	rest = strings.TrimPrefix(rest, "\n")
+	end := strings.Index(rest, "\"\"\"")
+	if end < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimRight(rest[:end], "\n")
+}
+
+// importGeminiSettings reads `.gemini/settings.json` and writes one
+// yaml per `mcpServers` entry and one yaml per `hooks.<event>` entry.
+// Returns (mcps, hooks, err).
+func importGeminiSettings(root, mcpDst, hooksDst string) (int, int, error) {
+	src := filepath.Join(root, geminiSettings)
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return 0, 0, fmt.Errorf("parse %s: %w", src, err)
+	}
+	mcps := 0
+	if servers, ok := doc["mcpServers"].(map[string]any); ok {
+		clean := map[string]any{}
+		for k, v := range servers {
+			if sub, ok := v.(map[string]any); ok {
+				clean[k] = sub
+			}
+		}
+		n, err := writeMCPYAMLs(clean, mcpDst)
+		if err != nil {
+			return n, 0, err
+		}
+		mcps = n
+	}
+	hooks := 0
+	if hooksMap, ok := doc["hooks"].(map[string]any); ok {
+		n, err := writeGeminiHooks(hooksMap, hooksDst)
+		if err != nil {
+			return mcps, n, err
+		}
+		hooks = n
+	}
+	return mcps, hooks, nil
+}
+
+// writeGeminiHooks writes one yaml per `hooks.<event>[i]` entry into
+// dstDir. Filenames follow the Claude hook convention:
+// `<event>-1-<index>.yaml` (single group since gemini hooks are flat
+// lists per event).
+func writeGeminiHooks(hooks map[string]any, dstDir string) (int, error) {
+	events := make([]string, 0, len(hooks))
+	for e := range hooks {
+		events = append(events, e)
+	}
+	sort.Strings(events)
+	count := 0
+	for _, event := range events {
+		entries, ok := hooks[event].([]any)
+		if !ok {
+			continue
+		}
+		for i, raw := range entries {
+			entry, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			name := fmt.Sprintf("%s-1-%d", strings.ToLower(event), i+1)
+			doc := map[string]any{
+				"name":  name,
+				"event": event,
+			}
+			if cmd, ok := entry["command"].(string); ok && cmd != "" {
+				doc["command"] = cmd
+			}
+			if m, ok := entry["matcher"].(string); ok && m != "" {
+				doc["matcher"] = m
+			}
+			raw, err := yaml.Marshal(doc)
+			if err != nil {
+				return count, fmt.Errorf("marshal hook %s: %w", name, err)
+			}
+			path := filepath.Join(dstDir, name+".yaml")
+			if err := os.WriteFile(path, raw, 0o644); err != nil {
+				return count, fmt.Errorf("write %s: %w", path, err)
+			}
+			count++
+		}
+	}
+	return count, nil
+}

--- a/internal/cli/import_gemini_test.go
+++ b/internal/cli/import_gemini_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportFromGemini_NoSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromGemini(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when GEMINI.md absent: %v", err)
+	}
+}
+
+func TestImportFromGemini_MirrorsRootGeminiMd(t *testing.T) {
+	dir := t.TempDir()
+	body := "# GEMINI.md\n\n## rule-a\n\nbody.\n"
+	writeFile(t, filepath.Join(dir, geminiMainFile), body)
+	if err := importFromGemini(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical to GEMINI.md. got %q", got)
+	}
+}
+
+func TestImportFromGemini_NestedInfersGlobs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, geminiMainFile), "## root-rule\n\nbody.\n")
+	writeFile(t, filepath.Join(dir, "src", geminiMainFile), "## src-rule\n\nscoped.\n")
+	if err := importFromGemini(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	src, _ := os.ReadFile(filepath.Join(dir, "rules", "src-rule.md"))
+	if !strings.Contains(string(src), "globs: src/**") {
+		t.Errorf("src rule missing globs: src/**, got:\n%s", src)
+	}
+	root, _ := os.ReadFile(filepath.Join(dir, "rules", "root-rule.md"))
+	if strings.Contains(string(root), "globs:") {
+		t.Errorf("root rule should not have globs, got:\n%s", root)
+	}
+}
+
+func TestImportFromGemini_ImportsCommands(t *testing.T) {
+	dir := t.TempDir()
+	toml := "description = \"Ship it\"\nprompt = \"\"\"\nrun ./deploy.sh\n\"\"\"\n"
+	writeFile(t, filepath.Join(dir, geminiCommandsDir, "deploy.toml"), toml)
+	if err := importFromGemini(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agents", "deploy.md"))
+	if err != nil {
+		t.Fatalf("missing agents/deploy.md: %v", err)
+	}
+	out := string(data)
+	for _, want := range []string{"name: deploy", "description: Ship it", "run ./deploy.sh"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in agent file:\n%s", want, out)
+		}
+	}
+}
+
+func TestImportFromGemini_ImportsSettings(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "mcpServers": {
+    "fs": {"command": "fs-server"}
+  },
+  "hooks": {
+    "PostToolUse": [
+      {"matcher": "Edit", "command": "fmt"}
+    ]
+  }
+}`
+	writeFile(t, filepath.Join(dir, geminiSettings), settings)
+	if err := importFromGemini(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	mcp, err := os.ReadFile(filepath.Join(dir, "mcps", "fs.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/fs.yaml: %v", err)
+	}
+	if !strings.Contains(string(mcp), "command: fs-server") {
+		t.Errorf("mcp missing command: %s", mcp)
+	}
+	hook, err := os.ReadFile(filepath.Join(dir, "hooks", "posttooluse-1-1.yaml"))
+	if err != nil {
+		t.Fatalf("missing hooks file: %v", err)
+	}
+	for _, want := range []string{"event: PostToolUse", "matcher: Edit", "command: fmt"} {
+		if !strings.Contains(string(hook), want) {
+			t.Errorf("expected %q in hook file: %s", want, hook)
+		}
+	}
+}
+
+func TestImportFromGemini_HookWithoutCommandOmitsField(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Edit"}
+    ]
+  }
+}`
+	writeFile(t, filepath.Join(dir, geminiSettings), settings)
+	if err := importFromGemini(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	hook, err := os.ReadFile(filepath.Join(dir, "hooks", "pretooluse-1-1.yaml"))
+	if err != nil {
+		t.Fatalf("missing hooks file: %v", err)
+	}
+	if strings.Contains(string(hook), "command:") {
+		t.Errorf("hook should omit command: when source has none, got: %s", hook)
+	}
+	if strings.Contains(string(hook), "null") {
+		t.Errorf("hook should not contain null command, got: %s", hook)
+	}
+}
+
+func TestExtractTOMLString_KeyBoundary(t *testing.T) {
+	in := `description-extra = "wrong"
+description = "right"
+`
+	if got := extractTOMLString(in, "description"); got != "right" {
+		t.Errorf("expected boundary match to skip 'description-extra', got %q", got)
+	}
+}

--- a/internal/cli/import_hierarchical.go
+++ b/internal/cli/import_hierarchical.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// hierarchicalFile pairs a discovered main markdown file with its
+// inferred scope. globs is "" for root, "<dir>/**" for nested files.
+type hierarchicalFile struct {
+	path  string
+	globs string
+}
+
+// findHierarchicalMainFiles walks root for every file named filename.
+// Hidden directories, common vendor trees, and the project's own
+// agnostic source dirs are skipped so unrelated copies (vendored
+// projects, scaffolds) do not slip in. Used by codex / gemini and
+// any other importer with subtree-scoped main files.
+func findHierarchicalMainFiles(root, filename string, src config.Sources) ([]hierarchicalFile, error) {
+	var out []hierarchicalFile
+	skipDirs := map[string]bool{"node_modules": true, "vendor": true}
+	for _, p := range []string{src.Agents, src.Skills, src.Rules, src.Hooks, src.MCPs} {
+		if p != "" {
+			skipDirs[firstSegment(p)] = true
+		}
+	}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != root && (strings.HasPrefix(name, ".") || skipDirs[name]) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != filename {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		dir := filepath.ToSlash(filepath.Dir(rel))
+		var globs string
+		if dir != "." {
+			globs = dir + "/**"
+		}
+		out = append(out, hierarchicalFile{path: path, globs: globs})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
+	return out, nil
+}
+
+// writeScopedRule writes a rule spec with optional `globs:` frontmatter
+// into dstDir/name.md. Used by importers that infer scope from a
+// hierarchical source layout.
+func writeScopedRule(dstDir, name, globs, body string) error {
+	var fm strings.Builder
+	fm.WriteString("---\nname: " + name + "\n")
+	if globs != "" {
+		fm.WriteString("globs: " + globs + "\n")
+	}
+	fm.WriteString("---\n\n")
+	fm.WriteString(strings.TrimRight(body, "\n"))
+	fm.WriteString("\n")
+	path := filepath.Join(dstDir, name+".md")
+	if err := os.WriteFile(path, []byte(fm.String()), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/cli/import_opencode.go
+++ b/internal/cli/import_opencode.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"path/filepath"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+var (
+	opencodeMainFile    = filepath.Join(".opencode", "AGENTS.md")
+	opencodeCommandsDir = filepath.Join(".opencode", "commands")
+)
+
+const (
+	opencodeMCPFile = "opencode.json"
+	opencodeMCPKey  = "mcp"
+)
+
+// importFromOpencode reads an existing OpenCode (SST) project
+// (`.opencode/AGENTS.md`, `.opencode/commands/`, `opencode.json`) under
+// root and writes specs into the configured source directories.
+func importFromOpencode(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Agents, src.MCPs); err != nil {
+		return err
+	}
+	rules, err := importOpencodeRules(root, filepath.Join(root, src.Rules))
+	if err != nil {
+		return err
+	}
+	agents, err := importOpencodeCommands(root, filepath.Join(root, src.Agents))
+	if err != nil {
+		return err
+	}
+	mcps, err := importOpencodeMCP(root, filepath.Join(root, src.MCPs))
+	if err != nil {
+		return err
+	}
+	if err := mirrorMainFile(root, opencodeMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)
+	return nil
+}
+
+// importOpencodeRules prefers `.opencode/commands/*.md` is NOT a rules
+// source for OpenCode. Rules come from slicing `.opencode/AGENTS.md`
+// on `## ` headings since OpenCode has no dedicated rules directory.
+func importOpencodeRules(root, dstDir string) (int, error) {
+	return sliceMainFileByH2(root, opencodeMainFile, dstDir)
+}
+
+// importOpencodeCommands copies `.opencode/commands/*.md` byte-for-byte
+// into the agents source dir. Each command file becomes one agent.
+func importOpencodeCommands(root, dstDir string) (int, error) {
+	src := filepath.Join(root, opencodeCommandsDir)
+	if !dirExists(src) {
+		return 0, nil
+	}
+	return copyMarkdownDir(src, dstDir)
+}
+
+// importOpencodeMCP reads `opencode.json` and writes one yaml per
+// `mcp.<name>` entry. The OpenCode shape differs from the standard
+// `mcpServers` schema: entries carry `type: "local"|"remote"`, `command`
+// is an array (`["cmd", "arg1", "arg2"]`), and env vars live under
+// `environment`. This translator normalizes each entry into the
+// agnostic MCP shape (`command:` string + `args:` slice, `env:` map)
+// before writing so the YAML re-emits cleanly.
+func importOpencodeMCP(root, dstDir string) (int, error) {
+	servers, err := readJSONMapAt(filepath.Join(root, opencodeMCPFile), opencodeMCPKey)
+	if err != nil || len(servers) == 0 {
+		return 0, err
+	}
+	normalized := map[string]any{}
+	for name, raw := range servers {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		normalized[name] = normalizeOpencodeMCPEntry(entry)
+	}
+	return writeMCPYAMLs(normalized, dstDir)
+}
+
+// normalizeOpencodeMCPEntry maps OpenCode's MCP entry shape to the
+// agnostic spec shape: drop `type`, split `command: [cmd, args...]`
+// into `command` + `args`, and rename `environment` → `env`. Other
+// keys (url, headers, ...) pass through unchanged so HTTP/remote
+// entries survive a round-trip.
+func normalizeOpencodeMCPEntry(entry map[string]any) map[string]any {
+	out := map[string]any{}
+	for k, v := range entry {
+		switch k {
+		case "type":
+			continue
+		case "environment":
+			out["env"] = v
+		case "command":
+			cmd, args := splitOpencodeCommand(v)
+			if cmd != "" {
+				out["command"] = cmd
+			}
+			if len(args) > 0 {
+				out["args"] = args
+			}
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// splitOpencodeCommand interprets v as a JSON-decoded array of strings
+// (`["cmd", "arg1", ...]`) and returns the first element as the
+// command and the rest as args. A plain string value falls back to
+// command-only.
+func splitOpencodeCommand(v any) (string, []string) {
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	list, ok := v.([]any)
+	if !ok || len(list) == 0 {
+		return "", nil
+	}
+	cmd, _ := list[0].(string)
+	args := make([]string, 0, len(list)-1)
+	for _, x := range list[1:] {
+		if s, ok := x.(string); ok {
+			args = append(args, s)
+		}
+	}
+	return cmd, args
+}

--- a/internal/cli/import_opencode_test.go
+++ b/internal/cli/import_opencode_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportFromOpencode_NoSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromOpencode(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when .opencode/AGENTS.md absent: %v", err)
+	}
+}
+
+func TestImportFromOpencode_MirrorsAgentsMd(t *testing.T) {
+	dir := t.TempDir()
+	body := "# AGENTS.md\n\n## rule-a\n\nbody.\n"
+	writeFile(t, filepath.Join(dir, opencodeMainFile), body)
+	if err := importFromOpencode(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical. got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "rule-a.md")); err != nil {
+		t.Errorf("missing sliced rule rule-a.md: %v", err)
+	}
+}
+
+func TestImportFromOpencode_CopiesCommands(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nname: reviewer\n---\n\nReview diffs.\n"
+	writeFile(t, filepath.Join(dir, opencodeCommandsDir, "reviewer.md"), body)
+	if err := importFromOpencode(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "agents", "reviewer.md"))
+	if err != nil {
+		t.Fatalf("missing agents/reviewer.md: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("agent not byte-identical. got %q", got)
+	}
+}
+
+func TestImportFromOpencode_ImportsMCP(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "fs": {
+      "type": "local",
+      "command": ["fs-server", "--root", "."],
+      "environment": {"TOKEN": "abc"}
+    }
+  }
+}`
+	writeFile(t, filepath.Join(dir, opencodeMCPFile), settings)
+	if err := importFromOpencode(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "mcps", "fs.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/fs.yaml: %v", err)
+	}
+	out := string(got)
+	for _, want := range []string{
+		"name: fs",
+		"command: fs-server",
+		"args:",
+		"- --root",
+		"env:",
+		"TOKEN: abc",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in mcp file:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"type: local", "environment:", "command:\n  - fs-server"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("unexpected %q in mcp file:\n%s", unwanted, out)
+		}
+	}
+}
+
+func TestImportFromOpencode_RemoteMCP(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "mcp": {
+    "remote-fs": {"type": "remote", "url": "https://example.test/mcp"}
+  }
+}`
+	writeFile(t, filepath.Join(dir, opencodeMCPFile), settings)
+	if err := importFromOpencode(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "mcps", "remote-fs.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "url: https://example.test/mcp") {
+		t.Errorf("expected url in mcp file:\n%s", out)
+	}
+	if strings.Contains(out, "type:") {
+		t.Errorf("type should be dropped:\n%s", out)
+	}
+}

--- a/internal/cli/import_shared.go
+++ b/internal/cli/import_shared.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// extractLeadingItalic returns the inner text of a `_..._` paragraph
+// at the start of body (no surrounding whitespace) and the body with
+// that paragraph plus its trailing blank line stripped. ok is false
+// when body does not begin with a single-line italic paragraph.
+//
+// Several adapters render `description:` as a leading italic paragraph
+// in the emitted markdown. Importers use this helper to reverse that
+// transformation so a description round-trips through frontmatter
+// rather than accumulating as body content.
+func extractLeadingItalic(body string) (desc, stripped string, ok bool) {
+	trimmed := strings.TrimLeft(body, "\n")
+	nl := strings.IndexByte(trimmed, '\n')
+	var first string
+	if nl < 0 {
+		first = trimmed
+	} else {
+		first = trimmed[:nl]
+	}
+	first = strings.TrimSpace(first)
+	if len(first) < 3 || !strings.HasPrefix(first, "_") || !strings.HasSuffix(first, "_") {
+		return "", body, false
+	}
+	if strings.Count(first, "_") != 2 {
+		return "", body, false
+	}
+	desc = first[1 : len(first)-1]
+	rest := ""
+	if nl >= 0 {
+		rest = strings.TrimLeft(trimmed[nl+1:], "\n")
+	}
+	return desc, rest, true
+}
+
+// sliceMainFileByH2 splits <root>/<srcName> on `## ` headings into one
+// rule per section in dstDir. Without headings it writes a single rule
+// named after the project directory. No-op when the source file is
+// absent or empty. Reused by every importer whose target keeps rules
+// in a single concatenated markdown file (CONVENTIONS.md, AGENTS.md,
+// GEMINI.md, .opencode/AGENTS.md, .rules, etc.).
+func sliceMainFileByH2(root, srcName, dstDir string) (int, error) {
+	src := filepath.Join(root, srcName)
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+
+	preamble, sections := splitH2Sections(string(data))
+	if len(sections) == 0 {
+		body := strings.TrimSpace(string(data))
+		if body == "" {
+			return 0, nil
+		}
+		name := projectSlug(root)
+		path := filepath.Join(dstDir, name+".md")
+		if err := writeRule(path, name, body); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+
+	used := map[string]int{}
+	for _, s := range sections {
+		used[s.slug] = 1
+	}
+	count := 0
+	if preamble != "" {
+		slug := preambleSlug(preamble, used)
+		path := filepath.Join(dstDir, slug+".md")
+		if err := writeRule(path, slug, preamble); err != nil {
+			return 0, err
+		}
+		count++
+	}
+	for _, s := range sections {
+		path := filepath.Join(dstDir, s.slug+".md")
+		if err := writeRule(path, s.slug, s.body); err != nil {
+			return count, err
+		}
+		count++
+	}
+	return count, nil
+}
+
+// importJSONMCPMap reads a JSON file at srcPath, extracts the
+// flat-or-dotted key, and writes one yaml per server into dstDir.
+// Common helper for amp / opencode / vscode-style MCP shapes where
+// servers are a map keyed by name.
+func importJSONMCPMap(srcPath, mapKey, dstDir string) (int, error) {
+	servers, err := readJSONMapAt(srcPath, mapKey)
+	if err != nil || len(servers) == 0 {
+		return 0, err
+	}
+	return writeMCPYAMLs(servers, dstDir)
+}
+
+// readJSONMapAt loads srcPath as JSON and returns the map at mapKey.
+// Supports a dotted key like "amp.mcpServers" so callers can target a
+// nested key without writing custom decoders. Missing file or missing
+// key returns (nil, nil); only IO and parse failures bubble up.
+func readJSONMapAt(srcPath, mapKey string) (map[string]any, error) {
+	data, err := os.ReadFile(srcPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", srcPath, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", srcPath, err)
+	}
+	v, ok := doc[mapKey]
+	if !ok {
+		return nil, nil
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	out := map[string]any{}
+	for k, val := range m {
+		sub, ok := val.(map[string]any)
+		if !ok {
+			continue
+		}
+		out[k] = sub
+	}
+	return out, nil
+}
+
+// writeMCPYAMLs writes one yaml file per server into dstDir. Each
+// destination doc has `name: <key>` prepended; server fields pass
+// through verbatim so transport-specific keys (command/args/env or
+// url/headers) survive a round-trip.
+func writeMCPYAMLs(servers map[string]any, dstDir string) (int, error) {
+	names := make([]string, 0, len(servers))
+	for k := range servers {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	count := 0
+	for _, name := range names {
+		entry, _ := servers[name].(map[string]any)
+		doc := map[string]any{"name": name}
+		for k, v := range entry {
+			doc[k] = v
+		}
+		raw, err := yaml.Marshal(doc)
+		if err != nil {
+			return count, fmt.Errorf("marshal mcp %s: %w", name, err)
+		}
+		path := filepath.Join(dstDir, name+".yaml")
+		if err := os.WriteFile(path, raw, 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", path, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// writeAgentMD writes an agent spec to path with a name + optional
+// description and tags frontmatter, followed by body.
+func writeAgentMD(path, name, description string, tags []string, body string) error {
+	var sb strings.Builder
+	sb.WriteString("---\nname: " + name + "\n")
+	if description != "" {
+		sb.WriteString("description: " + description + "\n")
+	}
+	if len(tags) > 0 {
+		sb.WriteString("tags: [" + strings.Join(tags, ", ") + "]\n")
+	}
+	sb.WriteString("---\n\n")
+	sb.WriteString(strings.TrimRight(body, "\n"))
+	sb.WriteString("\n")
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// stringSliceFromAny coerces a YAML-unmarshaled `any` value into a
+// []string, dropping non-string elements. Returns nil for missing or
+// non-list values.
+func stringSliceFromAny(v any) []string {
+	list, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(list))
+	for _, x := range list {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/cli/import_warp.go
+++ b/internal/cli/import_warp.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const (
+	warpMainFile     = "AGENTS.md"
+	warpWorkflowsDir = ".warp/workflows"
+	warpMCPFile      = ".warp/.mcp.json"
+	warpMCPKey       = "mcpServers"
+)
+
+// importFromWarp reads an existing Warp project (AGENTS.md,
+// `.warp/workflows/`, `.warp/.mcp.json`) under root and writes specs
+// into the configured source directories.
+func importFromWarp(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Agents, src.MCPs); err != nil {
+		return err
+	}
+	rules, err := sliceMainFileByH2(root, warpMainFile, filepath.Join(root, src.Rules))
+	if err != nil {
+		return err
+	}
+	agents, err := importWarpWorkflows(root, filepath.Join(root, src.Agents))
+	if err != nil {
+		return err
+	}
+	mcps, err := importJSONMCPMap(filepath.Join(root, warpMCPFile), warpMCPKey, filepath.Join(root, src.MCPs))
+	if err != nil {
+		return err
+	}
+	if err := mirrorMainFile(root, warpMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)
+	return nil
+}
+
+// importWarpWorkflows reads `.warp/workflows/*.yaml` and writes one
+// agent spec per workflow into dstDir. The workflow `command` field
+// becomes the agent body; `description` and `tags` survive in frontmatter.
+func importWarpWorkflows(root, dstDir string) (int, error) {
+	src := filepath.Join(root, warpWorkflowsDir)
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		full := filepath.Join(src, name)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return count, fmt.Errorf("read %s: %w", full, err)
+		}
+		var doc map[string]any
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return count, fmt.Errorf("parse %s: %w", full, err)
+		}
+		agentName, _ := doc["name"].(string)
+		if agentName == "" {
+			agentName = strings.TrimSuffix(strings.TrimSuffix(name, ".yml"), ".yaml")
+		}
+		body, _ := doc["command"].(string)
+		desc, _ := doc["description"].(string)
+		tags := stringSliceFromAny(doc["tags"])
+		out := filepath.Join(dstDir, agentName+".md")
+		if err := writeAgentMD(out, agentName, desc, tags, body); err != nil {
+			return count, err
+		}
+		count++
+	}
+	return count, nil
+}
+

--- a/internal/cli/import_warp.go
+++ b/internal/cli/import_warp.go
@@ -91,4 +91,3 @@ func importWarpWorkflows(root, dstDir string) (int, error) {
 	}
 	return count, nil
 }
-

--- a/internal/cli/import_warp_test.go
+++ b/internal/cli/import_warp_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportFromWarp_NoSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromWarp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when AGENTS.md absent: %v", err)
+	}
+}
+
+func TestImportFromWarp_MirrorsAgentsMd(t *testing.T) {
+	dir := t.TempDir()
+	body := "# AGENTS.md\n\n## rule-a\n\nbody.\n"
+	writeFile(t, filepath.Join(dir, warpMainFile), body)
+	if err := importFromWarp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical to AGENTS.md. got %q", got)
+	}
+}
+
+func TestImportFromWarp_ImportsWorkflowsAsAgents(t *testing.T) {
+	dir := t.TempDir()
+	wf := "name: deploy\ndescription: ship to prod\ncommand: |\n  ./scripts/deploy.sh\n"
+	writeFile(t, filepath.Join(dir, warpWorkflowsDir, "deploy.yaml"), wf)
+	if err := importFromWarp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "agents", "deploy.md"))
+	if err != nil {
+		t.Fatalf("missing agents/deploy.md: %v", err)
+	}
+	out := string(got)
+	for _, want := range []string{"name: deploy", "description: ship to prod", "./scripts/deploy.sh"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in agent file:\n%s", want, out)
+		}
+	}
+}
+
+func TestImportFromWarp_ImportsMCPServers(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "mcpServers": {
+    "fs": {"command": "fs-server", "args": ["--root", "."]}
+  }
+}`
+	writeFile(t, filepath.Join(dir, warpMCPFile), settings)
+	if err := importFromWarp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "mcps", "fs.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/fs.yaml: %v", err)
+	}
+	for _, want := range []string{"name: fs", "command: fs-server"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("expected %q in mcp file: %s", want, data)
+		}
+	}
+}
+
+func TestImportFromWarp_WorkflowTagsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	wf := "name: deploy\ndescription: ship\ntags:\n  - release\n  - ops\ncommand: ./deploy.sh\n"
+	writeFile(t, filepath.Join(dir, warpWorkflowsDir, "deploy.yaml"), wf)
+	if err := importFromWarp(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agents", "deploy.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "tags: [release, ops]") {
+		t.Errorf("expected tags frontmatter in agent file:\n%s", out)
+	}
+}

--- a/internal/cli/import_zed.go
+++ b/internal/cli/import_zed.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const (
+	zedMainFile  = ".rules"
+	zedTasksFile = ".zed/tasks.json"
+	zedSettings  = ".zed/settings.json"
+	zedMCPKey    = "context_servers"
+)
+
+// importFromZed reads an existing Zed project (`.rules`,
+// `.zed/tasks.json`, `.zed/settings.json`) under root and writes specs
+// into the configured source directories.
+func importFromZed(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Hooks, src.MCPs); err != nil {
+		return err
+	}
+	rules, err := sliceMainFileByH2(root, zedMainFile, filepath.Join(root, src.Rules))
+	if err != nil {
+		return err
+	}
+	hooks, err := importZedTasks(root, filepath.Join(root, src.Hooks))
+	if err != nil {
+		return err
+	}
+	mcps, err := importZedContextServers(root, filepath.Join(root, src.MCPs))
+	if err != nil {
+		return err
+	}
+	if err := mirrorMainFile(root, zedMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d hooks, %d mcps\n", rules, hooks, mcps)
+	return nil
+}
+
+// importZedTasks reads `.zed/tasks.json` and writes one hook yaml per
+// task entry. Each Zed task has `label`, `command`, and optional `args`;
+// we synthesize an `event: OnDemand` since Zed has no native lifecycle
+// hooks. The full shell command (command + args, joined) becomes the
+// hook command so the round-trip is lossless.
+func importZedTasks(root, dstDir string) (int, error) {
+	src := filepath.Join(root, zedTasksFile)
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	var tasks []map[string]any
+	if err := json.Unmarshal(data, &tasks); err != nil {
+		return 0, fmt.Errorf("parse %s: %w", src, err)
+	}
+	count := 0
+	for i, t := range tasks {
+		label, _ := t["label"].(string)
+		cmd, _ := t["command"].(string)
+		if cmd == "" {
+			continue
+		}
+		args := toStringSlice(t["args"])
+		// Reverse the `sh -c "<command>"` shape the emitter writes by
+		// extracting the inner command when present.
+		fullCmd := cmd
+		if cmd == "sh" && len(args) == 2 && args[0] == "-c" {
+			fullCmd = args[1]
+		} else if len(args) > 0 {
+			fullCmd = strings.TrimSpace(cmd + " " + strings.Join(args, " "))
+		}
+		name, desc := splitZedTaskLabel(label, i)
+		doc := map[string]any{
+			"name":    name,
+			"event":   "OnDemand",
+			"command": fullCmd,
+		}
+		if desc != "" {
+			doc["description"] = desc
+		}
+		raw, err := yaml.Marshal(doc)
+		if err != nil {
+			return count, fmt.Errorf("marshal hook %s: %w", name, err)
+		}
+		path := filepath.Join(dstDir, name+".yaml")
+		if err := os.WriteFile(path, raw, 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", path, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// splitZedTaskLabel reverses the emitter's `<name> — <description>`
+// label shape. Falls back to `task-<index>` when the label is empty.
+func splitZedTaskLabel(label string, index int) (name, description string) {
+	if label == "" {
+		return fmt.Sprintf("task-%d", index+1), ""
+	}
+	if i := strings.Index(label, " — "); i >= 0 {
+		return slugify(label[:i]), strings.TrimSpace(label[i+len(" — "):])
+	}
+	return slugify(label), ""
+}
+
+func toStringSlice(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, x := range arr {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// importZedContextServers reads `.zed/settings.json` and writes one
+// yaml per `context_servers` entry. Each server has a nested `command:
+// {path, args, env}` block which we flatten to `command`/`args`/`env`.
+func importZedContextServers(root, dstDir string) (int, error) {
+	src := filepath.Join(root, zedSettings)
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return 0, fmt.Errorf("parse %s: %w", src, err)
+	}
+	servers, ok := doc[zedMCPKey].(map[string]any)
+	if !ok || len(servers) == 0 {
+		return 0, nil
+	}
+	flat := map[string]any{}
+	for name, raw := range servers {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		out := map[string]any{}
+		if cmd, ok := entry["command"].(map[string]any); ok {
+			if p, ok := cmd["path"].(string); ok && p != "" {
+				out["command"] = p
+			}
+			if args := toStringSlice(cmd["args"]); len(args) > 0 {
+				out["args"] = args
+			}
+			if env, ok := cmd["env"].(map[string]any); ok && len(env) > 0 {
+				out["env"] = env
+			}
+		}
+		if _, hasCmd := out["command"]; !hasCmd {
+			continue
+		}
+		flat[name] = out
+	}
+	if len(flat) == 0 {
+		return 0, nil
+	}
+	return writeMCPYAMLs(flat, dstDir)
+}

--- a/internal/cli/import_zed_test.go
+++ b/internal/cli/import_zed_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportFromZed_NoSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromZed(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, agnosticMainFile)); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when .rules absent: %v", err)
+	}
+}
+
+func TestImportFromZed_MirrorsRulesFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "# Project rules\n\n## rule-a\n\nbody.\n"
+	writeFile(t, filepath.Join(dir, zedMainFile), body)
+	if err := importFromZed(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if string(got) != body {
+		t.Errorf("AGNOSTIC_AI.md not byte-identical. got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules", "rule-a.md")); err != nil {
+		t.Errorf("missing sliced rule rule-a.md: %v", err)
+	}
+}
+
+func TestImportFromZed_ImportsTasksAsHooks(t *testing.T) {
+	dir := t.TempDir()
+	tasks := `[
+  {"label": "fmt — gofmt the repo", "command": "sh", "args": ["-c", "gofmt -w ."]}
+]`
+	writeFile(t, filepath.Join(dir, zedTasksFile), tasks)
+	if err := importFromZed(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "hooks", "fmt.yaml"))
+	if err != nil {
+		t.Fatalf("missing hooks/fmt.yaml: %v", err)
+	}
+	for _, want := range []string{"event: OnDemand", "command: gofmt -w .", "description: gofmt the repo"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("expected %q in hook file: %s", want, got)
+		}
+	}
+}
+
+func TestImportFromZed_ImportsContextServers(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "context_servers": {
+    "fs": {"command": {"path": "fs-server", "args": ["--root", "."]}, "settings": {}}
+  }
+}`
+	writeFile(t, filepath.Join(dir, zedSettings), settings)
+	if err := importFromZed(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "mcps", "fs.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/fs.yaml: %v", err)
+	}
+	for _, want := range []string{"command: fs-server", "args:", "--root"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("expected %q in mcp file: %s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Every importer now mirrors the target's main file to `AGNOSTIC_AI.md` (last-import-wins).
- `import claude` prefers `.claude/rules/*.md` over slicing `CLAUDE.md`.
- New importers: `aider`, `amp`, `warp`, `gemini`, `copilot`, `opencode`, `zed`.
- Shared helpers extracted into `import_shared.go`.

## Test plan

- [x] `go test ./...` (528 pass)
- [x] Per-target tests for mirror + native layout reverse