### PR TITLE
feat(init): print clearer next-steps guidance after scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 - `import` now writes `AGNOSTIC_AI.md` to `.agnostic-ai/AGNOSTIC_AI.md` instead of the project root. Delete the old root-level `AGNOSTIC_AI.md` after upgrading. The path is added to the managed `.gitignore` block so `sync --gitignore` excludes it from version control.
+- `init` prints a clearer two-step "next steps" block after scaffolding (`agnostic-ai import <target>` then `agnostic-ai sync`) and confirms the base directory used. Replaces the previous terse one-liner.
 
 ### Fixed
 - `spec`: derive skill name from the parent directory when frontmatter is missing, so `skills/my-skill/SKILL.md` emits to `.claude/skills/my-skill/SKILL.md` instead of `.claude/skills/SKILL/SKILL.md`.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -193,15 +193,35 @@ func scaffold(root, base string, demo bool, preset string, targets []string) err
 			return err
 		}
 	}
-	summaryf("scaffold complete. edit %s then run `agnostic-ai sync`.\n", scaffoldHint(base, kinds))
 	if demo {
 		summaryf("seeded one example spec per source folder. delete or edit to taste.\n")
 	}
 	if preset != "" {
 		summaryf("seeded preset %q. review and tune the rules to match your house style.\n", preset)
 	}
-	summaryf("import existing AI CLI config with `agnostic-ai import <source>`.\n")
+	printNextSteps(base)
 	return nil
+}
+
+// printNextSteps emits the post-scaffold guidance: a confirmation line
+// with the chosen base dir, followed by the two-step workflow most
+// users want next (import existing CLI config, then sync to targets).
+func printNextSteps(base string) {
+	summaryf("✓ initialized agnostic-ai project at %s\n", baseLabel(base))
+	summaryf("\n")
+	summaryf("next steps:\n")
+	summaryf("  agnostic-ai import <target>   # mirror an existing CLI's config into specs\n")
+	summaryf("  agnostic-ai sync              # emit to your configured targets\n")
+}
+
+// baseLabel renders the user-facing label for the scaffold root. "."
+// means the legacy root-level layout, so show the project root instead
+// of a bare dot; any other base gets a trailing slash to read as a dir.
+func baseLabel(base string) string {
+	if base == "" || base == "." {
+		return "./"
+	}
+	return filepath.ToSlash(base) + "/"
 }
 
 // writeDemoFiles mirrors every file under initdata/ into baseDir,
@@ -270,12 +290,4 @@ func writePresetFiles(baseDir, name string) error {
 		}
 		return nil
 	})
-}
-
-func scaffoldHint(base string, kinds []string) string {
-	list := strings.Join(kinds, ",")
-	if base == "" || base == "." {
-		return fmt.Sprintf("{%s}/", list)
-	}
-	return fmt.Sprintf("%s/{%s}/", filepath.ToSlash(base), list)
 }

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,17 @@ import (
 
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
+
+// captureSummary redirects summaryf output for the duration of the
+// test and returns a buffer the caller can inspect.
+func captureSummary(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prev := logOut
+	buf := &bytes.Buffer{}
+	logOut = buf
+	t.Cleanup(func() { logOut = prev })
+	return buf
+}
 
 func TestScaffold_DefaultBaseDir(t *testing.T) {
 	dir := t.TempDir()
@@ -363,5 +375,64 @@ func TestInitCmd_Interactive_PipedUnknownTarget(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, "agnostic-ai.yaml")); statErr == nil {
 		t.Error("agnostic-ai.yaml should not be written on validation error")
+	}
+}
+
+func TestScaffold_PrintsNextStepsGuidance(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(dir, "", false, "", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"✓ initialized agnostic-ai project at .agnostic-ai/",
+		"next steps:",
+		"agnostic-ai import <target>",
+		"agnostic-ai sync",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestScaffold_PrintsCustomBaseInGuidance(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(dir, "specs", false, "", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "✓ initialized agnostic-ai project at specs/") {
+		t.Errorf("expected custom base label in output:\n%s", buf.String())
+	}
+}
+
+func TestScaffold_PrintsRootBaseInGuidance(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(dir, ".", false, "", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "✓ initialized agnostic-ai project at ./") {
+		t.Errorf("expected root base label in output:\n%s", buf.String())
+	}
+}
+
+func TestScaffold_DemoAndPresetLinesPrintBeforeNextSteps(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(dir, "", true, "go", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	demoIdx := strings.Index(out, "seeded one example spec")
+	presetIdx := strings.Index(out, `seeded preset "go"`)
+	nextIdx := strings.Index(out, "next steps:")
+	if demoIdx < 0 || presetIdx < 0 || nextIdx < 0 {
+		t.Fatalf("missing expected lines in output:\n%s", out)
+	}
+	if demoIdx > nextIdx || presetIdx > nextIdx {
+		t.Errorf("demo/preset lines should appear before next steps:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- Replace the terse post-init one-liner with a clear two-step "next steps" block that points users at `agnostic-ai import <target>` then `agnostic-ai sync`.
- Confirm the chosen base directory in the output so users see where their specs live (default `.agnostic-ai/`, custom dir, or `./` for the legacy root layout).
- Demo and preset summary lines still print before the guidance block, so users see what was seeded then what to do next.

Example output:
```
✓ initialized agnostic-ai project at .agnostic-ai/

next steps:
  agnostic-ai import <target>   # mirror an existing CLI's config into specs
  agnostic-ai sync              # emit to your configured targets
```

Closes #143

## Test plan
- [x] `go test ./...` (578 pass)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] Manual: `agnostic-ai init --all` shows the new block
- [x] Manual: `agnostic-ai init --all --demo --preset go` prints demo/preset lines before the next-steps block
- [x] New unit tests cover output content, custom base dir label, legacy `.` base dir label, and ordering of demo/preset lines vs. next-steps