### PR TITLE
feat(errs): stable error codes + explain (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- Stable `AAI-NNN` error codes prefix every user-facing error. `agnostic-ai explain <AAI-NNN>` prints the code's title, cause, and suggested fix; `--json` emits the same as a flat record. Initial codes: `AAI-001` (spec parse), `AAI-002` (unsupported kind), `AAI-003` (config missing), `AAI-004` (config decode), `AAI-102` (output collision), `AAI-202` (unknown import source), `AAI-301` (unknown sync target), `AAI-302` (mutually exclusive flags). Full list in `docs/user/errors.md`. Closes #163.
+
 ### Changed
 - **BREAKING**: `sync` writes a uniform pointer body to every target's entry-point file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`, `.agent/AGENTS.md`) plus `.agnostic-ai/AGNOSTIC_AI.md` — all byte-identical. Codex / amp / warp / gemini / opencode / aider / antigravity / copilot adapters stop concatenating rules or building nested AGENTS.md/GEMINI.md trees; claude now also gets a root `CLAUDE.md`. Opt back into legacy concat per target via `outputs.<target>.rules-file`. Targets sharing a path (codex + amp + warp at AGENTS.md) dedup to one write. Closes #153.
 - `import` prints a next-steps block: suggested `sync --check` / `sync`, plus hints for other detected CLIs to import.

--- a/docs/user/errors.md
+++ b/docs/user/errors.md
@@ -1,0 +1,83 @@
+# Error codes
+
+Every user-facing error returned by `agnostic-ai` is tagged with a stable code of the form `AAI-NNN`. The code prefixes the message in square brackets:
+
+```
+[AAI-003] read config: no agnostic-ai.yaml or agnostic.config.yaml in /path/to/project
+```
+
+Use `agnostic-ai explain <code>` to look up the title, cause, and suggested fix without leaving the terminal:
+
+```
+$ agnostic-ai explain AAI-003
+AAI-003: Config file missing
+
+Cause:
+  Neither `agnostic-ai.yaml` nor the legacy `agnostic.config.yaml` exists in the project root.
+
+Fix:
+  Run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one.
+```
+
+Pass `--json` for machine-readable output suitable for editor extensions.
+
+## Numbering
+
+| Range     | Area                       |
+| --------- | -------------------------- |
+| `001-099` | spec / config load + parse |
+| `100-199` | emit (collisions, hooks)   |
+| `200-299` | import                     |
+| `300-399` | sync / validate            |
+
+Codes are stable across releases. New codes append; existing codes are never renumbered.
+
+## Codes
+
+### AAI-001 — Spec parse failed
+
+A spec file could not be parsed. Markdown specs use YAML frontmatter; hooks and MCPs are pure YAML. The error includes the path and (when available) line:col of the offending byte.
+
+**Fix:** open the file at the reported position. Confirm the frontmatter delimiters (`---`) wrap the metadata and that the YAML is well-formed (correct indentation, no tabs, quoted strings where needed).
+
+### AAI-002 — Spec kind not supported by target
+
+A spec kind (hook, mcp, command, ...) is present in the bundle but the target adapter does not emit it. Default policy logs a warning; `on-unsupported: error` upgrades it to a hard failure.
+
+**Fix:** drop the spec, switch the target to one that supports the kind, or set `on-unsupported: warn` (or `silent`) in `agnostic-ai.yaml`.
+
+### AAI-003 — Config file missing
+
+Neither `agnostic-ai.yaml` nor the legacy `agnostic.config.yaml` exists in the project root.
+
+**Fix:** run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one.
+
+### AAI-004 — Config decode failed
+
+The config file was found but could not be parsed as YAML, or its keys do not match the expected schema.
+
+**Fix:** validate against `docs/schemas/config.schema.json`. Check indentation and that list keys (e.g. `targets:`) hold a YAML sequence.
+
+### AAI-102 — Targets emit to the same output path
+
+Two or more enabled targets would write to the same path (commonly `AGENTS.md`, shared by codex, amp, warp, opencode and zed). Last-writer-wins would mask drift.
+
+**Fix:** drop one of the colliding targets from `targets:` in `agnostic-ai.yaml`, or override the colliding path via `outputs.<target>.file`.
+
+### AAI-202 — Import source name unknown
+
+The argument passed to `agnostic-ai import` does not match any registered source.
+
+**Fix:** run `agnostic-ai import --help` for the supported list. Spelling counts.
+
+### AAI-301 — Unknown sync target
+
+A target requested via `--target`, `--only`, or the config is not a built-in adapter and no `agnostic-ai-adapter-<name>` binary is on PATH.
+
+**Fix:** check the target name spelling. Built-ins: `claude`, `codex`, `gemini`, `cursor`, `copilot`, `aider`, `cline`, `windsurf`, `continue`, `amp`, `zed`, `warp`, `opencode`, `antigravity`. External adapters live on PATH as `agnostic-ai-adapter-<name>`.
+
+### AAI-302 — Mutually exclusive flags
+
+Two flags whose effects conflict were passed together (e.g. `--only` with `--except`, or `--watch` with `--check`).
+
+**Fix:** pick one. The error message names both flags so you can drop the wrong one.

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -4,7 +4,6 @@ package adapters
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os/exec"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/adapters/windsurf"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/zed"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
@@ -157,9 +157,12 @@ func Resolve(name string) (Adapter, error) {
 		return a, nil
 	}
 	if errors.Is(err, exec.ErrNotFound) {
-		return nil, fmt.Errorf("unknown target: %s (no built-in adapter and no %s%s on PATH)", name, external.BinaryPrefix, name)
+		return nil, errs.Coded(errs.CodeSyncTargetUnknown,
+			"unknown target: %s (no built-in adapter and no %s%s on PATH)",
+			name, external.BinaryPrefix, name)
 	}
-	return nil, fmt.Errorf("unknown target: %s: %w", name, err)
+	return nil, errs.Coded(errs.CodeSyncTargetUnknown,
+		"unknown target: %s: %w", name, err)
 }
 
 // Names returns every registered target name.

