### PR TITLE
test(import): codex skill import preserves executable bit

### DIFF
--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -319,6 +320,31 @@ func TestImportFromCodex_CopiesSkillAssets(t *testing.T) {
 		want, _ := os.ReadFile(filepath.Join(skillRoot, filepath.FromSlash(rel)))
 		if string(got) != string(want) {
 			t.Errorf("skill asset %q not byte-identical: got %q want %q", rel, got, want)
+		}
+	}
+}
+
+func TestImportFromCodex_PreservesSkillScriptExecutableBit(t *testing.T) {
+	dir := t.TempDir()
+	skillRoot := filepath.Join(dir, ".agents", "skills", "build")
+	writeFile(t, filepath.Join(skillRoot, "SKILL.md"), "---\nname: build\n---\nbody\n")
+	scriptPath := filepath.Join(skillRoot, "run.sh")
+	writeFile(t, scriptPath, "#!/bin/sh\necho hi\n")
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, "skills", "build", "run.sh"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("executable bit dropped on import: mode=%v", info.Mode().Perm())
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `TestImportFromCodex_PreservesSkillScriptExecutableBit` (skipped on Windows). Mirrors the claude-side coverage.
- No production change. `copyDirTree` already preserves `info.Mode().Perm()` on write; this pins the contract behind a Codex-specific test.

Refs #177 — Codex skills audit ("multi-file round-trip already covered. Audit edge cases: symlinks, executable bits on Windows.").

## Why

Claude side had `TestImportFromClaude_PreservesSkillScriptExecutableBit`; Codex didn't. Without it, a refactor to `copyDirTree` could regress only Codex-imported skills and the test suite would still pass. This closes the gap.

## Test plan

- [x] `go test ./internal/cli/... -run "Codex.*Executable"` — 1 pass
- [x] `go test ./...` — 700 pass