### PR TITLE
feat(cli): adapt init/import next-steps to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- `import` prints a next-steps block after every importer, with suggestions to run `sync --check` / `sync` and hints for other detected CLIs to import.
+- `init` next-steps adapt to context: with `--demo` or `--preset` the next step is `sync` (not `import`); detected CLIs are surfaced as suggested `import` follow-ups. Selected targets are echoed back.
+
 ## v0.12.0 - 2026-05-14
 
 ### Added

--- a/internal/cli/import_aider.go
+++ b/internal/cli/import_aider.go
@@ -23,5 +23,6 @@ func importFromAider(root string, src config.Sources) error {
 		return err
 	}
 	summaryf("imported %d rules\n", n)
+	printImportNextSteps(root, "aider")
 	return nil
 }

--- a/internal/cli/import_amp.go
+++ b/internal/cli/import_amp.go
@@ -36,6 +36,7 @@ func importFromAmp(root string, src config.Sources) error {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)
+	printImportNextSteps(root, "amp")
 	return nil
 }
 

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -57,6 +57,7 @@ func importFromClaude(root string, src config.Sources) error {
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks\n",
 		c.rules, c.agents, c.skills, c.hooks)
+	printImportNextSteps(root, "claude")
 	return nil
 }
 

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -41,6 +41,7 @@ func importFromCodex(root string, src config.Sources) error {
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks, %d mcps\n",
 		rules, agents, skills, hooks, mcps)
+	printImportNextSteps(root, "codex")
 	return nil
 }
 

--- a/internal/cli/import_copilot.go
+++ b/internal/cli/import_copilot.go
@@ -50,6 +50,7 @@ func importFromCopilot(root string, src config.Sources) error {
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d mcps\n",
 		counts.rules, counts.agents+chatmodes, counts.skills, mcps)
+	printImportNextSteps(root, "copilot")
 	return nil
 }
 

--- a/internal/cli/import_cursor.go
+++ b/internal/cli/import_cursor.go
@@ -26,6 +26,7 @@ func importFromCursor(root string, src config.Sources) error {
 		return err
 	}
 	summaryf("imported %d rules\n", n)
+	printImportNextSteps(root, "cursor")
 	return nil
 }
 

--- a/internal/cli/import_gemini.go
+++ b/internal/cli/import_gemini.go
@@ -45,6 +45,7 @@ func importFromGemini(root string, src config.Sources) error {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps, %d hooks\n", rules, agents, mcps, hooks)
+	printImportNextSteps(root, "gemini")
 	return nil
 }
 

