### PR TITLE
feat(import): write AGNOSTIC_AI.md under .agnostic-ai/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- `import` now writes `AGNOSTIC_AI.md` to `.agnostic-ai/AGNOSTIC_AI.md` instead of the project root. Delete the old root-level `AGNOSTIC_AI.md` after upgrading. The path is added to the managed `.gitignore` block so `sync --gitignore` excludes it from version control.
+
 ### Fixed
 - `spec`: derive skill name from the parent directory when frontmatter is missing, so `skills/my-skill/SKILL.md` emits to `.claude/skills/my-skill/SKILL.md` instead of `.claude/skills/SKILL/SKILL.md`.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Already have `.cursor/rules` or `AGENTS.md`? Pull them in:
 agnostic-ai import cursor         # also: codex, claude, cline, windsurf, continue
 ```
 
-`import claude` prefers `.claude/rules/*.md` (each file → one rule, byte-identical) and falls back to slicing `CLAUDE.md` on `## headings` only when that directory is absent. It also mirrors `CLAUDE.md` to a project-root `AGNOSTIC_AI.md` so you keep a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
+`import claude` prefers `.claude/rules/*.md` (each file → one rule, byte-identical) and falls back to slicing `CLAUDE.md` on `## headings` only when that directory is absent. It also mirrors `CLAUDE.md` to `.agnostic-ai/AGNOSTIC_AI.md` so you keep a CLI-agnostic top-level instructions file under the managed directory alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` at the project root.
 
 ## CI gate
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -65,12 +65,12 @@ filename. Run after `init`, in the same project root.
 | `.claude/rules/*.md` (preferred) | `<rules>/<name>.md` (byte-identical copy) |
 | `CLAUDE.md` (split on `## headings`) | `<rules>/<slug>.md` per section — only when `.claude/rules/` is absent |
 | `CLAUDE.md` (no headings) | single `<rules>/<projectname>.md` — only when `.claude/rules/` is absent |
-| `CLAUDE.md` (any form) | `AGNOSTIC_AI.md` at project root (byte-identical copy) |
+| `CLAUDE.md` (any form) | `.agnostic-ai/AGNOSTIC_AI.md` (byte-identical copy) |
 | `.claude/agents/*.md` | `<agents>/<name>.md` (byte-identical copy) |
 | `.claude/skills/<name>/SKILL.md` | `<skills>/<name>/SKILL.md` |
 | `.claude/settings.json` hooks | `<hooks>/<event>[-<matcher-slug>]-<hash8>.yaml` (filename derived from event, matcher, and commands so re-imports converge on the same path) |
 
-When `.claude/rules/` exists, slicing `CLAUDE.md` is skipped entirely (even if the directory is empty) so the on-disk rules layout is the single source of truth for rule files. `AGNOSTIC_AI.md` is still written from `CLAUDE.md` so the project keeps a CLI-agnostic top-level instructions file alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
+When `.claude/rules/` exists, slicing `CLAUDE.md` is skipped entirely (even if the directory is empty) so the on-disk rules layout is the single source of truth for rule files. `.agnostic-ai/AGNOSTIC_AI.md` is still written from `CLAUDE.md` so the project keeps a CLI-agnostic top-level instructions file under the managed directory alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` at the project root.
 
 `import codex` walks the project for `AGENTS.md` files at any depth:
 

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -16,10 +16,12 @@ const (
 	claudeDir = ".claude"
 	// claudeMainFile is the project-root Claude Code instructions file.
 	claudeMainFile = "CLAUDE.md"
-	// agnosticMainFile is the project-root CLI-agnostic instructions
-	// file. Sits alongside CLAUDE.md / AGENTS.md / GEMINI.md and holds
-	// a verbatim copy of the source CLI's top-level instructions.
-	agnosticMainFile = "AGNOSTIC_AI.md"
+	// agnosticMainFile is the CLI-agnostic instructions file. Lives
+	// under the managed .agnostic-ai/ directory and holds a verbatim
+	// copy of the source CLI's top-level instructions (CLAUDE.md,
+	// AGENTS.md, GEMINI.md, etc.). Keeping it out of the project root
+	// avoids cluttering hand-authored files.
+	agnosticMainFile = ".agnostic-ai/AGNOSTIC_AI.md"
 )
 
 type importCounts struct{ rules, agents, skills, hooks int }
@@ -57,16 +59,18 @@ func importFromClaude(root string, src config.Sources) error {
 	return nil
 }
 
-// mirrorClaudeMainFile mirrors <root>/CLAUDE.md to <root>/AGNOSTIC_AI.md.
+// mirrorClaudeMainFile mirrors <root>/CLAUDE.md to
+// <root>/.agnostic-ai/AGNOSTIC_AI.md.
 func mirrorClaudeMainFile(root string) error {
 	return mirrorMainFile(root, claudeMainFile)
 }
 
 // mirrorMainFile copies <root>/<srcName> byte-for-byte to
-// <root>/AGNOSTIC_AI.md. No-op when the source is absent. Each importer
-// calls this with the target's own top-level instructions filename so
-// the project keeps a CLI-agnostic copy alongside the native file.
-// Later imports overwrite earlier mirrors (last-import wins).
+// <root>/.agnostic-ai/AGNOSTIC_AI.md. No-op when the source is absent.
+// Each importer calls this with the target's own top-level
+// instructions filename so the project keeps a CLI-agnostic copy
+// under the managed directory. Later imports overwrite earlier
+// mirrors (last-import wins).
 func mirrorMainFile(root, srcName string) error {
 	src := filepath.Join(root, srcName)
 	dst := filepath.Join(root, agnosticMainFile)
@@ -85,6 +89,9 @@ func copyFileIfExists(src, dst string) error {
 	}
 	if err != nil {
 		return fmt.Errorf("read %s: %w", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
 	if err := os.WriteFile(dst, data, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", dst, err)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -197,7 +197,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	}
 	if gitignoreOn {
 		entries := adapters.StopRecording()
-		entries = append(entries, ".agnostic-ai/.sync-state")
+		entries = append(entries, ".agnostic-ai/.sync-state", ".agnostic-ai/AGNOSTIC_AI.md")
 		if err := updateGitignore(cfg, normalizeAndSort(entries)); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
@@ -259,7 +259,7 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 
 	if gitignoreOn {
 		entries := adapters.StopRecording()
-		entries = append(entries, ".agnostic-ai/.sync-state")
+		entries = append(entries, ".agnostic-ai/.sync-state", ".agnostic-ai/AGNOSTIC_AI.md")
 		if err := updateGitignore(cfg, normalizeAndSort(entries)); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}


### PR DESCRIPTION
## Summary
- Move the generated `AGNOSTIC_AI.md` mirror from the project root into `.agnostic-ai/AGNOSTIC_AI.md` so every artifact agnostic-ai produces lives under one managed directory.
- `copyFileIfExists` now `MkdirAll`s the destination's parent before writing, since the target directory may not exist on a fresh import.
- `sync` appends `.agnostic-ai/AGNOSTIC_AI.md` to the managed `.gitignore` block (next to `.sync-state`) so it is excluded from version control automatically.

## Migration
Delete the old root-level `AGNOSTIC_AI.md` after upgrading. Re-running any `agnostic-ai import <target>` writes the new path. Running `agnostic-ai sync --gitignore on` refreshes the managed block.

## Test plan
- [x] `go test ./...` (574 passed, 23 packages)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] Existing `import_*_test.go` suites pass unchanged (they reference the `agnosticMainFile` constant).
- [x] Spec loader does not reach `.agnostic-ai/`; the file is not picked up as a spec.

Closes #141