### PR TITLE
fix(sync): detect output-path collisions across targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 - `agnostic-ai init` prompts for targets by default on a TTY. Pipe a comma-separated list, or pass `--all` / `-a` to skip the picker. `-i` / `--interactive` removed.
+- `DefaultTargets()` no longer includes `amp` and `warp`. Both share root `AGENTS.md` with `codex` per the community spec; the safe default keeps `codex` as the sole owner. Users running Amp or Warp must add them explicitly and drop or remap the colliders.
 
 ### Fixed
 - `import claude` keeps preamble before the first `##` and ignores `##` lines inside fenced code blocks.
 - `agnostic-ai.yaml`: only `version` is required. Editors no longer flag a minimal config.
+- `sync` and `sync --check` now fail fast with an `output collision` error when two or more enabled targets emit to the same path (e.g. `codex` + `amp` + `warp` all owning root `AGENTS.md`). Previously silent last-writer-wins caused permanent `--check` drift no matter the write order.
 
 ### Removed
 

--- a/agnostic-ai.yaml
+++ b/agnostic-ai.yaml
@@ -18,6 +18,13 @@ sources:
 # AI CLIs to emit configs for. Every adapter the tool ships is enabled
 # so the project itself acts as the end-to-end fixture for each emitter.
 # Comment any out to skip.
+#
+# Note: codex, amp, and warp all default to root `AGENTS.md` per the
+# community AGENTS.md spec. Only one can own the root file in a project,
+# so the dogfood set keeps codex (which also emits .codex/config.toml)
+# and drops amp and warp. Real users pick the one matching their CLI.
+# `sync` now fails fast with an output-collision error if more than one
+# is enabled without an `outputs.<target>.file` override.
 targets:
   - claude
   - codex
@@ -28,9 +35,7 @@ targets:
   - cline
   - windsurf
   - continue
-  - amp
   - zed
-  - warp
   - opencode
 
 # Per-target output overrides. Defaults work for everything below;

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -252,6 +252,25 @@ Set non-interactively with `agnostic-ai sync --auto-sync=yes` or
 - Output directories are created on demand. Existing files are overwritten.
 - Add generated outputs to `.gitignore` to keep specs as the single source of truth (recommended).
 