--- a/internal/cli/import_next_steps_test.go
+++ b/internal/cli/import_next_steps_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrintImportNextSteps_PrintsSyncBlock(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	printImportNextSteps(dir, "claude")
+	out := buf.String()
+	for _, want := range []string{
+		"next steps:",
+		"agnostic-ai sync --check",
+		"agnostic-ai sync",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintImportNextSteps_FiltersJustImported(t *testing.T) {
+	dir := t.TempDir()
+	// Seed a claude marker. The hint for claude must not appear when the
+	// user just imported claude.
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureSummary(t)
+	printImportNextSteps(dir, "claude")
+	if strings.Contains(buf.String(), "import claude") {
+		t.Errorf("hint should not echo the just-imported target:\n%s", buf.String())
+	}
+}
+
+func TestPrintImportNextSteps_SuggestsOtherDetectedTargets(t *testing.T) {
+	dir := t.TempDir()
+	// Seed a codex marker so importing claude points users at codex next.
+	if err := os.MkdirAll(filepath.Join(dir, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureSummary(t)
+	printImportNextSteps(dir, "claude")
+	out := buf.String()
+	wantHint := "also detected codex/ - run 'agnostic-ai import codex' to import it"
+	if !strings.Contains(out, wantHint) {
+		t.Errorf("expected codex hint %q in output:\n%s", wantHint, out)
+	}
+}
+
+func TestPrintImportNextSteps_TruncatesAtThreeAndCounts(t *testing.T) {
+	dir := t.TempDir()
+	// Drop markers for five extra targets so the cap (3) kicks in.
+	markers := []string{".codex", ".gemini", ".cursor", ".amp", ".zed"}
+	for _, m := range markers {
+		if err := os.MkdirAll(filepath.Join(dir, m), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	buf := captureSummary(t)
+	printImportNextSteps(dir, "claude")
+	out := buf.String()
+	if !strings.Contains(out, "(and 2 more detected targets)") {
+		t.Errorf("expected truncation footer:\n%s", out)
+	}
+}
+
+func TestPrintImportNextSteps_NoDetectedTargetsOmitsHints(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	printImportNextSteps(dir, "claude")
+	out := buf.String()
+	if strings.Contains(out, "also detected") {
+		t.Errorf("should not show hints when nothing else is detected:\n%s", out)
+	}
+}

--- a/internal/cli/import_opencode.go
+++ b/internal/cli/import_opencode.go
@@ -39,6 +39,7 @@ func importFromOpencode(root string, src config.Sources) error {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)
+	printImportNextSteps(root, "opencode")
 	return nil
 }
 

--- a/internal/cli/import_rulesdir.go
+++ b/internal/cli/import_rulesdir.go
@@ -134,5 +134,6 @@ func importFromRulesDir(root, target, srcDir string, src config.Sources) error {
 	}
 	summaryf("imported %d rules, %d agents, %d skills (from %s)\n",
 		c.rules, c.agents, c.skills, target)
+	printImportNextSteps(root, target)
 	return nil
 }

--- a/internal/cli/import_shared.go
+++ b/internal/cli/import_shared.go
@@ -246,6 +246,45 @@ func copyDirTree(srcDir, dstDir string) error {
 	})
 }
 
+// printImportNextSteps emits the post-import guidance block. It always
+// suggests the sync workflow first, then surfaces up to three other
+// detected CLIs as `import <name>` hints so users discover the rest of
+// the migration path without rereading the docs.
+//
+// justImported is the source name the caller passed to runImport; it
+// is filtered out of the suggested list so users do not see their own
+// CLI echoed back.
+func printImportNextSteps(root, justImported string) {
+	summaryf("\n")
+	summaryf("next steps:\n")
+	summaryf("  agnostic-ai sync --check   # preview what changes\n")
+	summaryf("  agnostic-ai sync           # write to configured targets\n")
+
+	detected := detectExistingTargets(root)
+	hints := make([]string, 0, len(detected))
+	for _, d := range detected {
+		if d == justImported {
+			continue
+		}
+		hints = append(hints, d)
+	}
+	if len(hints) == 0 {
+		return
+	}
+	shown := hints
+	extra := 0
+	if len(hints) > 3 {
+		shown = hints[:3]
+		extra = len(hints) - 3
+	}
+	for _, h := range shown {
+		summaryf("  also detected %s/ - run 'agnostic-ai import %s' to import it\n", h, h)
+	}
+	if extra > 0 {
+		summaryf("  (and %d more detected targets)\n", extra)
+	}
+}
+
 // stringSliceFromAny coerces a YAML-unmarshaled `any` value into a
 // []string, dropping non-string elements. Returns nil for missing or
 // non-list values.

--- a/internal/cli/import_warp.go
+++ b/internal/cli/import_warp.go
@@ -43,6 +43,7 @@ func importFromWarp(root string, src config.Sources) error {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)
+	printImportNextSteps(root, "warp")
 	return nil
 }
 

--- a/internal/cli/import_zed.go
+++ b/internal/cli/import_zed.go
@@ -44,6 +44,7 @@ func importFromZed(root string, src config.Sources) error {
 		return err
 	}
 	summaryf("imported %d rules, %d hooks, %d mcps\n", rules, hooks, mcps)
+	printImportNextSteps(root, "zed")
 	return nil
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -199,19 +199,42 @@ func scaffold(root, base string, demo bool, preset string, targets []string) err
 	if preset != "" {
 		summaryf("seeded preset %q. review and tune the rules to match your house style.\n", preset)
 	}
-	printNextSteps(base)
+	printNextSteps(root, base, targets, demo || preset != "")
 	return nil
 }
 
