### PR TITLE
feat(claude): first-class settings schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Stable `AAI-NNN` error codes on user-facing errors. `agnostic-ai explain <code>` prints title, cause, fix. See `docs/user/errors.md` (#163).
 - `agnostic-ai why <file>` traces an emitted file back to its adapter, source spec(s), output config keys, and last sync timestamp. `--format json` (#164).
 - `agnostic-ai graph` renders spec → target → file dependencies. Formats: text, mermaid, dot, json. Filters: `--target`, `--spec`, `--kind` (#172).
+- `claude`: first-class `outputs.claude.settings.*` block. Declare `model`, `outputStyle`, `apiKeyHelper`, `cleanupPeriodDays`, `includeCoAuthoredBy`, `enabledPlugins`, `env`, `statusLine`, and `permissions` in `agnostic-ai.yaml` instead of relying on overlay passthrough. Config layers on top of the captured overlay; spec-derived `hooks` block still wins for the `hooks` key (#177).
 
 ### Changed
 - **BREAKING**: `sync` writes a uniform pointer body to every target's entry-point file plus `.agnostic-ai/AGNOSTIC_AI.md`. Opt back into legacy concat via `outputs.<target>.rules-file`. Shared paths dedup to one write (#153).

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -3,6 +3,84 @@
   "$id": "https://raw.githubusercontent.com/Chemaclass/agnostic-ai/main/docs/schemas/config.schema.json",
   "$ref": "#/$defs/Config",
   "$defs": {
+    "ClaudePermissions": {
+      "properties": {
+        "allow": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "deny": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ask": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ClaudeSettings": {
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "outputStyle": {
+          "type": "string"
+        },
+        "apiKeyHelper": {
+          "type": "string"
+        },
+        "cleanupPeriodDays": {
+          "type": "integer"
+        },
+        "includeCoAuthoredBy": {
+          "type": "boolean"
+        },
+        "enabledPlugins": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "statusLine": {
+          "$ref": "#/$defs/ClaudeStatusLine"
+        },
+        "permissions": {
+          "$ref": "#/$defs/ClaudePermissions"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ClaudeStatusLine": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "padding": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Config": {
       "properties": {
         "version": {
@@ -106,6 +184,9 @@
         },
         "emit-skills-as-commands": {
           "type": "boolean"
+        },
+        "settings": {
+          "$ref": "#/$defs/ClaudeSettings"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -170,6 +170,7 @@ Per-target paths. Each target reads only the fields it understands; irrelevant f
 | `claude` | `rules-dir` | `.claude/rules` | One `.md` per rule (default). |
 | `claude` | `rules-file` | _empty_ | When set, switches back to the legacy concatenated single-file layout at that path (typically `CLAUDE.md`). `sync` skips the pointer-body write for `claude`. |
 | `claude` | `mcp-file` | `.mcp.json` | Standard `mcpServers` schema. |
+| `claude` | `settings` | _empty_ | First-class block mirroring `.claude/settings.json` keys. See [Claude settings](#claude-settings). |
 | `codex` | `agents-dir` | `.agents/agents` | One TOML file per agent (Codex subagent schema). |
 | `codex` | `skills-dir` | `.agents/skills` | One folder per skill per the Codex skills layout. |
 | `codex` | `rules-file` | _empty_ | When set, writes a legacy concatenated rules document at that path. `sync` skips the pointer-body write for `codex`. |
@@ -258,6 +259,56 @@ Persisted answer to the first-run auto-sync prompt. Three states:
 
 Set non-interactively with `agnostic-ai sync --auto-sync=yes` or
 `--auto-sync=no`. The prompt and persistence are skipped under `--dry-run`.
+
+## Claude settings
+
+The `outputs.claude.settings` block declares first-class
+`.claude/settings.json` keys. agnostic-ai writes each non-empty field
+on top of the captured overlay (from `import claude`) and below the
+spec-derived `hooks` block. Keys you do not set fall through to the
+overlay, so partial adoption is supported.
+
+```yaml
+outputs:
+  claude:
+    settings:
+      model: claude-opus-4-7
+      outputStyle: verbose
+      apiKeyHelper: ./bin/keyhelper.sh
+      cleanupPeriodDays: 30
+      includeCoAuthoredBy: false
+      enabledPlugins:
+        - plugin-a
+        - plugin-b
+      env:
+        FOO: bar
+      statusLine:
+        type: command
+        command: echo status
+        padding: 2
+      permissions:
+        allow:
+          - "Read(*)"
+        deny:
+          - "Shell(rm *)"
+        ask:
+          - "Edit(*)"
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `model` | string | Default model preference for new sessions. |
+| `outputStyle` | string | One of the Claude Code output styles. |
+| `apiKeyHelper` | string | Path to a script that prints an API key on stdout. |
+| `cleanupPeriodDays` | integer | Days of conversation history to retain. |
+| `includeCoAuthoredBy` | boolean | Append `Co-Authored-By: Claude` to git commits Claude creates. |
+| `enabledPlugins` | list of strings | Plugin identifiers Claude Code should load. |
+| `env` | map of strings | Environment variables exported into Claude sessions. |
+| `statusLine` | object | `type`, `command`, and optional `padding`. |
+| `permissions` | object | `allow`, `deny`, `ask` lists of tool-pattern strings. |
+
+Any setting not declared here still round-trips through the overlay
+captured during `agnostic-ai import claude`.
 
 ## Path semantics
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -82,7 +82,9 @@ Commands emit one file per spec under `.claude/commands/`. Each command becomes 
 
 `agnostic-ai import claude` captures the non-`hooks` portion of `.claude/settings.json` (statusLine, enabledPlugins, any other top-level key) into `.agnostic-ai/overlays/claude.settings.json`. `sync -t claude` reads that overlay and layers the spec-derived `hooks` key on top, so a re-sync from a fresh checkout reproduces the full settings.json even after `.claude/` has been wiped. Re-run `import claude` whenever you add a key to settings.json by hand.
 
-Config keys: `outputs.claude.dir` (default `.claude`), `outputs.claude.rules-dir` (default `.claude/rules`), `outputs.claude.rules-file` (unset; setting it switches back to the legacy concatenated single-file layout, typically `CLAUDE.md`), `outputs.claude.commands-dir` (default `.claude/commands`), `outputs.claude.mcp-file` (default `.mcp.json`).
+`outputs.claude.settings.*` declares first-class settings keys (model, outputStyle, statusLine, permissions, enabledPlugins, env, apiKeyHelper, cleanupPeriodDays, includeCoAuthoredBy). They merge on top of the captured overlay and below the spec-derived hooks block. See [Claude settings](configuration.md#claude-settings).
+
+Config keys: `outputs.claude.dir` (default `.claude`), `outputs.claude.rules-dir` (default `.claude/rules`), `outputs.claude.rules-file` (unset; setting it switches back to the legacy concatenated single-file layout, typically `CLAUDE.md`), `outputs.claude.commands-dir` (default `.claude/commands`), `outputs.claude.mcp-file` (default `.mcp.json`), `outputs.claude.settings` (first-class settings block).
 
 ### Codex (`codex`)
 

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -100,7 +100,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 
-	if err := writeSettings(b.Hooks, dir, dryRun); err != nil {
+	if err := writeSettings(b.Hooks, dir, cfg, dryRun); err != nil {
 		return err
 	}
 
@@ -128,42 +128,51 @@ func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
 	}, dryRun)
 }
 
-// writeSettings renders `.claude/settings.json` from the captured
-// overlay (if any) plus the spec-derived hooks block.
+// writeSettings renders `.claude/settings.json` by layering, in order
+// of increasing precedence:
 //
-// Three cases:
+//  1. Overlay captured during `import claude` (covers anything the user
+//     keeps inside `.claude/settings.json` directly).
+//  2. First-class fields from `outputs.claude.settings` in
+//     `agnostic-ai.yaml` (statusLine, permissions, env, model, etc).
+//  3. Spec-derived `hooks` block (always wins for the `hooks` key).
 //
-//   - Overlay present: it acts as the base map; the spec-derived `hooks`
-//     key overwrites whatever `hooks` the overlay carried (always empty
-//     in practice, the importer strips it). The whole document is
-//     written via WriteFile so disk content reflects the captured state
-//     exactly. No disk read of `.claude/settings.json` happens, so
-//     wiping `.claude/` between import and sync is harmless.
-//   - Overlay absent but hooks present: fall back to merging into any
-//     existing settings.json on disk. This preserves keys for users
-//     upgrading from older agnostic-ai versions that never ran the
-//     import overlay step.
-//   - Overlay absent and no hooks: write nothing.
-func writeSettings(hooks []spec.Entry, dir string, dryRun bool) error {
+// Three short-circuits:
+//
+//   - All three layers empty: write nothing.
+//   - Overlay absent but hooks present and config empty: merge into any
+//     existing settings.json on disk so a user-edited statusLine added
+//     directly to `.claude/settings.json` survives until `import claude`
+//     captures it.
+//   - Overlay absent but config layer non-empty: start from an empty
+//     map. Disk is not consulted, so the config is authoritative.
+func writeSettings(hooks []spec.Entry, dir string, cfg *config.Config, dryRun bool) error {
 	overlay, overlayOK, err := loadSettingsOverlay(dryRun)
 	if err != nil {
 		return err
 	}
+	configSettings := buildConfigSettings(cfg)
+	hasConfig := len(configSettings) > 0
 	hasHooks := len(hooks) > 0
-	if !overlayOK && !hasHooks {
+	if !overlayOK && !hasHooks && !hasConfig {
 		return nil
 	}
 	path := filepath.Join(dir, "settings.json")
-	if !overlayOK {
-		// Backwards-compat path: no overlay yet, merge into disk so a
-		// user-edited statusLine added directly to .claude/settings.json
-		// survives until they run `import claude` to capture it.
+	if !overlayOK && !hasConfig {
+		// Backwards-compat path: no overlay yet, merge hooks into disk
+		// so user-edited keys survive until `import claude` captures
+		// them into the overlay.
 		return emit.MergeJSONFile(path, buildHookSettings(hooks), dryRun)
 	}
 	doc := overlay
+	if doc == nil {
+		doc = map[string]any{}
+	}
+	for k, v := range configSettings {
+		doc[k] = v
+	}
 	if hasHooks {
-		settings := buildHookSettings(hooks)
-		for k, v := range settings {
+		for k, v := range buildHookSettings(hooks) {
 			doc[k] = v
 		}
 	} else {

--- a/internal/adapters/claude/settings_schema.go
+++ b/internal/adapters/claude/settings_schema.go
@@ -1,0 +1,98 @@
+package claude
+
+import "github.com/chemaclass/agnostic-ai/internal/config"
+
+// buildConfigSettings renders the first-class
+// `outputs.claude.settings.*` fields into the map shape that
+// `.claude/settings.json` expects. Returns an empty map when no
+// settings are configured so the caller can layer it unconditionally.
+//
+// Each top-level key is set only when the corresponding config field
+// is non-zero, so the resulting map can be merged on top of the
+// captured overlay without overwriting keys the user did not declare.
+func buildConfigSettings(cfg *config.Config) map[string]any {
+	out := map[string]any{}
+	if cfg == nil {
+		return out
+	}
+	o, ok := cfg.Outputs[target]
+	if !ok || o.Settings == nil {
+		return out
+	}
+	s := o.Settings
+	if s.Model != "" {
+		out["model"] = s.Model
+	}
+	if s.OutputStyle != "" {
+		out["outputStyle"] = s.OutputStyle
+	}
+	if s.APIKeyHelper != "" {
+		out["apiKeyHelper"] = s.APIKeyHelper
+	}
+	if s.CleanupPeriodDays != nil {
+		out["cleanupPeriodDays"] = *s.CleanupPeriodDays
+	}
+	if s.IncludeCoAuthoredBy != nil {
+		out["includeCoAuthoredBy"] = *s.IncludeCoAuthoredBy
+	}
+	if len(s.EnabledPlugins) > 0 {
+		out["enabledPlugins"] = stringSliceToAny(s.EnabledPlugins)
+	}
+	if len(s.Env) > 0 {
+		env := map[string]any{}
+		for k, v := range s.Env {
+			env[k] = v
+		}
+		out["env"] = env
+	}
+	if s.StatusLine != nil {
+		if sl := statusLineMap(s.StatusLine); len(sl) > 0 {
+			out["statusLine"] = sl
+		}
+	}
+	if s.Permissions != nil {
+		if p := permissionsMap(s.Permissions); len(p) > 0 {
+			out["permissions"] = p
+		}
+	}
+	return out
+}
+
+func statusLineMap(s *config.ClaudeStatusLine) map[string]any {
+	m := map[string]any{}
+	if s.Type != "" {
+		m["type"] = s.Type
+	}
+	if s.Command != "" {
+		m["command"] = s.Command
+	}
+	if s.Padding != nil {
+		m["padding"] = *s.Padding
+	}
+	return m
+}
+
+func permissionsMap(p *config.ClaudePermissions) map[string]any {
+	m := map[string]any{}
+	if len(p.Allow) > 0 {
+		m["allow"] = stringSliceToAny(p.Allow)
+	}
+	if len(p.Deny) > 0 {
+		m["deny"] = stringSliceToAny(p.Deny)
+	}
+	if len(p.Ask) > 0 {
+		m["ask"] = stringSliceToAny(p.Ask)
+	}
+	return m
+}
+
+// stringSliceToAny converts a typed string slice into a slice of any.
+// JSON encoding handles []string fine, but downstream merge helpers
+// inspect map values with type switches that only know []any.
+func stringSliceToAny(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}

--- a/internal/adapters/claude/settings_schema_test.go
+++ b/internal/adapters/claude/settings_schema_test.go
@@ -1,0 +1,241 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func intPtr(v int) *int    { return &v }
+func boolPtr(v bool) *bool { return &v }
+
+func TestEmit_FirstClassSettings_AllFields(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"claude": {
+				Settings: &config.ClaudeSettings{
+					Model:               "claude-opus-4-7",
+					OutputStyle:         "verbose",
+					APIKeyHelper:        "./bin/keyhelper.sh",
+					CleanupPeriodDays:   intPtr(30),
+					IncludeCoAuthoredBy: boolPtr(false),
+					EnabledPlugins:      []string{"plugin-a", "plugin-b"},
+					Env:                 map[string]string{"FOO": "bar", "BAZ": "qux"},
+					StatusLine: &config.ClaudeStatusLine{
+						Type:    "command",
+						Command: "echo status",
+						Padding: intPtr(2),
+					},
+					Permissions: &config.ClaudePermissions{
+						Allow: []string{"Read(*)"},
+						Deny:  []string{"Shell(rm *)"},
+						Ask:   []string{"Edit(*)"},
+					},
+				},
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatalf("expected settings.json from config alone: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v\n%s", err, raw)
+	}
+	if got := parsed["model"]; got != "claude-opus-4-7" {
+		t.Errorf("model: got %v", got)
+	}
+	if got := parsed["outputStyle"]; got != "verbose" {
+		t.Errorf("outputStyle: got %v", got)
+	}
+	if got := parsed["apiKeyHelper"]; got != "./bin/keyhelper.sh" {
+		t.Errorf("apiKeyHelper: got %v", got)
+	}
+	if got := parsed["cleanupPeriodDays"]; got != float64(30) {
+		t.Errorf("cleanupPeriodDays: got %v", got)
+	}
+	if got := parsed["includeCoAuthoredBy"]; got != false {
+		t.Errorf("includeCoAuthoredBy: got %v", got)
+	}
+	plugins, ok := parsed["enabledPlugins"].([]any)
+	if !ok || len(plugins) != 2 || plugins[0] != "plugin-a" {
+		t.Errorf("enabledPlugins wrong: %v", parsed["enabledPlugins"])
+	}
+	env, ok := parsed["env"].(map[string]any)
+	if !ok || env["FOO"] != "bar" {
+		t.Errorf("env wrong: %v", parsed["env"])
+	}
+	sl, ok := parsed["statusLine"].(map[string]any)
+	if !ok || sl["command"] != "echo status" || sl["padding"] != float64(2) {
+		t.Errorf("statusLine wrong: %v", parsed["statusLine"])
+	}
+	perms, ok := parsed["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("permissions missing: %v", parsed["permissions"])
+	}
+	for key, want := range map[string]string{"allow": "Read(*)", "deny": "Shell(rm *)", "ask": "Edit(*)"} {
+		list, ok := perms[key].([]any)
+		if !ok || len(list) != 1 || list[0] != want {
+			t.Errorf("permissions.%s wrong: %v", key, perms[key])
+		}
+	}
+}
+
+func TestEmit_FirstClassSettings_WinsOverOverlay(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	overlayPath := filepath.Join(dir, ".agnostic-ai/overlays/claude.settings.json")
+	if err := os.MkdirAll(filepath.Dir(overlayPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	overlay := `{"model": "old-model", "outputStyle": "from-overlay", "customKey": "preserved"}` + "\n"
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"claude": {Settings: &config.ClaudeSettings{Model: "claude-opus-4-7"}},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["model"] != "claude-opus-4-7" {
+		t.Errorf("config should override overlay model: %v", parsed["model"])
+	}
+	if parsed["outputStyle"] != "from-overlay" {
+		t.Errorf("overlay value should survive when config silent: %v", parsed["outputStyle"])
+	}
+	if parsed["customKey"] != "preserved" {
+		t.Errorf("unknown overlay key should pass through: %v", parsed["customKey"])
+	}
+}
+
+func TestEmit_FirstClassSettings_ConfigOnly_NoOverlayNoHooks(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"claude": {Settings: &config.ClaudeSettings{Model: "claude-opus-4-7"}},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatalf("config-only settings should still produce file: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["model"] != "claude-opus-4-7" {
+		t.Errorf("model not written from config: %v", parsed)
+	}
+	if _, ok := parsed["hooks"]; ok {
+		t.Errorf("hooks key should not appear without hook specs: %v", parsed)
+	}
+}
+
+func TestEmit_FirstClassSettings_WithHooks(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"claude": {Settings: &config.ClaudeSettings{
+				Permissions: &config.ClaudePermissions{Allow: []string{"Read(*)"}},
+			}},
+		},
+	}
+	entries := []spec.Entry{
+		{Kind: spec.KindHook, Name: "h1", Meta: map[string]any{
+			"event": "PostToolUse", "matcher": "Edit", "command": "fmt",
+		}},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := parsed["permissions"]; !ok {
+		t.Errorf("permissions missing: %s", raw)
+	}
+	if _, ok := parsed["hooks"]; !ok {
+		t.Errorf("hooks missing: %s", raw)
+	}
+}
+
+func TestEmit_FirstClassSettings_NilSettingsLeavesNothing(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"claude": {Dir: ".claude"},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude/settings.json")); !os.IsNotExist(err) {
+		t.Errorf("settings.json should not be written when nothing configured: %v", err)
+	}
+}
+
+func TestBuildConfigSettings_EmptyOnNilConfig(t *testing.T) {
+	if got := buildConfigSettings(nil); len(got) != 0 {
+		t.Errorf("nil config should yield empty map, got %v", got)
+	}
+	if got := buildConfigSettings(&config.Config{}); len(got) != 0 {
+		t.Errorf("no outputs should yield empty map, got %v", got)
+	}
+}
+
+func TestBuildConfigSettings_OmitsEmptyNested(t *testing.T) {
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"claude": {Settings: &config.ClaudeSettings{
+				StatusLine:  &config.ClaudeStatusLine{},
+				Permissions: &config.ClaudePermissions{},
+			}},
+		},
+	}
+	got := buildConfigSettings(cfg)
+	if _, ok := got["statusLine"]; ok {
+		t.Errorf("empty statusLine should be omitted: %v", got)
+	}
+	if _, ok := got["permissions"]; ok {
+		t.Errorf("empty permissions should be omitted: %v", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,24 +48,65 @@ type Sources struct {
 }
 
 type Output struct {
-	Dir                  string `yaml:"dir,omitempty"                      json:"dir,omitempty"`
-	File                 string `yaml:"file,omitempty"                     json:"file,omitempty"`
-	RulesFile            string `yaml:"rules-file,omitempty"               json:"rules-file,omitempty"`
-	RulesDir             string `yaml:"rules-dir,omitempty"                json:"rules-dir,omitempty"`
-	MCPFile              string `yaml:"mcp-file,omitempty"                 json:"mcp-file,omitempty"`
-	AgentsDir            string `yaml:"agents-dir,omitempty"               json:"agents-dir,omitempty"`
-	SkillsDir            string `yaml:"skills-dir,omitempty"               json:"skills-dir,omitempty"`
-	InstructionsDir      string `yaml:"instructions-dir,omitempty"         json:"instructions-dir,omitempty"`
-	CommandsDir          string `yaml:"commands-dir,omitempty"             json:"commands-dir,omitempty"`
-	ChatmodesDir         string `yaml:"chatmodes-dir,omitempty"            json:"chatmodes-dir,omitempty"`
-	WorkflowsDir         string `yaml:"workflows-dir,omitempty"            json:"workflows-dir,omitempty"`
-	AssistantsDir        string `yaml:"assistants-dir,omitempty"           json:"assistants-dir,omitempty"`
-	TasksFile            string `yaml:"tasks-file,omitempty"               json:"tasks-file,omitempty"`
-	ConfFile             string `yaml:"conf-file,omitempty"                json:"conf-file,omitempty"`
-	Model                string `yaml:"model,omitempty"                    json:"model,omitempty"`
-	WeakModel            string `yaml:"weak-model,omitempty"               json:"weak-model,omitempty"`
-	MCPDir               string `yaml:"mcp-dir,omitempty"                  json:"mcp-dir,omitempty"`
-	EmitSkillsAsCommands bool   `yaml:"emit-skills-as-commands,omitempty"  json:"emit-skills-as-commands,omitempty"`
+	Dir                  string          `yaml:"dir,omitempty"                      json:"dir,omitempty"`
+	File                 string          `yaml:"file,omitempty"                     json:"file,omitempty"`
+	RulesFile            string          `yaml:"rules-file,omitempty"               json:"rules-file,omitempty"`
+	RulesDir             string          `yaml:"rules-dir,omitempty"                json:"rules-dir,omitempty"`
+	MCPFile              string          `yaml:"mcp-file,omitempty"                 json:"mcp-file,omitempty"`
+	AgentsDir            string          `yaml:"agents-dir,omitempty"               json:"agents-dir,omitempty"`
+	SkillsDir            string          `yaml:"skills-dir,omitempty"               json:"skills-dir,omitempty"`
+	InstructionsDir      string          `yaml:"instructions-dir,omitempty"         json:"instructions-dir,omitempty"`
+	CommandsDir          string          `yaml:"commands-dir,omitempty"             json:"commands-dir,omitempty"`
+	ChatmodesDir         string          `yaml:"chatmodes-dir,omitempty"            json:"chatmodes-dir,omitempty"`
+	WorkflowsDir         string          `yaml:"workflows-dir,omitempty"            json:"workflows-dir,omitempty"`
+	AssistantsDir        string          `yaml:"assistants-dir,omitempty"           json:"assistants-dir,omitempty"`
+	TasksFile            string          `yaml:"tasks-file,omitempty"               json:"tasks-file,omitempty"`
+	ConfFile             string          `yaml:"conf-file,omitempty"                json:"conf-file,omitempty"`
+	Model                string          `yaml:"model,omitempty"                    json:"model,omitempty"`
+	WeakModel            string          `yaml:"weak-model,omitempty"               json:"weak-model,omitempty"`
+	MCPDir               string          `yaml:"mcp-dir,omitempty"                  json:"mcp-dir,omitempty"`
+	EmitSkillsAsCommands bool            `yaml:"emit-skills-as-commands,omitempty"  json:"emit-skills-as-commands,omitempty"`
+	Settings             *ClaudeSettings `yaml:"settings,omitempty"                 json:"settings,omitempty"`
+}
+
+// ClaudeSettings is the first-class representation of `.claude/settings.json`
+// keys that agnostic-ai understands schema-side, rather than treating every
+// key as an opaque overlay passthrough. Only the Claude adapter consumes
+// this struct today.
+//
+// Layering at emit time: overlay (captured during `import claude`) is the
+// base; non-zero fields here are written on top; the spec-derived `hooks`
+// block is written last. So a user can either pin a value declaratively in
+// `agnostic-ai.yaml` or leave it inside `.claude/settings.json` and let the
+// overlay carry it.
+type ClaudeSettings struct {
+	Model               string             `yaml:"model,omitempty"               json:"model,omitempty"`
+	OutputStyle         string             `yaml:"outputStyle,omitempty"         json:"outputStyle,omitempty"`
+	APIKeyHelper        string             `yaml:"apiKeyHelper,omitempty"        json:"apiKeyHelper,omitempty"`
+	CleanupPeriodDays   *int               `yaml:"cleanupPeriodDays,omitempty"   json:"cleanupPeriodDays,omitempty"`
+	IncludeCoAuthoredBy *bool              `yaml:"includeCoAuthoredBy,omitempty" json:"includeCoAuthoredBy,omitempty"`
+	EnabledPlugins      []string           `yaml:"enabledPlugins,omitempty"      json:"enabledPlugins,omitempty"`
+	Env                 map[string]string  `yaml:"env,omitempty"                 json:"env,omitempty"`
+	StatusLine          *ClaudeStatusLine  `yaml:"statusLine,omitempty"          json:"statusLine,omitempty"`
+	Permissions         *ClaudePermissions `yaml:"permissions,omitempty"         json:"permissions,omitempty"`
+}
+
+// ClaudeStatusLine mirrors the `statusLine` block of `.claude/settings.json`.
+// Claude Code accepts a `type` (today only "command") and a `command`
+// string; the optional `padding` field controls leading whitespace.
+type ClaudeStatusLine struct {
+	Type    string `yaml:"type,omitempty"    json:"type,omitempty"`
+	Command string `yaml:"command,omitempty" json:"command,omitempty"`
+	Padding *int   `yaml:"padding,omitempty" json:"padding,omitempty"`
+}
+
+// ClaudePermissions mirrors the `permissions` block. Each list contains
+// tool-pattern strings such as `Read(*)` or `Shell(rm *)`. Claude Code
+// silently drops malformed patterns; agnostic-ai passes through verbatim.
+type ClaudePermissions struct {
+	Allow []string `yaml:"allow,omitempty" json:"allow,omitempty"`
+	Deny  []string `yaml:"deny,omitempty"  json:"deny,omitempty"`
+	Ask   []string `yaml:"ask,omitempty"   json:"ask,omitempty"`
 }
 
 // Load reads the project config from root. It prefers


### PR DESCRIPTION
## Summary
- Add `outputs.claude.settings.*` block to `agnostic-ai.yaml` covering every native `.claude/settings.json` key the issue calls out: `model`, `outputStyle`, `apiKeyHelper`, `cleanupPeriodDays`, `includeCoAuthoredBy`, `enabledPlugins`, `env`, `statusLine`, `permissions.{allow,deny,ask}`.
- Emit layering at `sync -t claude`: captured overlay (low) → first-class config (mid) → spec-derived `hooks` (high). Unknown keys keep round-tripping through the overlay, so partial adoption is supported.
- Regenerate `docs/schemas/config.schema.json`, document the block in `docs/user/configuration.md` and `docs/user/targets.md`, and log it under `## [Unreleased]`.

First slice of #177's audit (Claude Settings). Hooks, commands, MCP, skills, codex bits land in follow-up PRs.

Refs #177.

## Test plan
- [x] `go test ./...` — 648 tests across 26 packages pass.
- [x] `go run ./cmd/schemagen` — schema regenerated, no drift.
- [x] New unit tests cover all-fields emit, config-overrides-overlay, config-only no-overlay, config + hooks combo, and empty-nested-omission.
- [ ] Manual: drop `outputs.claude.settings:` snippet into a real project, run `sync -t claude`, eyeball `.claude/settings.json`.