### PR TITLE
fix(claude): preserve rule frontmatter and drop blank line on empty meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 - `spec`: derive skill name from the parent directory when frontmatter is missing, so `skills/my-skill/SKILL.md` emits to `.claude/skills/my-skill/SKILL.md` instead of `.claude/skills/SKILL/SKILL.md`.
+- `claude`: agents, skills, commands, and rules no longer emit a leading blank line when frontmatter is empty (#137).
+- `claude`: per-file rules under `.claude/rules/<name>.md` now round-trip the spec's frontmatter and drop the synthetic `# <name>` heading. Body-only rules emit body-only (#138).
 
 ## v0.11.0 - 2026-05-14
 

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -69,7 +69,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 
 	for _, a := range b.Agents {
 		path := filepath.Join(dir, "agents", a.Name+".md")
-		if err := emit.WriteFile(path, emit.Frontmatter(emit.ResolveMeta(a.Meta, target))+"\n"+a.Body, dryRun); err != nil {
+		if err := emit.WriteFile(path, emit.Document(a.Meta, a.Body, target), dryRun); err != nil {
 			return err
 		}
 	}
@@ -77,7 +77,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	for _, s := range b.Skills {
 		folder := filepath.Join(dir, "skills", s.Name)
 		path := filepath.Join(folder, "SKILL.md")
-		if err := emit.WriteFile(path, emit.Frontmatter(emit.ResolveMeta(s.Meta, target))+"\n"+s.Body, dryRun); err != nil {
+		if err := emit.WriteFile(path, emit.Document(s.Meta, s.Body, target), dryRun); err != nil {
 			return err
 		}
 		if err := propagateSkillAssets(s, folder, dryRun); err != nil {
@@ -88,7 +88,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	commandsDir := emit.OutputCommandsDir(cfg, target, defaultCommandsDir)
 	for _, c := range b.Commands {
 		path := filepath.Join(commandsDir, c.Name+".md")
-		if err := emit.WriteFile(path, emit.Frontmatter(emit.ResolveMeta(c.Meta, target))+"\n"+c.Body, dryRun); err != nil {
+		if err := emit.WriteFile(path, emit.Document(c.Meta, c.Body, target), dryRun); err != nil {
 			return err
 		}
 	}
@@ -217,7 +217,7 @@ func writeRules(rules []spec.Entry, cfg *config.Config, dryRun bool) error {
 	rulesDir := emit.OutputRulesDir(cfg, target, defaultRulesDir)
 	for _, r := range rules {
 		path := filepath.Join(rulesDir, r.Name+".md")
-		if err := emit.WriteFile(path, "# "+r.Name+"\n\n"+r.Body, dryRun); err != nil {
+		if err := emit.WriteFile(path, emit.Document(r.Meta, r.Body, target), dryRun); err != nil {
 			return err
 		}
 	}

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -136,6 +136,131 @@ func TestEmit_WritesRulesPerFile(t *testing.T) {
 	}
 }
 
+func TestEmit_RuleWithoutMetaHasNoLeadingBlankLineOrSyntheticHeading(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindRule, Name: "r1", Body: "rule body line\n"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".claude/rules/r1.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(string(got), "\n") {
+		t.Errorf("rule file starts with blank line: %q", got)
+	}
+	if strings.HasPrefix(string(got), "# r1") {
+		t.Errorf("rule file has synthetic # heading: %q", got)
+	}
+	if string(got) != "rule body line\n" {
+		t.Errorf("expected body-only output, got %q", got)
+	}
+}
+
+func TestEmit_RuleWithMetaRoundTripsFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindRule,
+			Name: "r1",
+			Meta: map[string]any{"name": "r1", "description": "short"},
+			Body: "rule body\n",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".claude/rules/r1.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	if !strings.HasPrefix(s, "---\n") {
+		t.Errorf("expected frontmatter start, got %q", s)
+	}
+	if !strings.Contains(s, "description: short") {
+		t.Errorf("missing description in frontmatter: %q", s)
+	}
+	if strings.Contains(s, "# r1") {
+		t.Errorf("synthetic # heading must not be injected: %q", s)
+	}
+	if !strings.Contains(s, "rule body") {
+		t.Errorf("missing body: %q", s)
+	}
+}
+
+func TestEmit_AgentWithoutMetaHasNoLeadingBlankLine(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "reviewer", Body: "do reviews\n"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".claude/agents/reviewer.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(string(got), "\n") {
+		t.Errorf("agent file starts with blank line: %q", got)
+	}
+	if string(got) != "do reviews\n" {
+		t.Errorf("expected body-only output, got %q", got)
+	}
+}
+
+func TestEmit_SkillWithoutMetaHasNoLeadingBlankLine(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindSkill, Name: "validator", Body: "skill body\n"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".claude/skills/validator/SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(string(got), "\n") {
+		t.Errorf("skill file starts with blank line: %q", got)
+	}
+	if string(got) != "skill body\n" {
+		t.Errorf("expected body-only output, got %q", got)
+	}
+}
+
+func TestEmit_CommandWithoutMetaHasNoLeadingBlankLine(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindCommand, Name: "deploy", Body: "run deploy\n"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".claude/commands/deploy.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(string(got), "\n") {
+		t.Errorf("command file starts with blank line: %q", got)
+	}
+	if string(got) != "run deploy\n" {
+		t.Errorf("expected body-only output, got %q", got)
+	}
+}
+
 func TestEmit_RulesFileOverrideConcatenates(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/adapters/internal/emit/document.go
+++ b/internal/adapters/internal/emit/document.go
@@ -1,0 +1,17 @@
+package emit
+
+// Document renders a markdown document with optional YAML frontmatter
+// followed by body. When meta resolves to an empty frontmatter block,
+// the document is body-only with no leading blank line. The target
+// argument selects target-specific keys via ResolveMeta.
+//
+// Use this at every adapter call site that writes a `<frontmatter>\n<body>`
+// markdown file so empty-meta entries do not leak a blank first line and
+// non-empty meta round-trips cleanly back through the spec loader.
+func Document(meta map[string]any, body, target string) string {
+	fm := Frontmatter(ResolveMeta(meta, target))
+	if fm == "" {
+		return body
+	}
+	return fm + "\n" + body
+}

--- a/internal/adapters/internal/emit/document_test.go
+++ b/internal/adapters/internal/emit/document_test.go
@@ -1,0 +1,40 @@
+package emit
+
+import "testing"
+
+func TestDocument_EmptyMetaReturnsBodyOnly(t *testing.T) {
+	got := Document(nil, "hello body\n", "claude")
+	if got != "hello body\n" {
+		t.Errorf("expected body-only, got %q", got)
+	}
+}
+
+func TestDocument_EmptyMetaMapReturnsBodyOnly(t *testing.T) {
+	got := Document(map[string]any{}, "hello body\n", "claude")
+	if got != "hello body\n" {
+		t.Errorf("expected body-only, got %q", got)
+	}
+}
+
+func TestDocument_PrependsFrontmatterWithSeparatingNewline(t *testing.T) {
+	got := Document(map[string]any{"name": "r1"}, "body line\n", "claude")
+	want := "---\nname: r1\n---\n\nbody line\n"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestDocument_ResolvesTargetSpecificMeta(t *testing.T) {
+	meta := map[string]any{
+		"name":     "r1",
+		"x-claude": map[string]any{"allowed-tools": []any{"Read"}},
+		"x-cursor": map[string]any{"globs": "src/**"},
+	}
+	got := Document(meta, "body\n", "claude")
+	if !contains(got, "allowed-tools") {
+		t.Errorf("expected resolved claude key, got %q", got)
+	}
+	if contains(got, "globs") {
+		t.Errorf("expected cursor key stripped, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Agents, skills, commands, and rules no longer emit a leading blank first line when frontmatter is empty.
- Per-file rules under `.claude/rules/<name>.md` round-trip spec frontmatter and drop the synthetic `# <name>` heading. Body-only rules emit body-only.
- Adds `emit.Document(meta, body, target)` helper used at all four sites so the compose pattern lives in one place.

Closes #137
Closes #138

## Test plan
- [x] `go test ./...` (583 passed)
- [x] `go vet ./...`
- [x] `gofmt -s -l .` clean
- [x] New unit tests cover empty-meta (no leading blank line) and rule-with-meta (frontmatter retained, no synthetic heading) for agents, skills, commands, and rules