-// printNextSteps emits the post-scaffold guidance: a confirmation line
-// with the chosen base dir, followed by the two-step workflow most
-// users want next (import existing CLI config, then sync to targets).
-func printNextSteps(base string) {
+// printNextSteps emits the post-scaffold guidance. seeded reports
+// whether --demo or --preset wrote any source specs, in which case the
+// suggested next step is `sync` (the source dirs are not empty).
+// Otherwise the suggested next step is `import <target>`. Detected
+// CLI configs under root are surfaced as concrete `import` follow-ups.
+func printNextSteps(root, base string, targets []string, seeded bool) {
 	summaryf("✓ initialized agnostic-ai project at %s\n", baseLabel(base))
+	if len(targets) > 0 {
+		summaryf("  enabled: %s\n", strings.Join(targets, ", "))
+	}
 	summaryf("\n")
 	summaryf("next steps:\n")
-	summaryf("  agnostic-ai import <target>   # mirror an existing CLI's config into specs\n")
-	summaryf("  agnostic-ai sync              # emit to your configured targets\n")
+	if seeded {
+		summaryf("  agnostic-ai sync --check      # preview what will be written\n")
+		summaryf("  agnostic-ai sync              # emit to your configured targets\n")
+	} else {
+		summaryf("  agnostic-ai import <target>   # mirror an existing CLI's config into specs\n")
+		summaryf("  agnostic-ai sync              # emit to your configured targets\n")
+	}
+	detected := detectExistingTargets(root)
+	if len(detected) == 0 {
+		return
+	}
+	summaryf("\n")
+	summaryf("detected existing config:\n")
+	for i, d := range detected {
+		if i >= 3 {
+			summaryf("  (and %d more)\n", len(detected)-3)
+			return
+		}
+		summaryf("  agnostic-ai import %s\n", d)
+	}
 }
 
 // baseLabel renders the user-facing label for the scaffold root. "."

--- a/internal/cli/init_preset_test.go
+++ b/internal/cli/init_preset_test.go
@@ -136,6 +136,21 @@ func TestInit_PresetDoesNotOverwriteExistingFiles(t *testing.T) {
 	}
 }
 
+func TestInit_PresetSuggestsSyncInNextSteps(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(dir, "", false, "go", allTargetNames()); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "agnostic-ai sync --check") {
+		t.Errorf("preset scaffold should suggest sync --check:\n%s", out)
+	}
+	if strings.Contains(out, "agnostic-ai import <target>") {
+		t.Errorf("preset scaffold should not show import <target>:\n%s", out)
+	}
+}
+
 func TestAvailablePresets_ListsEmbedded(t *testing.T) {
 	got := availablePresets()
 	for _, want := range []string{"go", "ts-react", "python"} {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -436,3 +436,48 @@ func TestScaffold_DemoAndPresetLinesPrintBeforeNextSteps(t *testing.T) {
 		t.Errorf("demo/preset lines should appear before next steps:\n%s", out)
 	}
 }
+
+func TestScaffold_EchoesEnabledTargets(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(dir, "", false, "", []string{"claude", "codex"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "  enabled: claude, codex\n") {
+		t.Errorf("expected enabled targets line, got:\n%s", buf.String())
+	}
+}
+
+func TestScaffold_SeededSuggestsSyncNotImport(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(dir, "", true, "", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "agnostic-ai sync --check") {
+		t.Errorf("seeded scaffold should suggest sync --check:\n%s", out)
+	}
+	if strings.Contains(out, "agnostic-ai import <target>") {
+		t.Errorf("seeded scaffold should not show import <target>:\n%s", out)
+	}
+}
+
+func TestScaffold_DetectsExistingTargetsAndSuggestsImports(t *testing.T) {
+	dir := t.TempDir()
+	// Drop a marker for the codex CLI; init should surface it as a hint.
+	if err := os.MkdirAll(filepath.Join(dir, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureSummary(t)
+	if err := scaffold(dir, "", false, "", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "detected existing config:") {
+		t.Errorf("expected detected block:\n%s", out)
+	}
+	if !strings.Contains(out, "agnostic-ai import codex\n") {
+		t.Errorf("expected codex import hint:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- After every importer runs, print a uniform next-steps block pointing to `sync --check` / `sync`, plus up to three hints for other detected CLIs the user can import next.
- `init` next-steps now adapt to context: `--demo` or `--preset` already seeded source dirs, so the suggested next step is `sync --check` instead of `import <target>`. Detected CLI configs surface as concrete `import` follow-ups. The chosen targets are echoed back so the user sees what they enabled.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (628 passed)
- [x] Manual: `init --all --demo` in a dir with `.claude/` and `.codex/` markers prints the sync next-steps and detected hints.
- [x] Manual: `init` with piped `claude` then `import claude` shows the `also detected codex/` hint and omits the just-imported `claude`.