### PR TITLE
feat(codex): mcp_servers parity with .mcp.json schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `agnostic-ai install-hook`: pre-commit hook running `sync --check`, `--shared` for `.githooks/` (#169).
 - MCP spec: `description`, `disabled`, `roots` (#177).
 - Codex `outputs.codex.config`: first-class block with `notify` and `profiles.<name>` tables (#177).
+- Codex `[mcp_servers.<name>]`: emits `description`, `disabled`, `roots` for `.mcp.json` parity (#177).
 - Golden snapshot tests for every built-in adapter (#166).
 
 ## v0.13.0 - 2026-05-15

--- a/internal/adapters/codex/config_toml.go
+++ b/internal/adapters/codex/config_toml.go
@@ -126,7 +126,8 @@ func writeMCPServers(sb *strings.Builder, mcps []spec.Entry) {
 }
 
 // writeMCPServerTable emits one `[mcp_servers.<name>]` table with the
-// transport-appropriate keys.
+// transport-appropriate keys plus the shared description/disabled/roots
+// fields that mirror the `.mcp.json` schema.
 func writeMCPServerTable(sb *strings.Builder, m spec.Entry) {
 	sb.WriteString("[mcp_servers." + m.Name + "]\n")
 
@@ -152,7 +153,43 @@ func writeMCPServerTable(sb *strings.Builder, m spec.Entry) {
 		}
 		emit.WriteTOMLInlineStringTable(sb, "http_headers", emit.StringMap(m.Meta["headers"]))
 	}
+	writeMCPSharedFields(sb, m.Meta)
 	sb.WriteString("\n")
+}
+
+// writeMCPSharedFields emits description, disabled, and roots — the keys
+// .mcp.json supports across every transport — into the current
+// `[mcp_servers.<name>]` table. Roots renders as an array of inline tables.
+func writeMCPSharedFields(sb *strings.Builder, meta map[string]any) {
+	if desc, _ := meta["description"].(string); desc != "" {
+		emit.WriteTOMLString(sb, "description", desc)
+	}
+	if disabled, _ := meta["disabled"].(bool); disabled {
+		sb.WriteString("disabled = true\n")
+	}
+	raw, _ := meta["roots"].([]any)
+	if len(raw) == 0 {
+		return
+	}
+	sb.WriteString("roots = [")
+	first := true
+	for _, r := range raw {
+		root, _ := r.(map[string]any)
+		uri, _ := root["uri"].(string)
+		if uri == "" {
+			continue
+		}
+		if !first {
+			sb.WriteString(", ")
+		}
+		first = false
+		sb.WriteString(`{ uri = "` + emit.EscapeTOMLBasic(uri) + `"`)
+		if name, _ := root["name"].(string); name != "" {
+			sb.WriteString(`, name = "` + emit.EscapeTOMLBasic(name) + `"`)
+		}
+		sb.WriteString(" }")
+	}
+	sb.WriteString("]\n")
 }
 
 func writeHookSectionsFromMap(sb *strings.Builder, byEvent map[string][]spec.Entry) {

--- a/internal/adapters/codex/config_toml_test.go
+++ b/internal/adapters/codex/config_toml_test.go
@@ -166,6 +166,59 @@ func TestEmit_ConfigToml_NoFileWhenNoMCPOrHooks(t *testing.T) {
 	}
 }
 
+func TestEmit_MCP_DescriptionAndDisabled(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindMCP,
+			Name: "fs",
+			Meta: map[string]any{
+				"command":     "npx",
+				"description": "Filesystem MCP",
+				"disabled":    true,
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	for _, want := range []string{
+		`description = "Filesystem MCP"`,
+		"disabled = true",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %s", want, got)
+		}
+	}
+}
+
+func TestEmit_MCP_Roots(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindMCP,
+			Name: "fs",
+			Meta: map[string]any{
+				"command": "npx",
+				"roots": []any{
+					map[string]any{"uri": "file:///workspace", "name": "workspace"},
+					map[string]any{"uri": "file:///tmp"},
+				},
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	if !strings.Contains(got, `roots = [{ uri = "file:///workspace", name = "workspace" }, { uri = "file:///tmp" }]`) {
+		t.Errorf("missing roots inline array in:\n%s", got)
+	}
+}
+
 // MCP env values with backslashes / quotes survive the TOML round-trip.
 func TestEmit_MCP_EnvEscapesQuotesAndBackslashes(t *testing.T) {
 	dir := testutil.TempCwd(t)


### PR DESCRIPTION
## Summary

- Emit `description`, `disabled = true`, and `roots = [...]` inside `[mcp_servers.<name>]` tables in `.codex/config.toml`.
- Roots renders as an inline array of inline tables: `roots = [{ uri = "file:///workspace", name = "workspace" }, ...]`. URI required; name optional.
- 2 new tests cover description+disabled and roots.

Refs #177 — Codex MCP audit ("`mcp_servers.<id>` parity with `.mcp.json` (today partial)").

## Why

The shared MCP spec gained `description`, `disabled`, and `roots` fields. `.mcp.json` (Claude, Cursor, Continue, Warp, Zed) writes them. Codex's TOML emitter was the only adapter still dropping them. After this PR, agnostic-ai outputs are uniform across MCP-aware targets.

## Test plan

- [x] `go test ./internal/adapters/codex/...` — 32 pass (2 new)
- [x] `go test ./...` — 701 pass
- [x] Manual: roots inline array stays on one line for compact output