### PR TITLE
feat(codex): first-class tools list on agent TOML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - MCP spec: `description`, `disabled`, `roots` (#177).
 - Codex `outputs.codex.config`: first-class block with `notify`, `profiles.<name>`, and `model-providers.<id>` tables (#177).
 - Codex `[mcp_servers.<name>]`: emits `description`, `disabled`, `roots` for `.mcp.json` parity (#177).
+- Codex agent: top-level `tools:` first-classed in agent TOML (#177).
 - Golden snapshot tests for every built-in adapter (#166).
 
 ## v0.13.0 - 2026-05-15

--- a/internal/adapters/codex/agent_toml.go
+++ b/internal/adapters/codex/agent_toml.go
@@ -46,6 +46,9 @@ func agentTOML(a spec.Entry) string {
 	if v := stringOr(meta, "sandbox_mode", ""); v != "" {
 		emit.WriteTOMLString(&sb, "sandbox_mode", v)
 	}
+	if tools := stringSlice(meta["tools"]); len(tools) > 0 {
+		emit.WriteTOMLStringArray(&sb, "tools", tools)
+	}
 	if names := stringSlice(meta["nickname_candidates"]); len(names) > 0 {
 		emit.WriteTOMLStringArray(&sb, "nickname_candidates", names)
 	}
@@ -63,6 +66,7 @@ var codexAgentEmittedKeys = map[string]bool{
 	"model":                  true,
 	"model_reasoning_effort": true,
 	"sandbox_mode":           true,
+	"tools":                  true,
 	"nickname_candidates":    true,
 }
 

--- a/internal/adapters/codex/agent_toml_test.go
+++ b/internal/adapters/codex/agent_toml_test.go
@@ -73,6 +73,43 @@ func TestAgentTOML_XCodexOverridesTopLevel(t *testing.T) {
 	}
 }
 
+func TestAgentTOML_ToolsFirstClass(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "scoped",
+		Body: "Limited tool set.",
+		Meta: map[string]any{
+			"tools": []any{"bash", "edit", "read"},
+		},
+	}
+	got := agentTOML(a)
+	if !strings.Contains(got, `tools = ["bash", "edit", "read"]`) {
+		t.Errorf("missing tools array:\n%s", got)
+	}
+}
+
+func TestAgentTOML_XCodexToolsOverridesTopLevel(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "scoped",
+		Body: "x",
+		Meta: map[string]any{
+			"tools": []any{"bash"},
+			"x-codex": map[string]any{
+				"tools": []any{"edit", "read"},
+			},
+		},
+	}
+	got := agentTOML(a)
+	// Only one tools line, with x-codex content winning.
+	if !strings.Contains(got, `tools = ["edit", "read"]`) {
+		t.Errorf("x-codex.tools should win:\n%s", got)
+	}
+	if strings.Count(got, "tools = ") != 1 {
+		t.Errorf("tools should emit exactly once:\n%s", got)
+	}
+}
+
 func TestAgentTOML_NicknameCandidatesIgnoresNonStringSlice(t *testing.T) {
 	a := spec.Entry{
 		Kind: spec.KindAgent,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,12 +143,12 @@ type ClaudePermissions struct {
 // sync. Keys not listed here (e.g. user-specific overrides) belong in the
 // user-global `~/.codex/config.toml` which Codex merges last.
 type CodexConfig struct {
-	Sandbox               string                  `yaml:"sandbox,omitempty"                 json:"sandbox,omitempty"`
-	ApprovalPolicy        string                  `yaml:"approval-policy,omitempty"         json:"approval-policy,omitempty"`
-	Model                 string                  `yaml:"model,omitempty"                   json:"model,omitempty"`
-	ModelReasoningEffort  string                  `yaml:"model-reasoning-effort,omitempty"  json:"model-reasoning-effort,omitempty"`
-	ModelReasoningSummary string                  `yaml:"model-reasoning-summary,omitempty" json:"model-reasoning-summary,omitempty"`
-	HistoryPersistence    string                  `yaml:"history-persistence,omitempty"     json:"history-persistence,omitempty"`
+	Sandbox               string                        `yaml:"sandbox,omitempty"                 json:"sandbox,omitempty"`
+	ApprovalPolicy        string                        `yaml:"approval-policy,omitempty"         json:"approval-policy,omitempty"`
+	Model                 string                        `yaml:"model,omitempty"                   json:"model,omitempty"`
+	ModelReasoningEffort  string                        `yaml:"model-reasoning-effort,omitempty"  json:"model-reasoning-effort,omitempty"`
+	ModelReasoningSummary string                        `yaml:"model-reasoning-summary,omitempty" json:"model-reasoning-summary,omitempty"`
+	HistoryPersistence    string                        `yaml:"history-persistence,omitempty"     json:"history-persistence,omitempty"`
 	Notify                []string                      `yaml:"notify,omitempty"                  json:"notify,omitempty"`
 	Profiles              map[string]CodexProfile       `yaml:"profiles,omitempty"                json:"profiles,omitempty"`
 	ModelProviders        map[string]CodexModelProvider `yaml:"model-providers,omitempty"         json:"model-providers,omitempty"`


### PR DESCRIPTION
## Summary

- Promote agent frontmatter `tools:` from generic `x-codex` passthrough to a first-class field.
- Top-level `tools: [bash, edit, read]` now emits as `tools = ["bash", "edit", "read"]` in `.agents/agents/<name>.toml`.
- `x-codex.tools` still overrides top-level when both are set (same precedence rule as `model`, `sandbox_mode`, etc.).
- Added to `codexAgentEmittedKeys` so `writeXCodexExtras` does not double-emit.

Refs #177 — Codex agents audit ("Agent `tools` list schema").

## Why

The audit wants `tools` schema-level so users can scope a subagent's tool access from the same place they declare its model and sandbox. Today they have to nest under `x-codex:` which is meant for future / unknown keys.

## Test plan

- [x] `go test ./internal/adapters/codex/...` — 32 pass (2 new)
- [x] `go test ./...` — 701 pass
- [x] Top-level `tools:` emits
- [x] `x-codex.tools` overrides top-level when both set
- [x] Single `tools = ` line in output (no double-emit)