### PR TITLE
chore(dev): add make preflight + tools/hooks targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: build test test-race test-shell coverage coverage-html cover lint fmt vet install clean release playground-build playground-serve playground-clean
+.PHONY: build test test-race test-shell coverage coverage-html cover lint fmt fmt-check vet preflight tools hooks install clean release playground-build playground-serve playground-clean
 
 BIN := agnostic-ai
 PKG := ./cmd/agnostic-ai
+
+# Pinned to match .github/workflows/ci.yml (golangci-lint-action@v9 with version: v2.6).
+GOLANGCI_LINT_VERSION := v2.6.2
+LEFTHOOK_VERSION := v1.10.10
 
 build:
 	go build -trimpath -ldflags="-s -w" -o $(BIN) $(PKG)
@@ -21,8 +25,34 @@ lint:
 fmt:
 	gofmt -w .
 
+fmt-check:
+	@out=$$(gofmt -s -l .); if [ -n "$$out" ]; then \
+		echo "gofmt issues. run 'make fmt'."; \
+		echo "$$out"; \
+		exit 1; \
+	fi
+
 vet:
 	go vet ./...
+
+# preflight runs every gate the CI Lint and Test jobs run, in the same
+# order. Use this before `git push` (or wire it into a pre-push hook via
+# `make hooks`) so PR checks never surface a `make preflight`-fixable
+# error. Mirrors .github/workflows/ci.yml.
+preflight: fmt-check vet lint test
+	@echo "preflight: ok"
+
+# tools installs the developer toolchain pinned to the versions CI uses.
+# Idempotent. Run once after cloning, and again whenever the pins above
+# bump.
+tools:
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	go install github.com/evilmartians/lefthook@$(LEFTHOOK_VERSION)
+
+# hooks installs the lefthook git hooks defined in lefthook.yml. Run
+# once after cloning. Requires `make tools` first.
+hooks:
+	lefthook install
 
 cover:
 	go test -coverprofile=coverage.out ./...

--- a/docs/internal/contributing.md
+++ b/docs/internal/contributing.md
@@ -9,15 +9,15 @@ Go 1.23+.
 ```bash
 git clone https://github.com/Chemaclass/agnostic-ai
 cd agnostic-ai
+make tools      # installs golangci-lint + lefthook at CI-pinned versions
+make hooks      # wires lefthook git hooks (pre-commit, pre-push)
 make build      # builds ./agnostic-ai
 make test       # runs all tests
 ```
 
-Optional, to match CI: install [golangci-lint](https://golangci-lint.run/welcome/install/).
-
-```bash
-golangci-lint run
-```
+`make tools` puts binaries in `$(go env GOPATH)/bin`; ensure that is on
+your `$PATH`. `make hooks` then installs lefthook's pre-commit (gofmt
++ golangci-lint + go vet on staged files) and pre-push (`make preflight`).
 
 ## Dev loop
 
@@ -29,10 +29,14 @@ go run ./cmd/agnostic-ai sync --dry-run
 # focused tests
 go test ./internal/adapters/claude -run TestEmit_WritesAgent -v
 
-# before pushing
-make test
-golangci-lint run
+# before pushing — mirrors the CI Lint + Test jobs exactly
+make preflight
 ```
+
+`make preflight` runs `fmt-check` + `vet` + `lint` + `test`. The CI Lint
+job is `golangci-lint` against the same `.golangci.yml`; running
+`make preflight` locally means a green local run will not surface a new
+lint error on the PR.
 
 ## First PR
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,8 +20,10 @@ pre-commit:
 
 pre-push:
   commands:
-    tests:
-      run: go test -race ./...
+    # Mirrors the CI Lint + Test jobs so a green local push survives the
+    # PR checks. Equivalent to `make preflight`.
+    preflight:
+      run: make preflight
 
 commit-msg:
   commands:


### PR DESCRIPTION
## Summary

CI runs `golangci-lint` (Lint job) and `go test` (Test job), but the repo had no local equivalent that mirrored both. The last PR's lint-only failure (an `ST1005` error string) survived to the PR check stage because nothing local would have caught it without an explicit `golangci-lint run`. This PR closes that gap.

## Changes

- `make preflight` — runs `fmt-check`, `vet`, `lint`, `test` in the same order as `.github/workflows/ci.yml`. Single command to mirror the Lint + Test jobs.
- `make tools` — installs `golangci-lint` and `lefthook` pinned to the CI versions (`v2.6.2`, `v1.10.10`).
- `make hooks` — wraps `lefthook install` so contributors actually get the git hooks wired up.
- `lefthook.yml` pre-push now runs `make preflight` instead of only `go test -race`. A local `git push` that survives the hook will pass CI.
- `docs/internal/contributing.md` documents the new flow as the first thing after `git clone`.

## Test plan

- [x] `make tools` installs both binaries at the CI versions
- [x] `make preflight` passes locally on this branch
- [x] `make fmt-check` fails with a clear message when a file needs gofmt, passes when clean
- [x] CI workflow itself is unchanged; this only adds local-equivalent gates