--- a/internal/adapters/internal/emit/capabilities.go
+++ b/internal/adapters/internal/emit/capabilities.go
@@ -1,9 +1,9 @@
 package emit
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
@@ -47,7 +47,7 @@ func ReportUnsupported(c Capabilities, b spec.Bundle, mode string) error {
 		msg := fmt.Sprintf("  ! %s: %s not supported, skipped", c.Target, k)
 		switch mode {
 		case OnUnsupportedError:
-			return errors.New(msg)
+			return errs.Coded(errs.CodeUnsupportedKind, "%s", msg)
 		case OnUnsupportedSilent:
 			continue
 		default: // warn

--- a/internal/cli/collision.go
+++ b/internal/cli/collision.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
@@ -45,8 +46,9 @@ func detectCollisions(cfg *config.Config, b spec.Bundle, targets []string) error
 		return nil
 	}
 	sort.Strings(lines)
-	return fmt.Errorf("output collision: targets emit to the same path\n%s\n"+
-		"resolve by dropping one from `targets:` in agnostic-ai.yaml, "+
-		"or override the collider via `outputs.<target>.file`",
+	return errs.Coded(errs.CodeOutputCollision,
+		"output collision: targets emit to the same path\n%s\n"+
+			"resolve by dropping one from `targets:` in agnostic-ai.yaml, "+
+			"or override the collider via `outputs.<target>.file`",
 		strings.Join(lines, "\n"))
 }

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
@@ -45,18 +46,26 @@ type explainSpecRef struct {
 func newExplainCmd() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "explain <spec>",
-		Short: "List every output file and section a spec contributes to.",
+		Use:   "explain <spec | AAI-NNN>",
+		Short: "List every output file and section a spec contributes to, or describe an error code.",
 		Long: "Reverse provenance: takes one spec and shows where it lands in " +
 			"each target's emission. Pairs with the `<!-- source: ... -->` " +
-			"forward markers adapters write into merged documents.",
+			"forward markers adapters write into merged documents.\n\n" +
+			"When the argument matches an `AAI-NNN` error code, prints the " +
+			"code's title, cause, and suggested fix instead.",
 		Example: `  # Human-readable
   agnostic-ai explain rules/conventional-commits.md
 
   # Machine-readable, for editor extensions or scripts
-  agnostic-ai explain rules/conventional-commits.md --json`,
+  agnostic-ai explain rules/conventional-commits.md --json
+
+  # Look up an error code
+  agnostic-ai explain AAI-001`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if errs.IsCode(args[0]) {
+				return runExplainCode(cmd, errs.Code(args[0]), jsonOut)
+			}
 			cfg, bundle, err := loadProject(".")
 			if err != nil {
 				return err
@@ -219,6 +228,42 @@ func filterEntries(entries []spec.Entry, excludePath string) []spec.Entry {
 		out = append(out, e)
 	}
 	return out
+}
+
+// explainCodeOutput is the JSON envelope for `explain <AAI-NNN>`.
+type explainCodeOutput struct {
+	Version string `json:"version"`
+	Command string `json:"command"`
+	Code    string `json:"code"`
+	Title   string `json:"title"`
+	Cause   string `json:"cause"`
+	Fix     string `json:"fix"`
+}
+
+// runExplainCode prints the registry entry for an error code, or
+// errors when the code is not registered.
+func runExplainCode(cmd *cobra.Command, code errs.Code, jsonOut bool) error {
+	entry, ok := errs.Lookup(code)
+	if !ok {
+		return fmt.Errorf("unknown error code: %s (see docs/user/errors.md for the canonical list)", code)
+	}
+	if jsonOut {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(explainCodeOutput{
+			Version: "1",
+			Command: "explain",
+			Code:    string(entry.Code),
+			Title:   entry.Title,
+			Cause:   entry.Cause,
+			Fix:     entry.Fix,
+		})
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "%s: %s\n", entry.Code, entry.Title)
+	_, _ = fmt.Fprintf(out, "\nCause:\n  %s\n", entry.Cause)
+	_, _ = fmt.Fprintf(out, "\nFix:\n  %s\n", entry.Fix)
+	return nil
 }
 
 // emitExplainJSON serializes an explainOutput with stable indentation.

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -173,6 +173,57 @@ func TestExplain_SpecNotFound(t *testing.T) {
 	}
 }
 
+func TestExplain_ErrorCode_Human(t *testing.T) {
+	silence(t)
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "AAI-001"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "AAI-001:") {
+		t.Errorf("missing code header: %s", got)
+	}
+	if !strings.Contains(got, "Cause:") || !strings.Contains(got, "Fix:") {
+		t.Errorf("missing Cause/Fix sections: %s", got)
+	}
+}
+
+func TestExplain_ErrorCode_JSON(t *testing.T) {
+	silence(t)
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "AAI-102", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var got struct {
+		Version, Command, Code, Title, Cause, Fix string
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if got.Code != "AAI-102" {
+		t.Errorf("code: want AAI-102, got %q", got.Code)
+	}
+	if got.Title == "" || got.Cause == "" || got.Fix == "" {
+		t.Errorf("missing fields: %+v", got)
+	}
+}
+
+func TestExplain_ErrorCode_Unknown(t *testing.T) {
+	silence(t)
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"explain", "AAI-999"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unknown error code") {
+		t.Fatalf("expected unknown-code error, got %v", err)
+	}
+}
+
 func TestExplain_AgentSpec(t *testing.T) {
 	dir := setupExplainFixture(t)
 	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0o755); err != nil {

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 )
 
 // rulesDirImporters maps a source name to the rules directory the
@@ -86,5 +87,6 @@ func runImport(root, source string, src config.Sources) error {
 	if srcDir, ok := rulesDirImporters[source]; ok {
 		return importFromRulesDir(root, source, srcDir, src)
 	}
-	return fmt.Errorf("unknown source: %q (supported: %s)", source, importSources())
+	return errs.Coded(errs.CodeImportFileUnknown,
+		"unknown source: %q (supported: %s)", source, importSources())
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 )
 
 func newSyncCmd() *cobra.Command {
@@ -44,10 +46,10 @@ func newSyncCmd() *cobra.Command {
 				return err
 			}
 			if len(only) > 0 && len(except) > 0 {
-				return fmt.Errorf("--only and --except are mutually exclusive")
+				return errs.Coded(errs.CodeFlagConflict, "--only and --except are mutually exclusive")
 			}
 			if watch && check {
-				return fmt.Errorf("--watch and --check are incompatible")
+				return errs.Coded(errs.CodeFlagConflict, "--watch and --check are incompatible")
 			}
 
 			cfg, _, err := loadProject(".")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 )
 
 // File names recognized by Load.
@@ -123,7 +125,8 @@ func ResolveConfigPath(root string) (path string, legacy bool, err error) {
 	if fileExists(legacyPath) {
 		return legacyPath, true, nil
 	}
-	return "", false, fmt.Errorf("read config: no %s or %s in %s",
+	return "", false, errs.Coded(errs.CodeConfigMissing,
+		"read config: no %s or %s in %s",
 		ConfigFileName, LegacyConfigFileName, root)
 }
 
@@ -135,7 +138,7 @@ func loadInto(cfg *Config, path string) error {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
-		return fmt.Errorf("parse %s: %w", path, err)
+		return errs.Coded(errs.CodeConfigDecode, "parse %s: %w", path, err)
 	}
 	return nil
 }
@@ -157,7 +160,7 @@ func loadAndMerge(cfg *Config, basePath, localPath string) error {
 		return fmt.Errorf("re-encode merged config: %w", err)
 	}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
-		return fmt.Errorf("parse merged config: %w", err)
+		return errs.Coded(errs.CodeConfigDecode, "parse merged config: %w", err)
 	}
 	return nil
 }
@@ -172,7 +175,7 @@ func readYAMLMap(path string) (map[string]any, error) {
 		return out, nil
 	}
 	if err := yaml.Unmarshal(data, &out); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
+		return nil, errs.Coded(errs.CodeConfigDecode, "parse %s: %w", path, err)
 	}
 	return out, nil
 }

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,0 +1,93 @@
+// Package errs defines stable, user-facing error codes and a small
+// constructor for tagging errors with them. Codes follow the
+// `AAI-NNN` shape and are stable across releases so users can grep,
+// link to docs, and run `agnostic-ai explain <code>` for guidance.
+//
+// The constructor produces errors whose Error() begins with `[AAI-NNN] `
+// and whose underlying chain (when any %w is supplied) is preserved so
+// errors.Is / errors.As keep working unchanged for callers that already
+// match against sentinel errors.
+package errs
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// Code is a stable user-facing error identifier of the form `AAI-NNN`.
+type Code string
+
+// String returns the code as a plain string.
+func (c Code) String() string { return string(c) }
+
+// Stable codes. Numbering convention:
+//
+//	001-099  load / parse (specs, config)
+//	100-199  emit (collisions, hook conflicts)
+//	200-299  import
+//	300-399  sync / validate
+//
+// Renumbering an existing code is a breaking change; deprecate and
+// add a new one instead.
+const (
+	// Load / parse.
+	CodeSpecParse       Code = "AAI-001"
+	CodeUnsupportedKind Code = "AAI-002"
+	CodeConfigMissing   Code = "AAI-003"
+	CodeConfigDecode    Code = "AAI-004"
+
+	// Emit.
+	CodeOutputCollision Code = "AAI-102"
+
+	// Import.
+	CodeImportFileUnknown Code = "AAI-202"
+
+	// Sync / validate.
+	CodeSyncTargetUnknown Code = "AAI-301"
+	CodeFlagConflict      Code = "AAI-302"
+)
+
+// codedError is the concrete error type produced by Coded. It exposes
+// the Code and an unwrap chain so callers can still match wrapped
+// sentinel errors.
+type codedError struct {
+	code Code
+	msg  string
+	wrap error
+}
+
+func (e *codedError) Error() string { return "[" + string(e.code) + "] " + e.msg }
+func (e *codedError) Unwrap() error { return e.wrap }
+func (e *codedError) Code() Code    { return e.code }
+
+// Coded returns an error tagged with the given code. The format/args
+// follow fmt.Errorf semantics: pass `%w` to wrap an underlying error
+// so errors.Is / errors.As keep finding it. The wrapped error is also
+// surfaced via Unwrap; the visible message is `[AAI-NNN] <text>`.
+func Coded(code Code, format string, args ...any) error {
+	wrapped := fmt.Errorf(format, args...)
+	return &codedError{
+		code: code,
+		msg:  wrapped.Error(),
+		wrap: errors.Unwrap(wrapped),
+	}
+}
+
+// CodeOf returns the Code attached to err, or "" if none is in the
+// chain. Walks the entire chain via errors.As.
+func CodeOf(err error) Code {
+	var c *codedError
+	if errors.As(err, &c) {
+		return c.code
+	}
+	return ""
+}
+
+// reCode validates the AAI-NNN shape used by the explain command and
+// public docs.
+var reCode = regexp.MustCompile(`^AAI-\d{3,}$`)
+
+// IsCode reports whether s syntactically matches the `AAI-NNN` shape.
+// The check is shape-only; lookups still go through Lookup.
+func IsCode(s string) bool { return reCode.MatchString(s) }

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -1,0 +1,105 @@
+package errs
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+func TestCoded_PrefixIncludesCode(t *testing.T) {
+	err := Coded(CodeSpecParse, "boom")
+	want := "[AAI-001] boom"
+	if err.Error() != want {
+		t.Errorf("Error()=%q, want %q", err.Error(), want)
+	}
+}
+
+func TestCoded_FormatArgsExpand(t *testing.T) {
+	err := Coded(CodeConfigDecode, "parse %s: %s", "agnostic-ai.yaml", "bad indent")
+	if !strings.Contains(err.Error(), "parse agnostic-ai.yaml: bad indent") {
+		t.Errorf("missing formatted args: %q", err.Error())
+	}
+	if !strings.HasPrefix(err.Error(), "[AAI-004] ") {
+		t.Errorf("missing code prefix: %q", err.Error())
+	}
+}
+
+func TestCoded_WrapPreservesIs(t *testing.T) {
+	err := Coded(CodeConfigMissing, "read %s: %w", "agnostic-ai.yaml", fs.ErrNotExist)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Error("errors.Is should still match wrapped sentinel")
+	}
+	if got := CodeOf(err); got != CodeConfigMissing {
+		t.Errorf("CodeOf=%q, want %q", got, CodeConfigMissing)
+	}
+}
+
+func TestCoded_WrapPreservesAs(t *testing.T) {
+	original := &fs.PathError{Op: "open", Path: "x", Err: fs.ErrNotExist}
+	err := Coded(CodeUnsupportedKind, "missing dir: %w", original)
+	var pe *fs.PathError
+	if !errors.As(err, &pe) {
+		t.Fatal("errors.As should unwrap to *fs.PathError")
+	}
+	if pe.Path != "x" {
+		t.Errorf("PathError.Path=%q, want %q", pe.Path, "x")
+	}
+}
+
+func TestCodeOf_NilAndPlainReturnEmpty(t *testing.T) {
+	if got := CodeOf(nil); got != "" {
+		t.Errorf("CodeOf(nil)=%q, want empty", got)
+	}
+	if got := CodeOf(fmt.Errorf("plain")); got != "" {
+		t.Errorf("CodeOf(plain)=%q, want empty", got)
+	}
+}
+
+func TestIsCode_ShapeOnly(t *testing.T) {
+	cases := map[string]bool{
+		"AAI-001":  true,
+		"AAI-9999": true,
+		"AAI-12":   false, // require >= 3 digits
+		"aai-001":  false,
+		"AAI001":   false,
+		"":         false,
+	}
+	for in, want := range cases {
+		if got := IsCode(in); got != want {
+			t.Errorf("IsCode(%q)=%v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestRegistry_AllCoveredCodesHaveEntries(t *testing.T) {
+	codes := []Code{
+		CodeSpecParse, CodeUnsupportedKind, CodeConfigMissing, CodeConfigDecode,
+		CodeOutputCollision,
+		CodeImportFileUnknown,
+		CodeSyncTargetUnknown, CodeFlagConflict,
+	}
+	for _, c := range codes {
+		e, ok := Lookup(c)
+		if !ok {
+			t.Errorf("Lookup(%s): missing registry entry", c)
+			continue
+		}
+		if e.Title == "" || e.Cause == "" || e.Fix == "" {
+			t.Errorf("%s: empty Title/Cause/Fix", c)
+		}
+	}
+}
+
+func TestAll_SortedByCode(t *testing.T) {
+	all := All()
+	if len(all) == 0 {
+		t.Fatal("All(): want non-empty")
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1].Code >= all[i].Code {
+			t.Errorf("All() not sorted: %s before %s", all[i-1].Code, all[i].Code)
+		}
+	}
+}

--- a/internal/errs/registry.go
+++ b/internal/errs/registry.go
@@ -1,0 +1,82 @@
+package errs
+
+import "sort"
+
+// Entry is a registry record describing one error code.
+type Entry struct {
+	Code  Code
+	Title string
+	Cause string
+	Fix   string
+}
+
+// registry holds the canonical metadata for every defined code. Keep
+// in sync with docs/user/errors.md.
+var registry = map[Code]Entry{
+	CodeSpecParse: {
+		Code:  CodeSpecParse,
+		Title: "Spec parse failed",
+		Cause: "A spec file could not be parsed. Markdown specs use YAML frontmatter; hooks and MCPs are pure YAML. The error includes the path and (when available) line:col of the offending byte.",
+		Fix:   "Open the file at the reported position. Confirm the frontmatter delimiters (`---`) wrap the metadata and that the YAML is well-formed (correct indentation, no tabs, quoted strings where needed).",
+	},
+	CodeUnsupportedKind: {
+		Code:  CodeUnsupportedKind,
+		Title: "Spec kind not supported by target",
+		Cause: "A spec kind (hook, mcp, command, ...) is present in the bundle but the target adapter does not emit it. Default policy logs a warning; `on-unsupported: error` upgrades it to a hard failure.",
+		Fix:   "Either drop the spec, switch the target to one that supports the kind, or set `on-unsupported: warn` (or `silent`) in agnostic-ai.yaml.",
+	},
+	CodeConfigMissing: {
+		Code:  CodeConfigMissing,
+		Title: "Config file missing",
+		Cause: "Neither `agnostic-ai.yaml` nor the legacy `agnostic.config.yaml` exists in the project root.",
+		Fix:   "Run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one.",
+	},
+	CodeConfigDecode: {
+		Code:  CodeConfigDecode,
+		Title: "Config decode failed",
+		Cause: "The config file was found but could not be parsed as YAML, or its keys do not match the expected schema.",
+		Fix:   "Validate against `docs/schemas/config.schema.json`. Check indentation and that list keys (e.g. `targets:`) hold a YAML sequence.",
+	},
+	CodeOutputCollision: {
+		Code:  CodeOutputCollision,
+		Title: "Targets emit to the same output path",
+		Cause: "Two or more enabled targets would write to the same path (commonly AGENTS.md, shared by codex, amp, warp, opencode and zed). Last-writer-wins would mask drift.",
+		Fix:   "Drop one of the colliding targets from `targets:` in agnostic-ai.yaml, or override the colliding path via `outputs.<target>.file`.",
+	},
+	CodeImportFileUnknown: {
+		Code:  CodeImportFileUnknown,
+		Title: "Import source name unknown",
+		Cause: "The argument passed to `agnostic-ai import` does not match any registered source.",
+		Fix:   "Run `agnostic-ai import --help` for the supported list. Spelling counts.",
+	},
+	CodeSyncTargetUnknown: {
+		Code:  CodeSyncTargetUnknown,
+		Title: "Unknown sync target",
+		Cause: "A target requested via `--target`, `--only`, or the config is not a built-in adapter and no `agnostic-ai-adapter-<name>` binary is on PATH.",
+		Fix:   "Check the target name spelling. Built-ins: claude, codex, gemini, cursor, copilot, aider, cline, windsurf, continue, amp, zed, warp, opencode, antigravity. External adapters live on PATH as `agnostic-ai-adapter-<name>`.",
+	},
+	CodeFlagConflict: {
+		Code:  CodeFlagConflict,
+		Title: "Mutually exclusive flags",
+		Cause: "Two flags whose effects conflict were passed together (e.g. `--only` with `--except`, or `--watch` with `--check`).",
+		Fix:   "Pick one. The error message names both flags so you can drop the wrong one.",
+	},
+}
+
+// Lookup returns the registry entry for code. The boolean is false
+// when the code is not registered.
+func Lookup(code Code) (Entry, bool) {
+	e, ok := registry[code]
+	return e, ok
+}
+
+// All returns every registered entry, sorted by code, for docs and the
+// `explain` listing.
+func All() []Entry {
+	out := make([]Entry, 0, len(registry))
+	for _, e := range registry {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Code < out[j].Code })
+	return out
+}

--- a/internal/spec/yamlerr.go
+++ b/internal/spec/yamlerr.go
@@ -1,12 +1,13 @@
 package spec
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/errs"
 )
 
 // formatYAMLError wraps a yaml.v3 parse error in a `path:line:col: msg`
@@ -21,7 +22,7 @@ func formatYAMLError(path string, err error, lineOffset int) error {
 	}
 	msgs := yamlErrorMessages(err)
 	if len(msgs) == 0 {
-		return fmt.Errorf("%s: %s", path, err.Error())
+		return errs.Coded(errs.CodeSpecParse, "%s: %s", path, err.Error())
 	}
 	line, col, body := extractPosition(msgs[0])
 	if line > 0 {
@@ -32,7 +33,7 @@ func formatYAMLError(path string, err error, lineOffset int) error {
 	if col <= 0 {
 		col = 1
 	}
-	return fmt.Errorf("%s:%d:%d: %s", path, line, col, body)
+	return errs.Coded(errs.CodeSpecParse, "%s:%d:%d: %s", path, line, col, body)
 }
 
 // yamlErrorMessages flattens a yaml.v3 error chain into individual

--- a/internal/spec/yamlerr_test.go
+++ b/internal/spec/yamlerr_test.go
@@ -10,10 +10,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// codePrefix is the AAI-001 prefix that errs.Coded prepends to spec
+// parse errors. Tests assert against the body after the prefix so the
+// error code stays orthogonal to position formatting.
+const codePrefix = "[AAI-001] "
+
 func TestFormatYAMLError_LineAndCol(t *testing.T) {
 	err := errors.New("yaml: line 3: column 5: did not find expected key")
 	got := formatYAMLError("rules/x.md", err, 1).Error()
-	want := "rules/x.md:4:5: did not find expected key"
+	want := codePrefix + "rules/x.md:4:5: did not find expected key"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -22,7 +27,7 @@ func TestFormatYAMLError_LineAndCol(t *testing.T) {
 func TestFormatYAMLError_LineOnly(t *testing.T) {
 	err := errors.New("yaml: line 2: mapping values are not allowed in this context")
 	got := formatYAMLError("hooks/h.yaml", err, 0).Error()
-	want := "hooks/h.yaml:2:1: mapping values are not allowed in this context"
+	want := codePrefix + "hooks/h.yaml:2:1: mapping values are not allowed in this context"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -31,7 +36,7 @@ func TestFormatYAMLError_LineOnly(t *testing.T) {
 func TestFormatYAMLError_Unparseable(t *testing.T) {
 	err := errors.New("totally unrecognized format")
 	got := formatYAMLError("p.md", err, 0).Error()
-	want := "p.md:1:1: totally unrecognized format"
+	want := codePrefix + "p.md:1:1: totally unrecognized format"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -48,7 +53,7 @@ func TestFormatYAMLError_TypeErrorUsesFirstMessage(t *testing.T) {
 		"yaml: line 4: column 1: cannot unmarshal !!str into int",
 	}}
 	got := formatYAMLError("mcps/m.yaml", te, 0).Error()
-	want := "mcps/m.yaml:4:1: cannot unmarshal !!str into int"
+	want := codePrefix + "mcps/m.yaml:4:1: cannot unmarshal !!str into int"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -93,10 +98,11 @@ func TestParseYAML_ErrorIncludesPathAndPosition(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
-	if !strings.HasPrefix(err.Error(), path+":") {
-		t.Errorf("error %q does not start with %q", err.Error(), path+":")
+	if !strings.HasPrefix(err.Error(), codePrefix+path+":") {
+		t.Errorf("error %q does not start with %q", err.Error(), codePrefix+path+":")
 	}
-	parts := strings.SplitN(err.Error(), ":", 4)
+	body := strings.TrimPrefix(err.Error(), codePrefix)
+	parts := strings.SplitN(body, ":", 4)
 	if len(parts) < 4 {
 		t.Errorf("error %q missing line:col envelope", err.Error())
 	}


### PR DESCRIPTION
## Summary
- New `internal/errs` package: `Code` type, `Coded(code, format, args...)` constructor, registry of title/cause/fix per code. Wrapping is additive — `errors.Is`/`errors.As` keep matching wrapped sentinels.
- 8 codes wired across the CLI: `AAI-001` (spec parse), `AAI-002` (unsupported kind), `AAI-003` (config missing), `AAI-004` (config decode), `AAI-102` (output collision), `AAI-202` (unknown import source), `AAI-301` (unknown sync target), `AAI-302` (flag conflict).
- `agnostic-ai explain <AAI-NNN>` prints title, cause, and fix; `--json` emits the same as a flat record. Existing `explain <spec-path>` unchanged.
- Docs: new `docs/user/errors.md` lists every code with cause and fix.
- CHANGELOG `[Unreleased]` `Added` entry.

Closes #163.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — 626 pass (was 615; +8 in `internal/errs`, +3 explain code tests)
- [x] `go vet ./...` clean, `gofmt` clean
- [x] Manual: `agnostic-ai explain AAI-001`, `--json`, unknown code (`AAI-999`), and triggering a real coded error (`sync` with no config)