+## Output collisions
+
+`codex`, `amp`, and `warp` all default to root `AGENTS.md` per the
+community [agents.md](https://agents.md) spec. Only one adapter can own
+the root file in a project.
+
+`sync` and `sync --check` fail fast with an `output collision` error
+listing every duplicated path and the targets that emit to it. Resolve
+by either:
+
+1. Dropping one of the colliding targets from `targets:` in `agnostic-ai.yaml`.
+2. Overriding the colliding path on the loser via `outputs.<target>.file`
+   (note: most CLIs only read their canonical filename, so this is
+   rarely useful in practice).
+
+The shipped defaults keep `codex` as the AGENTS.md owner. Users on Amp
+or Warp instead must enable that target explicitly and drop `codex`
+(and any other AGENTS.md owner) from `targets:`.
+
 ## Precedence
 
 Last wins:

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -33,6 +33,9 @@ func collectDrift(targets []string) ([]driftReport, error) {
 	if len(targets) == 0 {
 		targets = cfg.Targets
 	}
+	if err := detectCollisions(cfg, b, targets); err != nil {
+		return nil, err
+	}
 	for _, t := range targets {
 		adapter, err := adapters.Resolve(t)
 		if err != nil {

--- a/internal/cli/collision.go
+++ b/internal/cli/collision.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// detectCollisions returns an error when two or more targets emit to the
+// same output path. AGENTS.md is a community-shared file consumed by
+// Codex, Amp, Warp, OpenCode and Zed; enabling more than one adapter
+// that owns the same default path causes silent last-writer-wins, and
+// `sync --check` then reports perpetual drift no matter the write order.
+// Force the user to pick: drop a target, or override the colliding path
+// via outputs.<target>.file in agnostic-ai.yaml.
+func detectCollisions(cfg *config.Config, b spec.Bundle, targets []string) error {
+	owners := map[string][]string{}
+	for _, t := range targets {
+		adapter, err := adapters.Resolve(t)
+		if err != nil {
+			continue
+		}
+		adapters.StartCapture()
+		if err := adapter.Emit(b, cfg, false); err != nil {
+			adapters.StopCapture()
+			return fmt.Errorf("%s: %w", t, err)
+		}
+		for _, f := range adapters.StopCapture() {
+			owners[f.Path] = append(owners[f.Path], t)
+		}
+	}
+	var lines []string
+	for path, ts := range owners {
+		if len(ts) < 2 {
+			continue
+		}
+		sort.Strings(ts)
+		lines = append(lines, fmt.Sprintf("  %s ← %s", path, strings.Join(ts, ", ")))
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	sort.Strings(lines)
+	return fmt.Errorf("output collision: targets emit to the same path.\n%s\n"+
+		"Resolve by dropping one from `targets:` in agnostic-ai.yaml, "+
+		"or override the collider via `outputs.<target>.file`.",
+		strings.Join(lines, "\n"))
+}

--- a/internal/cli/collision.go
+++ b/internal/cli/collision.go
@@ -45,8 +45,8 @@ func detectCollisions(cfg *config.Config, b spec.Bundle, targets []string) error
 		return nil
 	}
 	sort.Strings(lines)
-	return fmt.Errorf("output collision: targets emit to the same path.\n%s\n"+
-		"Resolve by dropping one from `targets:` in agnostic-ai.yaml, "+
-		"or override the collider via `outputs.<target>.file`.",
+	return fmt.Errorf("output collision: targets emit to the same path\n%s\n"+
+		"resolve by dropping one from `targets:` in agnostic-ai.yaml, "+
+		"or override the collider via `outputs.<target>.file`",
 		strings.Join(lines, "\n"))
 }

--- a/internal/cli/collision_test.go
+++ b/internal/cli/collision_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func TestSync_DetectsAGENTSMdCollision(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "codex,amp"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected collision error when codex and amp share AGENTS.md")
+	}
+	if !strings.Contains(err.Error(), "output collision") {
+		t.Errorf("expected 'output collision' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "AGENTS.md") {
+		t.Errorf("expected colliding path in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "amp") || !strings.Contains(err.Error(), "codex") {
+		t.Errorf("expected both target names in error, got: %v", err)
+	}
+}
+
+func TestSync_NoCollisionForDisjointTargets(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude,codex"})
+	if err := root.Execute(); err != nil {
+		t.Errorf("claude+codex should not collide: %v", err)
+	}
+}
+
+func TestSync_Check_DetectsCollision(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "codex,warp", "--check"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected collision error from sync --check")
+	}
+	if !strings.Contains(err.Error(), "output collision") {
+		t.Errorf("expected 'output collision' in error, got: %v", err)
+	}
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -160,6 +160,9 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	if len(effectiveTargets) == 0 {
 		effectiveTargets = cfg.Targets
 	}
+	if err := detectCollisions(cfg, b, effectiveTargets); err != nil {
+		return err
+	}
 	if backup {
 		adapters.SetBackup(true)
 		defer adapters.SetBackup(false)
@@ -216,6 +219,9 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 	effectiveTargets := targets
 	if len(effectiveTargets) == 0 {
 		effectiveTargets = cfg.Targets
+	}
+	if err := detectCollisions(cfg, b, effectiveTargets); err != nil {
+		return err
 	}
 	if backup {
 		adapters.SetBackup(true)

--- a/internal/cli/sync_picker_test.go
+++ b/internal/cli/sync_picker_test.go
@@ -136,8 +136,10 @@ func TestSync_AllFlagSkipsPrompt(t *testing.T) {
 	dir := setupFixture(t)
 	testutil.Chdir(t, dir)
 	silence(t)
+	// Use the non-colliding default set. amp and warp share root AGENTS.md
+	// with codex, so enabling all three at once is now an explicit error.
 	if err := os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"),
-		[]byte("version: 1\ntargets:\n"+listTargets(allTargetNames())), 0o644); err != nil {
+		[]byte("version: 1\ntargets:\n"+listTargets(nonCollidingTargets())), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -151,6 +153,20 @@ func TestSync_AllFlagSkipsPrompt(t *testing.T) {
 	if !strings.Contains(string(data), "- claude") || !strings.Contains(string(data), "- opencode") {
 		t.Errorf("--all should not narrow targets, got:\n%s", data)
 	}
+}
+
+// nonCollidingTargets is allTargetNames minus amp and warp; both share
+// root AGENTS.md with codex and trip the output-collision guard.
+func nonCollidingTargets() []string {
+	skip := map[string]bool{"amp": true, "warp": true}
+	all := allTargetNames()
+	out := make([]string, 0, len(all))
+	for _, n := range all {
+		if !skip[n] {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 func listTargets(targets []string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,11 +213,17 @@ func warnLegacyOnce(path string) {
 		LegacyConfigFileName, ConfigFileName)
 }
 
+// DefaultTargets returns the safe out-of-the-box target list. Codex,
+// Amp, and Warp all default to root AGENTS.md per the community spec;
+// enabling more than one without an `outputs.<target>.file` override
+// triggers an output-collision error. The default picks Codex (which
+// also emits .codex/config.toml). Users who run Amp or Warp instead
+// must add them explicitly and drop or remap the colliders.
 func DefaultTargets() []string {
 	return []string{
 		"claude", "codex", "gemini", "cursor",
 		"copilot", "aider", "cline", "windsurf", "continue",
-		"amp", "zed", "warp", "opencode",
+		"zed", "opencode",
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,10 +80,12 @@ on-unsupported: error
 }
 
 func TestDefaultTargets(t *testing.T) {
+	// amp and warp are intentionally absent: both share root AGENTS.md
+	// with codex, so the safe default keeps codex as the sole owner.
 	want := []string{
 		"claude", "codex", "gemini", "cursor",
 		"copilot", "aider", "cline", "windsurf", "continue",
-		"amp", "zed", "warp", "opencode",
+		"zed", "opencode",
 	}
 	targets := DefaultTargets()
 	if len(targets) != len(want) {
@@ -96,6 +98,13 @@ func TestDefaultTargets(t *testing.T) {
 	for _, tgt := range targets {
 		if !wantSet[tgt] {
 			t.Errorf("unexpected target %q in DefaultTargets()", tgt)
+		}
+	}
+	for _, banned := range []string{"amp", "warp"} {
+		for _, tgt := range targets {
+			if tgt == banned {
+				t.Errorf("%q must not be in DefaultTargets (collides with codex on AGENTS.md)", banned)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`scripts/release.sh` preflight `sync --check` was failing with permanent drift on `AGENTS.md`. Root cause: `codex`, `amp`, and `warp` all default to root `AGENTS.md` per the community [agents.md](https://agents.md) spec. With all three enabled, the last writer wins on every sync and `--check` reports drift on whichever adapter wrote earlier, regardless of order. Real users hit this whenever they enable more than one AGENTS.md owner.

## Changes

- `internal/cli/collision.go`: new `detectCollisions(cfg, b, targets)` runs each adapter in capture mode, groups output paths, and returns a clear error listing every duplicated path and the targets that emit to it.
- Wired into `runSyncOnce`, `runSyncJSON`, and `collectDrift` so `sync`, `sync --json`, and `sync --check` all fail fast.
- `internal/config/config.go`: `DefaultTargets()` drops `amp` and `warp`; `codex` remains the sole AGENTS.md owner in the safe default.
- `agnostic-ai.yaml`: matching dogfood update with comment explaining the rule.
- `docs/user/configuration.md`: new "Output collisions" section documenting the rule and resolution paths.
- `CHANGELOG.md`: entry under `[Unreleased]`.
- Tests: collision fires for `codex+amp` (sync) and `codex+warp` (sync --check); disjoint sets stay clean.

## Test plan

- [x] `go test ./...` — 531 passing
- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `go run ./cmd/agnostic-ai sync --check` clean against this branch's dogfood config
- [x] Collision error reproduces with `sync -t codex,amp`

Closes the immediate release blocker on `scripts/release.sh`.