### PR TITLE
fix(spec): derive skill name from parent dir, not SKILL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+- `spec`: derive skill name from the parent directory when frontmatter is missing, so `skills/my-skill/SKILL.md` emits to `.claude/skills/my-skill/SKILL.md` instead of `.claude/skills/SKILL/SKILL.md`.
+
 ## v0.11.0 - 2026-05-14
 
 ### Added

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -305,7 +305,14 @@ func walkDir(dir, ext string, kind Kind, parse func(string) (Entry, error)) ([]E
 		}
 		entry.Kind = kind
 		if entry.Name == "" {
-			entry.Name = strings.TrimSuffix(d.Name(), ext)
+			if kind == KindSkill && d.Name() == "SKILL.md" {
+				// Skills nest under `<skill>/SKILL.md` so the parent
+				// directory is the authoritative name, not the filename
+				// stem. Mirrors the special case in assignScopes.
+				entry.Name = filepath.Base(filepath.Dir(path))
+			} else {
+				entry.Name = strings.TrimSuffix(d.Name(), ext)
+			}
 		}
 		entries = append(entries, entry)
 		return nil

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -115,6 +115,26 @@ func TestLoadAll_NameFromFilenameIfMissing(t *testing.T) {
 	}
 }
 
+func TestLoadAll_SkillNameFromParentDirWhenFrontmatterMissing(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "skills", "my-skill", "SKILL.md"), "skill body without frontmatter")
+
+	cfg := defaultsForTest()
+	entries, err := LoadAll(dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Name != "my-skill" {
+		t.Errorf("expected name=my-skill (parent dir), got %q", entries[0].Name)
+	}
+	if entries[0].Kind != KindSkill {
+		t.Errorf("expected kind=skill, got %q", entries[0].Kind)
+	}
+}
+
 func TestLoadAll_MissingDirsAreSkipped(t *testing.T) {
 	dir := t.TempDir()
 	cfg := defaultsForTest()


### PR DESCRIPTION
Closes #139

## Summary
- `walkDir` in `internal/spec/spec.go` fell back to the filename stem when a skill had no `name` frontmatter, so `skills/my-skill/SKILL.md` got `Name = "SKILL"`. The Claude adapter then emitted to `.claude/skills/SKILL/SKILL.md`.
- Mirror the special case already in `assignScopes`: when the file is `SKILL.md`, use the parent directory as the authoritative name.
- Added `TestLoadAll_SkillNameFromParentDirWhenFrontmatterMissing` to lock the behavior.

## Test plan
- [x] `go test ./...` (575 passed across 23 packages)
- [x] `go test ./tests/integration/...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean