### PR TITLE
feat(codex): profiles and notify in outputs.codex.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `agnostic-ai doctor`: diagnostic with `mcp`, `install`, `config` subcommands, `--json` (#159).
 - `agnostic-ai install-hook`: pre-commit hook running `sync --check`, `--shared` for `.githooks/` (#169).
 - MCP spec: `description`, `disabled`, `roots` (#177).
-- Codex `outputs.codex.config`: first-class block for native `.codex/config.toml` keys (#177).
+- Codex `outputs.codex.config`: first-class block with `notify` and `profiles.<name>` tables (#177).
 - Golden snapshot tests for every built-in adapter (#166).
 
 ## v0.13.0 - 2026-05-15

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -100,6 +100,42 @@
         },
         "history-persistence": {
           "type": "string"
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "profiles": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CodexProfile"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CodexProfile": {
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "sandbox": {
+          "type": "string"
+        },
+        "approval-policy": {
+          "type": "string"
+        },
+        "model-reasoning-effort": {
+          "type": "string"
+        },
+        "model-reasoning-summary": {
+          "type": "string"
+        },
+        "model-provider": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -351,6 +351,15 @@ outputs:
       model-reasoning-effort: high
       model-reasoning-summary: auto
       history-persistence: project
+      notify: ["python3", "/etc/codex/notify.py"]
+      profiles:
+        work:
+          model: o4-mini
+          sandbox: workspace-write
+          approval-policy: on-failure
+        oss:
+          model: gpt-oss-20b
+          model-provider: ollama
 ```
 
 | Field | Type | Notes |
@@ -361,6 +370,8 @@ outputs:
 | `model-reasoning-effort` | string | Reasoning effort level for o-series models: `low`, `medium`, `high`. |
 | `model-reasoning-summary` | string | Reasoning summary verbosity: `auto`, `concise`, `detailed`. |
 | `history-persistence` | string | Conversation history scope: `project`, `global`, or `none`. |
+| `notify` | string array | External program Codex invokes on session events. First element is the executable; rest are arguments. |
+| `profiles` | map | Named `[profiles.<name>]` blocks. Each entry overrides top-level fields when Codex runs with `--profile <name>`. Supported keys: `model`, `sandbox`, `approval-policy`, `model-reasoning-effort`, `model-reasoning-summary`, `model-provider`. |
 
 ## Path semantics
 

--- a/internal/adapters/codex/config_toml.go
+++ b/internal/adapters/codex/config_toml.go
@@ -36,7 +36,7 @@ func hasCodexConfig(cfg *config.CodexConfig) bool {
 	}
 	return cfg.Sandbox != "" || cfg.ApprovalPolicy != "" || cfg.Model != "" ||
 		cfg.ModelReasoningEffort != "" || cfg.ModelReasoningSummary != "" ||
-		cfg.HistoryPersistence != ""
+		cfg.HistoryPersistence != "" || len(cfg.Notify) > 0 || len(cfg.Profiles) > 0
 }
 
 // writeCodexConfigFields emits the first-class `.codex/config.toml` scalars
@@ -60,12 +60,47 @@ func writeCodexConfigFields(sb *strings.Builder, cfg *config.CodexConfig) {
 	if cfg.ModelReasoningSummary != "" {
 		emit.WriteTOMLString(sb, "model_reasoning_summary", cfg.ModelReasoningSummary)
 	}
+	if len(cfg.Notify) > 0 {
+		emit.WriteTOMLStringArray(sb, "notify", cfg.Notify)
+	}
 	if cfg.HistoryPersistence != "" {
 		sb.WriteString("\n[history]\n")
 		emit.WriteTOMLString(sb, "persistence", cfg.HistoryPersistence)
 	}
+	writeCodexProfiles(sb, cfg.Profiles)
 	if hasCodexConfig(cfg) {
 		sb.WriteString("\n")
+	}
+}
+
+// writeCodexProfiles emits each `[profiles.<name>]` table sorted by name for
+// deterministic output. Empty fields are skipped so the profile only carries
+// the overrides the user actually set.
+func writeCodexProfiles(sb *strings.Builder, profiles map[string]config.CodexProfile) {
+	if len(profiles) == 0 {
+		return
+	}
+	for _, name := range slices.Sorted(maps.Keys(profiles)) {
+		p := profiles[name]
+		sb.WriteString("\n[profiles." + name + "]\n")
+		if p.Model != "" {
+			emit.WriteTOMLString(sb, "model", p.Model)
+		}
+		if p.Sandbox != "" {
+			emit.WriteTOMLString(sb, "sandbox", p.Sandbox)
+		}
+		if p.ApprovalPolicy != "" {
+			emit.WriteTOMLString(sb, "approval_policy", p.ApprovalPolicy)
+		}
+		if p.ModelReasoningEffort != "" {
+			emit.WriteTOMLString(sb, "model_reasoning_effort", p.ModelReasoningEffort)
+		}
+		if p.ModelReasoningSummary != "" {
+			emit.WriteTOMLString(sb, "model_reasoning_summary", p.ModelReasoningSummary)
+		}
+		if p.ModelProvider != "" {
+			emit.WriteTOMLString(sb, "model_provider", p.ModelProvider)
+		}
 	}
 }
 

--- a/internal/adapters/codex/config_toml_test.go
+++ b/internal/adapters/codex/config_toml_test.go
@@ -248,6 +248,72 @@ func TestEmit_CodexConfig_ModelReasoningAndHistory(t *testing.T) {
 	}
 }
 
+func TestEmit_CodexConfig_Notify(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"codex": {
+				Config: &config.CodexConfig{
+					Notify: []string{"python3", "/etc/codex/notify.py"},
+				},
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	if !strings.Contains(got, `notify = ["python3", "/etc/codex/notify.py"]`) {
+		t.Errorf("missing notify array in:\n%s", got)
+	}
+}
+
+func TestEmit_CodexConfig_Profiles(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"codex": {
+				Config: &config.CodexConfig{
+					Profiles: map[string]config.CodexProfile{
+						"work": {
+							Model:          "o4-mini",
+							Sandbox:        "workspace-write",
+							ApprovalPolicy: "on-failure",
+						},
+						"oss": {
+							Model:         "gpt-oss-20b",
+							ModelProvider: "ollama",
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	for _, want := range []string{
+		"[profiles.oss]",
+		`model = "gpt-oss-20b"`,
+		`model_provider = "ollama"`,
+		"[profiles.work]",
+		`model = "o4-mini"`,
+		`sandbox = "workspace-write"`,
+		`approval_policy = "on-failure"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Sort order: oss before work alphabetically.
+	if strings.Index(got, "[profiles.oss]") > strings.Index(got, "[profiles.work]") {
+		t.Error("expected profiles to emit in sorted order (oss before work)")
+	}
+}
+
 func TestEmit_CodexConfig_NoFileWhenEmpty(t *testing.T) {
 	dir := testutil.TempCwd(t)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,12 +143,27 @@ type ClaudePermissions struct {
 // sync. Keys not listed here (e.g. user-specific overrides) belong in the
 // user-global `~/.codex/config.toml` which Codex merges last.
 type CodexConfig struct {
+	Sandbox               string                  `yaml:"sandbox,omitempty"                 json:"sandbox,omitempty"`
+	ApprovalPolicy        string                  `yaml:"approval-policy,omitempty"         json:"approval-policy,omitempty"`
+	Model                 string                  `yaml:"model,omitempty"                   json:"model,omitempty"`
+	ModelReasoningEffort  string                  `yaml:"model-reasoning-effort,omitempty"  json:"model-reasoning-effort,omitempty"`
+	ModelReasoningSummary string                  `yaml:"model-reasoning-summary,omitempty" json:"model-reasoning-summary,omitempty"`
+	HistoryPersistence    string                  `yaml:"history-persistence,omitempty"     json:"history-persistence,omitempty"`
+	Notify                []string                `yaml:"notify,omitempty"                  json:"notify,omitempty"`
+	Profiles              map[string]CodexProfile `yaml:"profiles,omitempty"                json:"profiles,omitempty"`
+}
+
+// CodexProfile mirrors a `[profiles.<name>]` table in `.codex/config.toml`.
+// Codex resolves a profile by name (`codex --profile work`) and overlays its
+// fields on top of the top-level defaults. Empty fields fall through to the
+// top-level config.
+type CodexProfile struct {
+	Model                 string `yaml:"model,omitempty"                   json:"model,omitempty"`
 	Sandbox               string `yaml:"sandbox,omitempty"                 json:"sandbox,omitempty"`
 	ApprovalPolicy        string `yaml:"approval-policy,omitempty"         json:"approval-policy,omitempty"`
-	Model                 string `yaml:"model,omitempty"                   json:"model,omitempty"`
 	ModelReasoningEffort  string `yaml:"model-reasoning-effort,omitempty"  json:"model-reasoning-effort,omitempty"`
 	ModelReasoningSummary string `yaml:"model-reasoning-summary,omitempty" json:"model-reasoning-summary,omitempty"`
-	HistoryPersistence    string `yaml:"history-persistence,omitempty"     json:"history-persistence,omitempty"`
+	ModelProvider         string `yaml:"model-provider,omitempty"          json:"model-provider,omitempty"`
 }
 
 // Load reads the project config from root. It prefers


### PR DESCRIPTION
## Summary

- Add `profiles.<name>` table support to `outputs.codex.config`. Each profile carries `model`, `sandbox`, `approval-policy`, `model-reasoning-effort`, `model-reasoning-summary`, and `model-provider`. Codex resolves via `codex --profile <name>`.
- Add `notify` array field — Codex invokes the configured program on session events.
- Schema regenerated, docs updated, golden suite untouched.

Refs #177 — Codex config audit checklist.

## Why

`outputs.codex.config` covered the top-level scalars but skipped two of the most-requested native features. Profiles let teams declare per-context overrides without hand-editing `.codex/config.toml`; `notify` wires session-event hooks into Codex's own dispatch path rather than agnostic-ai's hook kind.

## Test plan

- [x] `go test ./internal/adapters/codex/...` — 32 pass (2 new)
- [x] `go test ./...` — 701 pass
- [x] `go run ./cmd/schemagen` — schema regenerated
- [x] Profiles emit sorted by name
- [x] `notify` emits as TOML string array