### PR TITLE
feat(init): pre-tick targets with existing markers in picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### init
+- `init` pre-ticks any target whose marker is present in the working directory (`.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.github/copilot-instructions.md`, etc.). First-sync picker does the same.
+
 ## v0.10.0 - 2026-05-14
 
 ### claude

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -259,6 +259,8 @@ agnostic-ai sync -t claude,cursor,copilot
 
 CLI flag overrides config. Unknown targets log a warning and skip.
 
+Interactive `init` pre-ticks any target whose marker is present in the working directory (e.g. `.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.github/copilot-instructions.md`). The first-time sync prompt does the same. Toggle entries in the picker before confirming.
+
 ## New targets
 
 See [adding-adapters](../internal/adding-adapters.md). ~50 lines plus one registry entry.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -82,7 +82,7 @@ func newInitCmd() *cobra.Command {
 			}
 			targets := allTargetNames()
 			if !all {
-				picked, err := selectTargetsForSync(cmd.InOrStdin(), cmd.ErrOrStderr())
+				picked, err := selectTargetsForSync(cmd.InOrStdin(), cmd.ErrOrStderr(), detectExistingTargets("."))
 				if err != nil {
 					return err
 				}

--- a/internal/cli/init_interactive.go
+++ b/internal/cli/init_interactive.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -102,14 +104,21 @@ func filterToCanonicalOrder(picked map[string]bool) []string {
 
 // runInteractivePrompt drives the huh multi-select. It is glue around
 // the third-party widget; behavior is verified manually rather than
-// in unit tests.
-func runInteractivePrompt(stderr io.Writer) ([]string, error) {
+// in unit tests. preselected names are pre-ticked on entry.
+func runInteractivePrompt(stderr io.Writer, preselected []string) ([]string, error) {
 	opts := make([]huh.Option[string], len(allTargets))
 	for i, t := range allTargets {
 		label := fmt.Sprintf("%-9s %s", t.Name, t.Desc)
 		opts[i] = huh.NewOption(label, t.Name)
 	}
-	var picked []string
+	picked := make([]string, 0, len(preselected))
+	known := map[string]bool{}
+	for _, n := range preselected {
+		if !known[n] && isKnownTarget(n) {
+			known[n] = true
+			picked = append(picked, n)
+		}
+	}
 	form := huh.NewMultiSelect[string]().
 		Title("Select targets to enable").
 		Options(opts...).
@@ -125,4 +134,41 @@ func runInteractivePrompt(stderr io.Writer) ([]string, error) {
 		pickedSet[n] = true
 	}
 	return filterToCanonicalOrder(pickedSet), nil
+}
+
+// targetMarkers maps each canonical target to filesystem paths that
+// indicate the project already uses that CLI. A target is "detected"
+// when at least one of its markers exists. Markers are chosen to be
+// exclusive (no shared root files like AGENTS.md) so detection does not
+// over-tick.
+var targetMarkers = map[string][]string{
+	"claude":   {".claude"},
+	"codex":    {".codex", ".agents/agents"},
+	"gemini":   {".gemini"},
+	"cursor":   {".cursor"},
+	"copilot":  {".github/copilot-instructions.md", ".github/instructions"},
+	"aider":    {".aider.conf.yml", ".aider.conf.yaml"},
+	"cline":    {".clinerules"},
+	"windsurf": {".windsurf"},
+	"continue": {".continue"},
+	"amp":      {".amp"},
+	"zed":      {".zed"},
+	"warp":     {".warp"},
+	"opencode": {".opencode"},
+}
+
+// detectExistingTargets returns the canonical-ordered subset of
+// allTargets whose marker paths exist under root. Used by `init` to
+// pre-tick CLIs the user already has configured.
+func detectExistingTargets(root string) []string {
+	picked := map[string]bool{}
+	for _, t := range allTargets {
+		for _, marker := range targetMarkers[t.Name] {
+			if _, err := os.Stat(filepath.Join(root, marker)); err == nil {
+				picked[t.Name] = true
+				break
+			}
+		}
+	}
+	return filterToCanonicalOrder(picked)
 }

--- a/internal/cli/init_interactive_test.go
+++ b/internal/cli/init_interactive_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -56,6 +58,71 @@ func TestParsePipedSelection_Empty(t *testing.T) {
 		if !errors.Is(err, errNoTargets) {
 			t.Errorf("input %q: want errNoTargets, got %v", in, err)
 		}
+	}
+}
+
+func TestDetectExistingTargets_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	got := detectExistingTargets(dir)
+	if len(got) != 0 {
+		t.Errorf("empty dir: want no targets, got %v", got)
+	}
+}
+
+func TestDetectExistingTargets_DirMarkers(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{".claude", ".codex", ".gemini", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"claude", "codex", "gemini", "cursor"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDetectExistingTargets_CopilotFileMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".github", "copilot-instructions.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"copilot"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDetectExistingTargets_AgentsAgentsTriggersCodex(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".agents", "agents"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"codex"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDetectExistingTargets_CanonicalOrder(t *testing.T) {
+	dir := t.TempDir()
+	// Create in non-canonical order; result must still follow allTargets.
+	for _, sub := range []string{".opencode", ".claude", ".zed", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"claude", "cursor", "zed", "opencode"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }
 

--- a/internal/cli/sync_picker.go
+++ b/internal/cli/sync_picker.go
@@ -51,7 +51,7 @@ func targetsMatchDefault(targets []string) bool {
 // Returns (nil, nil) on a silent fallback — non-TTY with no piped data
 // — so the caller keeps the original targets.
 func firstSyncTargetSelection(root string, in io.Reader, out io.Writer) ([]string, error) {
-	picked, err := selectTargetsForSync(in, out)
+	picked, err := selectTargetsForSync(in, out, detectExistingTargets(root))
 	if err != nil {
 		return nil, err
 	}
@@ -67,16 +67,17 @@ func firstSyncTargetSelection(root string, in io.Reader, out io.Writer) ([]strin
 
 // selectTargetsForSync returns the user's chosen target subset.
 // Branches on input mode:
-//   - TTY: run the same multi-select prompt as `init -i`.
+//   - TTY: run the same multi-select prompt as `init -i`, pre-ticking
+//     preselected names.
 //   - Piped (non-TTY with data on stdin): parse one comma-separated line.
 //   - Neither (non-TTY, no data): return (nil, nil) for silent fallback.
 //
 // Differs from selectTargets (used by `init -i`), which errors instead
 // of returning a silent-fallback signal.
-func selectTargetsForSync(in io.Reader, stderr io.Writer) ([]string, error) {
+func selectTargetsForSync(in io.Reader, stderr io.Writer, preselected []string) ([]string, error) {
 	if f, ok := in.(*os.File); ok {
 		if term.IsTerminal(f.Fd()) {
-			return runInteractivePrompt(stderr)
+			return runInteractivePrompt(stderr, preselected)
 		}
 		if !hasPipedData(f) {
 			return nil, nil

--- a/internal/cli/sync_picker_test.go
+++ b/internal/cli/sync_picker_test.go
@@ -64,7 +64,7 @@ func TestShouldPromptTargetSelection_TargetsNarrowed(t *testing.T) {
 }
 
 func TestSelectTargetsForSync_NonTTYNoData(t *testing.T) {
-	picked, err := selectTargetsForSync(bytes.NewReader(nil), &bytes.Buffer{})
+	picked, err := selectTargetsForSync(bytes.NewReader(nil), &bytes.Buffer{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestSelectTargetsForSync_NonTTYNoData(t *testing.T) {
 
 func TestSelectTargetsForSync_PipedReader(t *testing.T) {
 	in := strings.NewReader("claude,codex\n")
-	picked, err := selectTargetsForSync(in, &bytes.Buffer{})
+	picked, err := selectTargetsForSync(in, &bytes.Buffer{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestSelectTargetsForSync_PipedReader(t *testing.T) {
 
 func TestSelectTargetsForSync_PipedUnknownTarget(t *testing.T) {
 	in := strings.NewReader("claude,bogus\n")
-	_, err := selectTargetsForSync(in, &bytes.Buffer{})
+	_, err := selectTargetsForSync(in, &bytes.Buffer{}, nil)
 	if err == nil {
 		t.Error("expected error for unknown target")
 	}


### PR DESCRIPTION
## Summary
- Detect per-target marker paths under cwd (`.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.github/copilot-instructions.md`, etc.).
- Pre-tick matching entries in the `init` multi-select and the first-sync target picker so users with an existing CLI config see it selected by default.
- Markers exclusive per target (no shared `AGENTS.md`) to avoid over-ticking.

## Test plan
- [x] `go test ./...` — 564 passed
- [x] `go vet ./...` clean
- [x] New unit tests: empty dir, dir markers, copilot file marker, `.agents/agents` codex marker, canonical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)