### PR TITLE
feat(init): gitignore .agnostic-ai/.sync-state on scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 - `import` prints a next-steps block after every importer, with suggestions to run `sync --check` / `sync` and hints for other detected CLIs to import.
 - `init` next-steps adapt to context: with `--demo` or `--preset` the next step is `sync` (not `import`); detected CLIs are surfaced as suggested `import` follow-ups. Selected targets are echoed back.
+- `init` now writes `.agnostic-ai/.sync-state` to `.gitignore` alongside `agnostic-ai.local.yaml`, so the sync-state file is ignored from the moment the project is scaffolded. Closes #151.
 
 ## v0.12.0 - 2026-05-14
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -183,6 +183,9 @@ func scaffold(root, base string, demo bool, preset string, targets []string) err
 	if err := ensureLineInGitignore(root, config.LocalOverrideFileName); err != nil {
 		return err
 	}
+	if err := ensureLineInGitignore(root, ".agnostic-ai/.sync-state"); err != nil {
+		return err
+	}
 	if demo {
 		if err := writeDemoFiles(filepath.Join(root, base)); err != nil {
 			return err

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -125,6 +125,43 @@ func TestInitCmd_DefaultsToAgnosticAi(t *testing.T) {
 	}
 }
 
+func TestScaffold_GitignoreContainsLocalOverrideAndSyncState(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffold(dir, "", false, "", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	for _, want := range []string{"agnostic-ai.local.yaml", ".agnostic-ai/.sync-state"} {
+		if !strings.Contains(string(got), want+"\n") {
+			t.Errorf("missing %q in .gitignore:\n%s", want, got)
+		}
+	}
+}
+
+func TestScaffold_GitignoreIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"),
+		[]byte("node_modules/\n.agnostic-ai/.sync-state\nagnostic-ai.local.yaml\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := scaffold(dir, "", false, "", allTargetNames()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := strings.Count(string(got), ".agnostic-ai/.sync-state"); c != 1 {
+		t.Errorf("expected one .sync-state line, got %d:\n%s", c, got)
+	}
+	if c := strings.Count(string(got), "agnostic-ai.local.yaml"); c != 1 {
+		t.Errorf("expected one local-override line, got %d:\n%s", c, got)
+	}
+}
+
 func TestInitCmd_RejectsExtraArgs(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)


### PR DESCRIPTION
## Summary
- `init` writes `.agnostic-ai/.sync-state` to `.gitignore` alongside `agnostic-ai.local.yaml`, so the sync-state file is ignored from the moment the project is scaffolded (previously only added by the first `sync` run).
- Idempotent: pre-existing entries are not duplicated.
- `CHANGELOG.md` entry under `[Unreleased]` -> `Changed`.

Closes #151

## Test plan
- [x] `go test ./...` (621 passed)
- [x] New unit tests cover both lines being present and idempotency on a pre-populated `.gitignore`.