### PR TITLE
fix(sync): add .agnostic-ai/.sync-state to managed .gitignore block

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -21,8 +21,24 @@ type syncStateFile struct {
 	FilesChanged int       `json:"files_changed"`
 }
 
+// stateFileGitignoreEntry is the project-relative path of the sync state
+// file as it appears in .gitignore. Forward-slashed because gitignore
+// entries always use forward slashes regardless of OS.
+const stateFileGitignoreEntry = ".agnostic-ai/.sync-state"
+
 func stateFilePath(projectRoot string) string {
 	return filepath.Join(projectRoot, ".agnostic-ai", ".sync-state")
+}
+
+// finalizeGitignore writes the managed .gitignore block from the recorded
+// emit paths plus the sync state file entry. Callers must have called
+// adapters.StartRecording() earlier.
+func finalizeGitignore(cfg *config.Config) error {
+	entries := append(adapters.StopRecording(), stateFileGitignoreEntry)
+	if err := updateGitignore(cfg, normalizeAndSort(entries)); err != nil {
+		return fmt.Errorf("gitignore: %w", err)
+	}
+	return nil
 }
 
 func writeStateFile(projectRoot string, filesChanged int) error {
@@ -196,10 +212,8 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		filesChanged = adapters.StopCounting()
 	}
 	if gitignoreOn {
-		entries := adapters.StopRecording()
-		entries = append(entries, ".agnostic-ai/.sync-state")
-		if err := updateGitignore(cfg, normalizeAndSort(entries)); err != nil {
-			return fmt.Errorf("gitignore: %w", err)
+		if err := finalizeGitignore(cfg); err != nil {
+			return err
 		}
 		summaryf("→ updated .gitignore\n")
 	}
@@ -258,10 +272,8 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 	}
 
 	if gitignoreOn {
-		entries := adapters.StopRecording()
-		entries = append(entries, ".agnostic-ai/.sync-state")
-		if err := updateGitignore(cfg, normalizeAndSort(entries)); err != nil {
-			return fmt.Errorf("gitignore: %w", err)
+		if err := finalizeGitignore(cfg); err != nil {
+			return err
 		}
 	}
 	if !dryRun {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -196,7 +196,9 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		filesChanged = adapters.StopCounting()
 	}
 	if gitignoreOn {
-		if err := updateGitignore(cfg, normalizeAndSort(adapters.StopRecording())); err != nil {
+		entries := adapters.StopRecording()
+		entries = append(entries, ".agnostic-ai/.sync-state")
+		if err := updateGitignore(cfg, normalizeAndSort(entries)); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
 		summaryf("→ updated .gitignore\n")
@@ -256,7 +258,9 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 	}
 
 	if gitignoreOn {
-		if err := updateGitignore(cfg, normalizeAndSort(adapters.StopRecording())); err != nil {
+		entries := adapters.StopRecording()
+		entries = append(entries, ".agnostic-ai/.sync-state")
+		if err := updateGitignore(cfg, normalizeAndSort(entries)); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
 	}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -59,6 +59,26 @@ func TestSync_SingleTarget(t *testing.T) {
 	}
 }
 
+func TestSync_AddsStateFileToGitignore(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+
+	root := cli.NewRootCmd("test")
+	root.SetArgs([]string{"sync"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(content), ".agnostic-ai/.sync-state") {
+		t.Errorf("expected .agnostic-ai/.sync-state in .gitignore, got: %s", content)
+	}
+}
+
 func TestValidate_OK(t *testing.T) {
 	dir := setupFixture(t)
 	testutil.Chdir(t, dir)
@@ -107,7 +127,7 @@ func setupFixture(t *testing.T) string {
 	dir := t.TempDir()
 
 	must(t, os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"),
-		[]byte("version: 1\n"), 0o644))
+		[]byte("version: 1\ngitignore:\n  enabled: true\n"), 0o644))
 
 	must(t, os.MkdirAll(filepath.Join(dir, "agents"), 0o755))
 	must(t, os.WriteFile(filepath.Join(dir, "agents", "sample-agent.md"),


### PR DESCRIPTION
## Summary

Sync writes `.agnostic-ai/.sync-state` but never excluded it from version control. Each developer's sync produces a different timestamp, creating meaningless diffs and merge conflicts.

Include `.sync-state` in the managed gitignore block so it's automatically excluded.

## Test plan

- [x] `sync` adds `.agnostic-ai/.sync-state` to .gitignore
- [x] Integration test verifies file appears in .gitignore after sync
- [x] All existing tests pass

## Closes

Closes #136