### PR TITLE
feat(lint): LINT005 flag matchers on non-tool events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `import all`: detects every AI CLI config present and imports each in one shot. (#160)
 - `init --from <cli>`: scaffold + import from an existing CLI in one command. (#160)
 - `init --dry-run` / `import --dry-run`: preview without writing. (#158)
-- `agnostic-ai lint`: semantic checks — LINT001 empty spec, LINT002 hook collision, LINT003 duplicate name, LINT004 dead spec. `--strict` for CI. (#171)
+- `agnostic-ai lint`: semantic checks — LINT001 empty spec, LINT002 hook collision, LINT003 duplicate name, LINT004 dead spec, LINT005 matcher on non-tool event. `--strict` for CI. (#171, #177)
 - `agnostic-ai doctor`: unified 6-step diagnostic with subcommands `mcp`, `install`, `config`. `--json` for machine-readable output. (#159)
 - `agnostic-ai install-hook`: installs `.git/hooks/pre-commit` running `sync --check`. `--shared` commits the hook via `.githooks/`. (#169)
 - MCP spec: `description`, `disabled`, and `roots` frontmatter fields. (#177)

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -66,6 +66,7 @@ func newLintCmd() *cobra.Command {
 			findings = append(findings, lintHookCollisions(b.Hooks)...)
 			findings = append(findings, lintDuplicateNames(entries)...)
 			findings = append(findings, lintDeadSpecs(entries, cfg.Targets)...)
+			findings = append(findings, lintHookMatcherMisuse(b.Hooks)...)
 
 			if len(findings) == 0 {
 				cmd.Printf("ok — %d spec(s) clean\n", len(entries))
@@ -195,6 +196,34 @@ func lintDeadSpecs(entries []spec.Entry, targets []string) []lintFinding {
 			Severity: lintWarn,
 			Path:     e.Path,
 			Message:  msg,
+		})
+	}
+	return out
+}
+
+// lintHookMatcherMisuse flags hook specs whose event does not consume a
+// matcher but still set one. The matcher is silently ignored by the native
+// CLI, so the spec author likely intended a different event or should drop
+// the matcher (LINT005, warn).
+func lintHookMatcherMisuse(hooks []spec.Entry) []lintFinding {
+	var out []lintFinding
+	for _, h := range hooks {
+		event, _ := h.Meta["event"].(string)
+		matcher, _ := h.Meta["matcher"].(string)
+		if event == "" || matcher == "" {
+			continue
+		}
+		if _, ok := matcherAcceptingEvents[event]; ok {
+			continue
+		}
+		out = append(out, lintFinding{
+			Code:     "LINT005",
+			Severity: lintWarn,
+			Path:     h.Path,
+			Message: fmt.Sprintf(
+				"matcher %q set but event %q does not consume a matcher; drop the matcher or use a tool-call event (e.g. PreToolUse, PostToolUse)",
+				matcher, event,
+			),
 		})
 	}
 	return out

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -116,3 +116,45 @@ func TestLintDeadSpecs_NoFindingWhenTargetSupports(t *testing.T) {
 		t.Errorf("expected 0 findings when target supports kind, got %d", len(got))
 	}
 }
+
+func TestLintHookMatcherMisuse_FlagsMatcherOnNonToolEvent(t *testing.T) {
+	hooks := []spec.Entry{
+		{
+			Kind: spec.KindHook, Name: "bad", Path: "hooks/bad.yaml",
+			Meta: map[string]any{"event": "SessionStart", "matcher": "Bash"},
+		},
+		{
+			Kind: spec.KindHook, Name: "ok", Path: "hooks/ok.yaml",
+			Meta: map[string]any{"event": "PostToolUse", "matcher": "Edit"},
+		},
+		{
+			Kind: spec.KindHook, Name: "no-matcher", Path: "hooks/nm.yaml",
+			Meta: map[string]any{"event": "SessionStart"},
+		},
+	}
+	findings := lintHookMatcherMisuse(hooks)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 matcher-misuse finding, got %d", len(findings))
+	}
+	f := findings[0]
+	if f.Code != "LINT005" {
+		t.Errorf("expected code LINT005, got %s", f.Code)
+	}
+	if f.Severity != lintWarn {
+		t.Errorf("expected warn severity, got %s", f.Severity)
+	}
+	if f.Path != "hooks/bad.yaml" {
+		t.Errorf("expected path hooks/bad.yaml, got %s", f.Path)
+	}
+}
+
+func TestLintHookMatcherMisuse_NoFindingsOnCleanHooks(t *testing.T) {
+	hooks := []spec.Entry{
+		{Kind: spec.KindHook, Name: "a", Path: "hooks/a.yaml", Meta: map[string]any{"event": "PreToolUse", "matcher": "Bash"}},
+		{Kind: spec.KindHook, Name: "b", Path: "hooks/b.yaml", Meta: map[string]any{"event": "AfterTool", "matcher": "shell"}},
+		{Kind: spec.KindHook, Name: "c", Path: "hooks/c.yaml", Meta: map[string]any{"event": "SessionStart"}},
+	}
+	if got := lintHookMatcherMisuse(hooks); len(got) != 0 {
+		t.Errorf("expected 0 findings on clean hooks, got %d", len(got))
+	}
+}

--- a/internal/cli/native_capabilities.go
+++ b/internal/cli/native_capabilities.go
@@ -29,6 +29,14 @@ var hookEventsByTarget = map[string]map[string]struct{}{
 	),
 }
 
+// matcherAcceptingEvents lists the hook events whose native CLI consumes a
+// matcher field. Events outside this set ignore matchers entirely; setting
+// one is a no-op the user likely did not intend.
+var matcherAcceptingEvents = setOf(
+	"PreToolUse", "PostToolUse", // claude, codex
+	"BeforeTool", "AfterTool", // gemini
+)
+
 // targetsSupportingKind lists the targets whose adapter actually
 // emits non-empty output for the given kind. Used by the orphan-kind
 // validator: if a project has hook specs but no enabled target maps


### PR DESCRIPTION
## Summary

- New lint check LINT005 (warn): hook spec has `matcher:` set but its `event:` is one the native CLI ignores matchers for (e.g. SessionStart, UserPromptSubmit, Stop, Notification, PreCompact).
- Matcher-accepting events whitelisted in `native_capabilities.go`: PreToolUse, PostToolUse (claude/codex) and BeforeTool, AfterTool (gemini).
- Refs #177 — Claude+Codex audit, hook section.

## Why

Today a user can write a hook with `event: SessionStart` and `matcher: "Bash"` and ship it without warning. The matcher is silently dropped by the native CLI at runtime. Catching this at lint time saves a debugging session.

## Test plan

- [x] `go test ./internal/cli/... -run Lint` — 8 tests pass (2 new)
- [x] `go test ./...` — 699 tests pass
- [x] LINT005 fires on matcher + SessionStart
- [x] LINT005 quiet on matcher + PreToolUse, AfterTool
- [x] LINT005 quiet when matcher is empty