### PR TITLE
feat(skills): roundtrip full skill directories for claude and codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### init
 - `init` pre-ticks any target whose marker is present in the working directory (`.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.github/copilot-instructions.md`, etc.). First-sync picker does the same.
 
+### claude
+- `import claude` mirrors each skill directory in full. Helper scripts, fixtures, and nested subdirectories alongside `SKILL.md` are copied byte-for-byte into the source skills dir (was: only `SKILL.md`).
+- `sync` propagates every sibling file under a source skill folder into `.claude/skills/<name>/`. Frontmatter on `SKILL.md` is still re-rendered from the spec; everything else is copied verbatim with file mode bits preserved (executable scripts stay executable).
+
+### codex
+- `import codex` mirrors each `.agents/skills/<name>/` directory in full, including `agents/openai.yaml` and any helper assets (was: only `SKILL.md`).
+- `sync` propagates skill sibling files into `.agents/skills/<name>/`. The Codex-specific `agents/openai.yaml` derived from `x-codex` still wins over a verbatim source copy of the same path.
+
+### all
+- `emit.CopyTree` helper added for adapters that mirror file trees with mode preservation; honors capture, dry-run, recording, and backup modes uniformly.
+
 ## v0.10.0 - 2026-05-14
 
 ### claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### init
+- `init` pre-ticks any target whose marker is present in the working directory (`.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.github/copilot-instructions.md`, etc.). First-sync picker does the same.
+
 ## v0.10.0 - 2026-05-14
 
 ### claude

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -259,6 +259,8 @@ agnostic-ai sync -t claude,cursor,copilot
 
 CLI flag overrides config. Unknown targets log a warning and skip.
 
+Interactive `init` pre-ticks any target whose marker is present in the working directory (e.g. `.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.github/copilot-instructions.md`). The first-time sync prompt does the same. Toggle entries in the picker before confirming.
+
 ## New targets
 
 See [adding-adapters](../internal/adding-adapters.md). ~50 lines plus one registry entry.

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -73,8 +73,12 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	}
 
 	for _, s := range b.Skills {
-		path := filepath.Join(dir, "skills", s.Name, "SKILL.md")
+		folder := filepath.Join(dir, "skills", s.Name)
+		path := filepath.Join(folder, "SKILL.md")
 		if err := emit.WriteFile(path, emit.Frontmatter(emit.ResolveMeta(s.Meta, target))+"\n"+s.Body, dryRun); err != nil {
+			return err
+		}
+		if err := propagateSkillAssets(s, folder, dryRun); err != nil {
 			return err
 		}
 	}
@@ -88,6 +92,27 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	}
 
 	return emit.WriteMCPFile(b.MCPs, emit.MCPSchemaServersMap, emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)
+}
+
+// propagateSkillAssets mirrors every sibling file under the source
+// skill directory (`<skills-src>/<name>/`) into the emitted skill
+// folder, skipping SKILL.md because the adapter re-renders it from the
+// spec frontmatter. Skills authored in agnostic-ai can ship helper
+// scripts, fixtures, or nested subdirectories alongside SKILL.md; this
+// preserves them across `sync` so the Claude Code skill continues to
+// work after a round-trip.
+//
+// No-op when the source path is unknown (e.g. specs loaded from raw
+// bytes in the WASM playground) so adapters stay safe for in-memory
+// callers.
+func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
+	if s.Path == "" {
+		return nil
+	}
+	srcDir := filepath.Dir(s.Path)
+	return emit.CopyTree(srcDir, dstDir, func(rel string) bool {
+		return rel == "SKILL.md"
+	}, dryRun)
 }
 
 // writeSettings renders `.claude/settings.json` from the captured

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -55,6 +55,58 @@ func TestEmit_WritesSkillNested(t *testing.T) {
 	}
 }
 
+func TestEmit_PropagatesSkillAssets(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	srcSkill := filepath.Join(dir, ".agnostic-ai", "skills", "validator")
+	if err := os.MkdirAll(filepath.Join(srcSkill, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "SKILL.md"), []byte("---\nname: validator\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "scripts", "run.py"), []byte("print('ok')\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "README.md"), []byte("docs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "validator",
+			Path: filepath.Join(srcSkill, "SKILL.md"),
+			Meta: map[string]any{"name": "validator"},
+			Body: "body",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{"scripts/run.py", "README.md"} {
+		got, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "validator", filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("missing propagated asset %q: %v", rel, err)
+			continue
+		}
+		want, _ := os.ReadFile(filepath.Join(srcSkill, filepath.FromSlash(rel)))
+		if string(got) != string(want) {
+			t.Errorf("asset %q not byte-identical:\ngot:  %q\nwant: %q", rel, got, want)
+		}
+	}
+
+	info, err := os.Stat(filepath.Join(dir, ".claude", "skills", "validator", "scripts", "run.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("executable bit dropped on emit: mode=%v", info.Mode().Perm())
+	}
+}
+
 func TestEmit_WritesRulesPerFile(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -98,12 +99,14 @@ func TestEmit_PropagatesSkillAssets(t *testing.T) {
 		}
 	}
 
-	info, err := os.Stat(filepath.Join(dir, ".claude", "skills", "validator", "scripts", "run.py"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm()&0o111 == 0 {
-		t.Errorf("executable bit dropped on emit: mode=%v", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, ".claude", "skills", "validator", "scripts", "run.py"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("executable bit dropped on emit: mode=%v", info.Mode().Perm())
+		}
 	}
 }
 

--- a/internal/adapters/codex/codex_test.go
+++ b/internal/adapters/codex/codex_test.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -348,12 +349,14 @@ func TestEmit_SkillFolder_PropagatesAssets(t *testing.T) {
 		}
 	}
 
-	info, err := os.Stat(filepath.Join(dir, ".agents", "skills", "yaml-validator", "scripts", "run.py"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm()&0o111 == 0 {
-		t.Errorf("executable bit dropped on emit: mode=%v", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, ".agents", "skills", "yaml-validator", "scripts", "run.py"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("executable bit dropped on emit: mode=%v", info.Mode().Perm())
+		}
 	}
 }
 

--- a/internal/adapters/codex/codex_test.go
+++ b/internal/adapters/codex/codex_test.go
@@ -306,6 +306,57 @@ func TestEmit_SkillFolder_NoOpenAIYAMLWithoutExtras(t *testing.T) {
 	}
 }
 
+func TestEmit_SkillFolder_PropagatesAssets(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	srcSkill := filepath.Join(dir, ".agnostic-ai", "skills", "yaml-validator")
+	if err := os.MkdirAll(filepath.Join(srcSkill, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "SKILL.md"), []byte("---\nname: yaml-validator\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "scripts", "run.py"), []byte("print('ok')\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "fixtures.json"), []byte(`{"k":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "yaml-validator",
+			Path: filepath.Join(srcSkill, "SKILL.md"),
+			Body: "body",
+			Meta: map[string]any{"description": "Validate YAML."},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{"scripts/run.py", "fixtures.json"} {
+		got, err := os.ReadFile(filepath.Join(dir, ".agents", "skills", "yaml-validator", filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("missing propagated asset %q: %v", rel, err)
+			continue
+		}
+		want, _ := os.ReadFile(filepath.Join(srcSkill, filepath.FromSlash(rel)))
+		if string(got) != string(want) {
+			t.Errorf("asset %q not byte-identical:\ngot:  %q\nwant: %q", rel, got, want)
+		}
+	}
+
+	info, err := os.Stat(filepath.Join(dir, ".agents", "skills", "yaml-validator", "scripts", "run.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("executable bit dropped on emit: mode=%v", info.Mode().Perm())
+	}
+}
+
 func TestEmit_SkillFolder_RespectsSkillsDirOverride(t *testing.T) {
 	dir := testutil.TempCwd(t)
 

--- a/internal/adapters/codex/skill.go
+++ b/internal/adapters/codex/skill.go
@@ -22,14 +22,26 @@ var openaiYAMLKeys = []string{"interface", "policy", "dependencies"}
 //	<skillsDir>/<name>/
 //	  SKILL.md           (required, frontmatter + body)
 //	  agents/openai.yaml (optional, when x-codex provides UI/policy/deps)
+//	  <attached files>   (any sibling files / subdirs in the source skill)
 //
 // The SKILL.md frontmatter is reduced to the two fields Codex requires
 // (`name`, `description`) so the file stays valid against the published
 // schema regardless of what extra metadata the source spec carries.
+//
+// Any other files or subdirectories that live next to the source
+// SKILL.md (helper scripts, fixtures, additional docs) are propagated
+// byte-for-byte into the emitted skill folder. The optional Codex
+// `agents/openai.yaml` overlay derived from `x-codex` is written last
+// so a spec-authored value wins over any verbatim copy of the same
+// path from the source tree.
 func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 	folder := filepath.Join(skillsDir, s.Name)
 
 	if err := emit.WriteFile(filepath.Join(folder, "SKILL.md"), skillMarkdown(s), dryRun); err != nil {
+		return err
+	}
+
+	if err := propagateSkillAssets(s, folder, dryRun); err != nil {
 		return err
 	}
 
@@ -39,6 +51,20 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 		}
 	}
 	return nil
+}
+
+// propagateSkillAssets mirrors every sibling file under the source
+// skill directory into the emitted folder, skipping SKILL.md because
+// the adapter re-renders it from the spec frontmatter. No-op when the
+// source path is unknown (in-memory specs from the playground).
+func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
+	if s.Path == "" {
+		return nil
+	}
+	srcDir := filepath.Dir(s.Path)
+	return emit.CopyTree(srcDir, dstDir, func(rel string) bool {
+		return rel == "SKILL.md"
+	}, dryRun)
 }
 
 func skillMarkdown(s spec.Entry) string {

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -6,6 +6,7 @@ package emit
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -164,6 +165,10 @@ func StopDetailedRecording() []WrittenFile {
 // action (create/update/skip) is determined by comparing against existing
 // content; unchanged files are skipped and not rewritten.
 func WriteFile(path, content string, dryRun bool) error {
+	return writeFileWithMode(path, content, filePerm, dryRun)
+}
+
+func writeFileWithMode(path, content string, mode os.FileMode, dryRun bool) error {
 	state.mu.Lock()
 	capturing := state.capturing
 	backup := state.backup
@@ -212,7 +217,7 @@ func WriteFile(path, content string, dryRun bool) error {
 				return fmt.Errorf("backup %s: %w", path, err)
 			}
 		}
-		if err := os.WriteFile(path, []byte(content), filePerm); err != nil {
+		if err := os.WriteFile(path, []byte(content), mode); err != nil {
 			return fmt.Errorf("write %s: %w", path, err)
 		}
 		state.mu.Lock()
@@ -228,10 +233,59 @@ func WriteFile(path, content string, dryRun bool) error {
 			}
 		}
 	}
-	if err := os.WriteFile(path, []byte(content), filePerm); err != nil {
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
+}
+
+// CopyTree mirrors the regular files under srcDir into dstDir,
+// preserving file mode bits so executable scripts keep their +x bit.
+// Empty source dir is a no-op. Symlinks and other irregular entries
+// are skipped silently.
+//
+// Each copied file flows through the same mode pipeline as WriteFile,
+// so dryRun, capture, recording, detailed recording, and backup all
+// behave identically. skip is an optional predicate keyed on the path
+// relative to srcDir (forward slashes). Returning true skips the file
+// — adapters use this to exclude SKILL.md when they re-render the
+// frontmatter themselves and only want sibling assets propagated.
+func CopyTree(srcDir, dstDir string, skip func(rel string) bool, dryRun bool) error {
+	info, err := os.Stat(srcDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", srcDir, err)
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		if skip != nil && skip(filepath.ToSlash(rel)) {
+			return nil
+		}
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		dst := filepath.Join(dstDir, rel)
+		return writeFileWithMode(dst, string(data), fi.Mode().Perm(), dryRun)
+	})
 }
 
 // Frontmatter renders meta as a YAML frontmatter block. Empty meta returns

--- a/internal/cli/import_claude_skills.go
+++ b/internal/cli/import_claude_skills.go
@@ -17,8 +17,12 @@ func importClaudeAgents(root, dstDir string) (int, error) {
 	return copyMarkdownDir(src, dstDir)
 }
 
-// importClaudeSkills copies each .claude/skills/<name>/SKILL.md to
-// <dstDir>/<name>/SKILL.md. Other files inside the skill dir are ignored.
+// importClaudeSkills copies each `.claude/skills/<name>/` directory tree
+// byte-for-byte into `<dstDir>/<name>/`. SKILL.md must exist for the
+// skill to be considered; once present, every sibling file (and nested
+// subdirectories such as `scripts/`, `assets/`, helper Python/JS
+// modules, fixtures, etc.) is mirrored verbatim so a roundtrip
+// preserves the full skill payload.
 func importClaudeSkills(root, dstDir string) (int, error) {
 	src := filepath.Join(root, claudeDir, "skills")
 	entries, err := os.ReadDir(src)
@@ -33,21 +37,15 @@ func importClaudeSkills(root, dstDir string) (int, error) {
 		if !e.IsDir() {
 			continue
 		}
-		skillPath := filepath.Join(src, e.Name(), "SKILL.md")
-		data, err := os.ReadFile(skillPath)
-		if errors.Is(err, fs.ErrNotExist) {
+		skillSrc := filepath.Join(src, e.Name())
+		if _, err := os.Stat(filepath.Join(skillSrc, "SKILL.md")); errors.Is(err, fs.ErrNotExist) {
 			continue
+		} else if err != nil {
+			return count, fmt.Errorf("stat skill %s: %w", e.Name(), err)
 		}
-		if err != nil {
-			return count, fmt.Errorf("read skill %s: %w", e.Name(), err)
-		}
-		out := filepath.Join(dstDir, e.Name())
-		if err := os.MkdirAll(out, 0o755); err != nil {
-			return count, fmt.Errorf("mkdir %s: %w", out, err)
-		}
-		dst := filepath.Join(out, "SKILL.md")
-		if err := os.WriteFile(dst, data, 0o644); err != nil {
-			return count, fmt.Errorf("write %s: %w", dst, err)
+		skillDst := filepath.Join(dstDir, e.Name())
+		if err := copyDirTree(skillSrc, skillDst); err != nil {
+			return count, fmt.Errorf("copy skill %s: %w", e.Name(), err)
 		}
 		count++
 	}

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -183,6 +183,53 @@ func TestImportFromClaude_CopiesSkills(t *testing.T) {
 	}
 }
 
+func TestImportFromClaude_CopiesSkillAssets(t *testing.T) {
+	dir := t.TempDir()
+	skillRoot := filepath.Join(dir, ".claude", "skills", "validator")
+	writeFile(t, filepath.Join(skillRoot, "SKILL.md"), "---\nname: validator\n---\nbody\n")
+	writeFile(t, filepath.Join(skillRoot, "scripts", "run.py"), "print('ok')\n")
+	writeFile(t, filepath.Join(skillRoot, "fixtures", "data.json"), `{"k":1}`)
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{"SKILL.md", "scripts/run.py", "fixtures/data.json"} {
+		got, err := os.ReadFile(filepath.Join(dir, "skills", "validator", filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("missing imported skill asset %q: %v", rel, err)
+			continue
+		}
+		want, _ := os.ReadFile(filepath.Join(skillRoot, filepath.FromSlash(rel)))
+		if string(got) != string(want) {
+			t.Errorf("skill asset %q not byte-identical: got %q want %q", rel, got, want)
+		}
+	}
+}
+
+func TestImportFromClaude_PreservesSkillScriptExecutableBit(t *testing.T) {
+	dir := t.TempDir()
+	skillRoot := filepath.Join(dir, ".claude", "skills", "build")
+	writeFile(t, filepath.Join(skillRoot, "SKILL.md"), "---\nname: build\n---\nbody\n")
+	scriptPath := filepath.Join(skillRoot, "run.sh")
+	writeFile(t, scriptPath, "#!/bin/sh\necho hi\n")
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "skills", "build", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("executable bit dropped on import: mode=%v", info.Mode().Perm())
+	}
+}
+
 func TestImportFromClaude_ImportsHooks(t *testing.T) {
 	dir := t.TempDir()
 	settings := `{

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -221,12 +222,14 @@ func TestImportFromClaude_PreservesSkillScriptExecutableBit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	info, err := os.Stat(filepath.Join(dir, "skills", "build", "run.sh"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm()&0o111 == 0 {
-		t.Errorf("executable bit dropped on import: mode=%v", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, "skills", "build", "run.sh"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("executable bit dropped on import: mode=%v", info.Mode().Perm())
+		}
 	}
 }
 

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -123,10 +123,11 @@ func writeCodexAgentSpec(dstDir, name string, doc map[string]any) error {
 	return nil
 }
 
-// importCodexSkills walks `<root>/.agents/skills/<name>/SKILL.md` and
-// copies each into `<dstDir>/<name>/SKILL.md` byte-for-byte. The skills
-// emitter writes SKILL.md with frontmatter (`name`, `description`) plus
-// body; that shape round-trips as-is.
+// importCodexSkills walks `<root>/.agents/skills/<name>/` and mirrors
+// each skill folder byte-for-byte into `<dstDir>/<name>/`. Every file
+// under the skill directory — SKILL.md, `agents/openai.yaml`, helper
+// scripts, fixtures, nested subdirectories — is preserved so an import
+// then `sync` keeps the full skill payload intact across all targets.
 func importCodexSkills(root, dstDir string) (int, error) {
 	srcDir := filepath.Join(root, codexSkillsDir)
 	entries, err := os.ReadDir(srcDir)
@@ -141,21 +142,15 @@ func importCodexSkills(root, dstDir string) (int, error) {
 		if !e.IsDir() {
 			continue
 		}
-		src := filepath.Join(srcDir, e.Name(), "SKILL.md")
-		data, err := os.ReadFile(src)
-		if errors.Is(err, fs.ErrNotExist) {
+		skillSrc := filepath.Join(srcDir, e.Name())
+		if _, err := os.Stat(filepath.Join(skillSrc, "SKILL.md")); errors.Is(err, fs.ErrNotExist) {
 			continue
+		} else if err != nil {
+			return count, fmt.Errorf("stat skill %s: %w", e.Name(), err)
 		}
-		if err != nil {
-			return count, fmt.Errorf("read %s: %w", src, err)
-		}
-		dstSubdir := filepath.Join(dstDir, e.Name())
-		if err := os.MkdirAll(dstSubdir, 0o755); err != nil {
-			return count, fmt.Errorf("mkdir %s: %w", dstSubdir, err)
-		}
-		dst := filepath.Join(dstSubdir, "SKILL.md")
-		if err := os.WriteFile(dst, data, 0o644); err != nil {
-			return count, fmt.Errorf("write %s: %w", dst, err)
+		skillDst := filepath.Join(dstDir, e.Name())
+		if err := copyDirTree(skillSrc, skillDst); err != nil {
+			return count, fmt.Errorf("copy skill %s: %w", e.Name(), err)
 		}
 		count++
 	}

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -298,6 +298,31 @@ func TestImportFromCodex_SkillsFromFolders(t *testing.T) {
 	}
 }
 
+func TestImportFromCodex_CopiesSkillAssets(t *testing.T) {
+	dir := t.TempDir()
+	skillRoot := filepath.Join(dir, ".agents", "skills", "validator")
+	writeFile(t, filepath.Join(skillRoot, "SKILL.md"),
+		"---\nname: validator\n---\nbody\n")
+	writeFile(t, filepath.Join(skillRoot, "scripts", "run.py"), "print('ok')\n")
+	writeFile(t, filepath.Join(skillRoot, "agents", "openai.yaml"), "interface: cli\n")
+
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{"SKILL.md", "scripts/run.py", "agents/openai.yaml"} {
+		got, err := os.ReadFile(filepath.Join(dir, "skills", "validator", filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("missing imported skill asset %q: %v", rel, err)
+			continue
+		}
+		want, _ := os.ReadFile(filepath.Join(skillRoot, filepath.FromSlash(rel)))
+		if string(got) != string(want) {
+			t.Errorf("skill asset %q not byte-identical: got %q want %q", rel, got, want)
+		}
+	}
+}
+
 func TestImportFromCodex_HooksAndMCPsFromConfigTOML(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".codex/config.toml"), `[mcp_servers.fs]

--- a/internal/cli/import_shared.go
+++ b/internal/cli/import_shared.go
@@ -196,6 +196,47 @@ func writeAgentMD(path, name, description string, tags []string, body string) er
 	return nil
 }
 
+// copyDirTree walks srcDir recursively and writes every regular file
+// byte-for-byte into the matching location under dstDir, recreating
+// the directory layout as it goes. File mode bits are preserved so an
+// executable script remains executable on the destination. Symlinks
+// are not followed; if they appear inside a skill folder they are
+// silently skipped (skills are documented to be plain files +
+// directories — symlinks would not survive a tar/zip release anyway).
+func copyDirTree(srcDir, dstDir string) error {
+	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dstDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(target), err)
+		}
+		if err := os.WriteFile(target, data, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+		return nil
+	})
+}
+
 // stringSliceFromAny coerces a YAML-unmarshaled `any` value into a
 // []string, dropping non-string elements. Returns nil for missing or
 // non-list values.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -82,7 +82,7 @@ func newInitCmd() *cobra.Command {
 			}
 			targets := allTargetNames()
 			if !all {
-				picked, err := selectTargetsForSync(cmd.InOrStdin(), cmd.ErrOrStderr())
+				picked, err := selectTargetsForSync(cmd.InOrStdin(), cmd.ErrOrStderr(), detectExistingTargets("."))
 				if err != nil {
 					return err
 				}

--- a/internal/cli/init_interactive.go
+++ b/internal/cli/init_interactive.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -102,14 +104,21 @@ func filterToCanonicalOrder(picked map[string]bool) []string {
 
 // runInteractivePrompt drives the huh multi-select. It is glue around
 // the third-party widget; behavior is verified manually rather than
-// in unit tests.
-func runInteractivePrompt(stderr io.Writer) ([]string, error) {
+// in unit tests. preselected names are pre-ticked on entry.
+func runInteractivePrompt(stderr io.Writer, preselected []string) ([]string, error) {
 	opts := make([]huh.Option[string], len(allTargets))
 	for i, t := range allTargets {
 		label := fmt.Sprintf("%-9s %s", t.Name, t.Desc)
 		opts[i] = huh.NewOption(label, t.Name)
 	}
-	var picked []string
+	picked := make([]string, 0, len(preselected))
+	known := map[string]bool{}
+	for _, n := range preselected {
+		if !known[n] && isKnownTarget(n) {
+			known[n] = true
+			picked = append(picked, n)
+		}
+	}
 	form := huh.NewMultiSelect[string]().
 		Title("Select targets to enable").
 		Options(opts...).
@@ -125,4 +134,41 @@ func runInteractivePrompt(stderr io.Writer) ([]string, error) {
 		pickedSet[n] = true
 	}
 	return filterToCanonicalOrder(pickedSet), nil
+}
+
+// targetMarkers maps each canonical target to filesystem paths that
+// indicate the project already uses that CLI. A target is "detected"
+// when at least one of its markers exists. Markers are chosen to be
+// exclusive (no shared root files like AGENTS.md) so detection does not
+// over-tick.
+var targetMarkers = map[string][]string{
+	"claude":   {".claude"},
+	"codex":    {".codex", ".agents/agents"},
+	"gemini":   {".gemini"},
+	"cursor":   {".cursor"},
+	"copilot":  {".github/copilot-instructions.md", ".github/instructions"},
+	"aider":    {".aider.conf.yml", ".aider.conf.yaml"},
+	"cline":    {".clinerules"},
+	"windsurf": {".windsurf"},
+	"continue": {".continue"},
+	"amp":      {".amp"},
+	"zed":      {".zed"},
+	"warp":     {".warp"},
+	"opencode": {".opencode"},
+}
+
+// detectExistingTargets returns the canonical-ordered subset of
+// allTargets whose marker paths exist under root. Used by `init` to
+// pre-tick CLIs the user already has configured.
+func detectExistingTargets(root string) []string {
+	picked := map[string]bool{}
+	for _, t := range allTargets {
+		for _, marker := range targetMarkers[t.Name] {
+			if _, err := os.Stat(filepath.Join(root, marker)); err == nil {
+				picked[t.Name] = true
+				break
+			}
+		}
+	}
+	return filterToCanonicalOrder(picked)
 }

--- a/internal/cli/init_interactive_test.go
+++ b/internal/cli/init_interactive_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -56,6 +58,71 @@ func TestParsePipedSelection_Empty(t *testing.T) {
 		if !errors.Is(err, errNoTargets) {
 			t.Errorf("input %q: want errNoTargets, got %v", in, err)
 		}
+	}
+}
+
+func TestDetectExistingTargets_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	got := detectExistingTargets(dir)
+	if len(got) != 0 {
+		t.Errorf("empty dir: want no targets, got %v", got)
+	}
+}
+
+func TestDetectExistingTargets_DirMarkers(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{".claude", ".codex", ".gemini", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"claude", "codex", "gemini", "cursor"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDetectExistingTargets_CopilotFileMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".github", "copilot-instructions.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"copilot"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDetectExistingTargets_AgentsAgentsTriggersCodex(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".agents", "agents"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"codex"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDetectExistingTargets_CanonicalOrder(t *testing.T) {
+	dir := t.TempDir()
+	// Create in non-canonical order; result must still follow allTargets.
+	for _, sub := range []string{".opencode", ".claude", ".zed", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	got := detectExistingTargets(dir)
+	want := []string{"claude", "cursor", "zed", "opencode"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }
 

--- a/internal/cli/sync_picker.go
+++ b/internal/cli/sync_picker.go
@@ -51,7 +51,7 @@ func targetsMatchDefault(targets []string) bool {
 // Returns (nil, nil) on a silent fallback — non-TTY with no piped data
 // — so the caller keeps the original targets.
 func firstSyncTargetSelection(root string, in io.Reader, out io.Writer) ([]string, error) {
-	picked, err := selectTargetsForSync(in, out)
+	picked, err := selectTargetsForSync(in, out, detectExistingTargets(root))
 	if err != nil {
 		return nil, err
 	}
@@ -67,16 +67,17 @@ func firstSyncTargetSelection(root string, in io.Reader, out io.Writer) ([]strin
 
 // selectTargetsForSync returns the user's chosen target subset.
 // Branches on input mode:
-//   - TTY: run the same multi-select prompt as `init -i`.
+//   - TTY: run the same multi-select prompt as `init -i`, pre-ticking
+//     preselected names.
 //   - Piped (non-TTY with data on stdin): parse one comma-separated line.
 //   - Neither (non-TTY, no data): return (nil, nil) for silent fallback.
 //
 // Differs from selectTargets (used by `init -i`), which errors instead
 // of returning a silent-fallback signal.
-func selectTargetsForSync(in io.Reader, stderr io.Writer) ([]string, error) {
+func selectTargetsForSync(in io.Reader, stderr io.Writer, preselected []string) ([]string, error) {
 	if f, ok := in.(*os.File); ok {
 		if term.IsTerminal(f.Fd()) {
-			return runInteractivePrompt(stderr)
+			return runInteractivePrompt(stderr, preselected)
 		}
 		if !hasPipedData(f) {
 			return nil, nil

--- a/internal/cli/sync_picker_test.go
+++ b/internal/cli/sync_picker_test.go
@@ -64,7 +64,7 @@ func TestShouldPromptTargetSelection_TargetsNarrowed(t *testing.T) {
 }
 
 func TestSelectTargetsForSync_NonTTYNoData(t *testing.T) {
-	picked, err := selectTargetsForSync(bytes.NewReader(nil), &bytes.Buffer{})
+	picked, err := selectTargetsForSync(bytes.NewReader(nil), &bytes.Buffer{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestSelectTargetsForSync_NonTTYNoData(t *testing.T) {
 
 func TestSelectTargetsForSync_PipedReader(t *testing.T) {
 	in := strings.NewReader("claude,codex\n")
-	picked, err := selectTargetsForSync(in, &bytes.Buffer{})
+	picked, err := selectTargetsForSync(in, &bytes.Buffer{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestSelectTargetsForSync_PipedReader(t *testing.T) {
 
 func TestSelectTargetsForSync_PipedUnknownTarget(t *testing.T) {
 	in := strings.NewReader("claude,bogus\n")
-	_, err := selectTargetsForSync(in, &bytes.Buffer{})
+	_, err := selectTargetsForSync(in, &bytes.Buffer{}, nil)
 	if err == nil {
 		t.Error("expected error for unknown target")
 	}


### PR DESCRIPTION
## Summary

- `import claude` / `import codex` now mirror the full skill directory, preserving file mode bits (executable scripts keep +x)
- `claude` / `codex` emit propagates every sibling file under the source skill folder into the emitted skill directory; `SKILL.md` is still re-rendered from spec, everything else copies verbatim
- New `emit.CopyTree` helper: tree-aware, mode-aware, routed through capture/dry-run/recording/backup state
- `init` interactive picker pre-ticks targets that already have markers in the project
- Windows CI fix: guard exec-bit assertions since `Mode().Perm()&0o111` always returns 0 on Windows

## Test plan

- [ ] `import claude` with a skill dir containing helper scripts copies all files, preserves +x
- [ ] `import codex` same
- [ ] `sync` emits full skill dir, not just `SKILL.md`
- [ ] Dry-run mode shows all files that would be written
- [ ] Windows CI passes (exec-bit guards)