### PR TITLE
feat(codex): model_providers blocks in outputs.codex.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `agnostic-ai doctor`: diagnostic with `mcp`, `install`, `config` subcommands, `--json` (#159).
 - `agnostic-ai install-hook`: pre-commit hook running `sync --check`, `--shared` for `.githooks/` (#169).
 - MCP spec: `description`, `disabled`, `roots` (#177).
-- Codex `outputs.codex.config`: first-class block with `notify` and `profiles.<name>` tables (#177).
+- Codex `outputs.codex.config`: first-class block with `notify`, `profiles.<name>`, and `model-providers.<id>` tables (#177).
 - Codex `[mcp_servers.<name>]`: emits `description`, `disabled`, `roots` for `.mcp.json` parity (#177).
 - Golden snapshot tests for every built-in adapter (#166).
 

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -112,6 +112,33 @@
             "$ref": "#/$defs/CodexProfile"
           },
           "type": "object"
+        },
+        "model-providers": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CodexModelProvider"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CodexModelProvider": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "base-url": {
+          "type": "string"
+        },
+        "wire-api": {
+          "type": "string"
+        },
+        "api-key-env": {
+          "type": "string"
+        },
+        "env-key": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -372,6 +372,7 @@ outputs:
 | `history-persistence` | string | Conversation history scope: `project`, `global`, or `none`. |
 | `notify` | string array | External program Codex invokes on session events. First element is the executable; rest are arguments. |
 | `profiles` | map | Named `[profiles.<name>]` blocks. Each entry overrides top-level fields when Codex runs with `--profile <name>`. Supported keys: `model`, `sandbox`, `approval-policy`, `model-reasoning-effort`, `model-reasoning-summary`, `model-provider`. |
+| `model-providers` | map | Named `[model_providers.<id>]` blocks declaring backends Codex can call. Supported keys: `name`, `base-url`, `wire-api`, `api-key-env`, `env-key`. Reference an `id` from `profiles.<name>.model-provider`. |
 
 ## Path semantics
 

--- a/internal/adapters/codex/config_toml.go
+++ b/internal/adapters/codex/config_toml.go
@@ -36,7 +36,8 @@ func hasCodexConfig(cfg *config.CodexConfig) bool {
 	}
 	return cfg.Sandbox != "" || cfg.ApprovalPolicy != "" || cfg.Model != "" ||
 		cfg.ModelReasoningEffort != "" || cfg.ModelReasoningSummary != "" ||
-		cfg.HistoryPersistence != "" || len(cfg.Notify) > 0 || len(cfg.Profiles) > 0
+		cfg.HistoryPersistence != "" || len(cfg.Notify) > 0 ||
+		len(cfg.Profiles) > 0 || len(cfg.ModelProviders) > 0
 }
 
 // writeCodexConfigFields emits the first-class `.codex/config.toml` scalars
@@ -67,9 +68,38 @@ func writeCodexConfigFields(sb *strings.Builder, cfg *config.CodexConfig) {
 		sb.WriteString("\n[history]\n")
 		emit.WriteTOMLString(sb, "persistence", cfg.HistoryPersistence)
 	}
+	writeCodexModelProviders(sb, cfg.ModelProviders)
 	writeCodexProfiles(sb, cfg.Profiles)
 	if hasCodexConfig(cfg) {
 		sb.WriteString("\n")
+	}
+}
+
+// writeCodexModelProviders emits each `[model_providers.<id>]` table sorted
+// by id for deterministic output. Empty fields are skipped so each provider
+// only carries the keys the user actually set.
+func writeCodexModelProviders(sb *strings.Builder, providers map[string]config.CodexModelProvider) {
+	if len(providers) == 0 {
+		return
+	}
+	for _, id := range slices.Sorted(maps.Keys(providers)) {
+		p := providers[id]
+		sb.WriteString("\n[model_providers." + id + "]\n")
+		if p.Name != "" {
+			emit.WriteTOMLString(sb, "name", p.Name)
+		}
+		if p.BaseURL != "" {
+			emit.WriteTOMLString(sb, "base_url", p.BaseURL)
+		}
+		if p.WireAPI != "" {
+			emit.WriteTOMLString(sb, "wire_api", p.WireAPI)
+		}
+		if p.APIKeyEnv != "" {
+			emit.WriteTOMLString(sb, "api_key_env", p.APIKeyEnv)
+		}
+		if p.EnvKey != "" {
+			emit.WriteTOMLString(sb, "env_key", p.EnvKey)
+		}
 	}
 }
 

--- a/internal/adapters/codex/config_toml_test.go
+++ b/internal/adapters/codex/config_toml_test.go
@@ -367,6 +367,53 @@ func TestEmit_CodexConfig_Profiles(t *testing.T) {
 	}
 }
 
+func TestEmit_CodexConfig_ModelProviders(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"codex": {
+				Config: &config.CodexConfig{
+					ModelProviders: map[string]config.CodexModelProvider{
+						"ollama": {
+							Name:    "Ollama",
+							BaseURL: "http://localhost:11434/v1",
+							WireAPI: "responses",
+						},
+						"azure": {
+							Name:      "Azure",
+							BaseURL:   "https://my.openai.azure.com/openai",
+							WireAPI:   "responses",
+							APIKeyEnv: "AZURE_OPENAI_API_KEY",
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	for _, want := range []string{
+		"[model_providers.azure]",
+		`name = "Azure"`,
+		`base_url = "https://my.openai.azure.com/openai"`,
+		`api_key_env = "AZURE_OPENAI_API_KEY"`,
+		"[model_providers.ollama]",
+		`name = "Ollama"`,
+		`base_url = "http://localhost:11434/v1"`,
+		`wire_api = "responses"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "[model_providers.azure]") > strings.Index(got, "[model_providers.ollama]") {
+		t.Error("expected model providers to emit in sorted order (azure before ollama)")
+	}
+}
+
 func TestEmit_CodexConfig_NoFileWhenEmpty(t *testing.T) {
 	dir := testutil.TempCwd(t)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,8 +149,22 @@ type CodexConfig struct {
 	ModelReasoningEffort  string                  `yaml:"model-reasoning-effort,omitempty"  json:"model-reasoning-effort,omitempty"`
 	ModelReasoningSummary string                  `yaml:"model-reasoning-summary,omitempty" json:"model-reasoning-summary,omitempty"`
 	HistoryPersistence    string                  `yaml:"history-persistence,omitempty"     json:"history-persistence,omitempty"`
-	Notify                []string                `yaml:"notify,omitempty"                  json:"notify,omitempty"`
-	Profiles              map[string]CodexProfile `yaml:"profiles,omitempty"                json:"profiles,omitempty"`
+	Notify                []string                      `yaml:"notify,omitempty"                  json:"notify,omitempty"`
+	Profiles              map[string]CodexProfile       `yaml:"profiles,omitempty"                json:"profiles,omitempty"`
+	ModelProviders        map[string]CodexModelProvider `yaml:"model-providers,omitempty"         json:"model-providers,omitempty"`
+}
+
+// CodexModelProvider mirrors a `[model_providers.<id>]` table in
+// `.codex/config.toml`. Each provider declares how Codex talks to a model
+// backend (OpenAI-compatible, Azure, Ollama, custom OSS endpoints, ...).
+// `Name` and `BaseURL` are usually required; the other fields fill in
+// transport details.
+type CodexModelProvider struct {
+	Name      string `yaml:"name,omitempty"        json:"name,omitempty"`
+	BaseURL   string `yaml:"base-url,omitempty"    json:"base-url,omitempty"`
+	WireAPI   string `yaml:"wire-api,omitempty"    json:"wire-api,omitempty"`
+	APIKeyEnv string `yaml:"api-key-env,omitempty" json:"api-key-env,omitempty"`
+	EnvKey    string `yaml:"env-key,omitempty"     json:"env-key,omitempty"`
 }
 
 // CodexProfile mirrors a `[profiles.<name>]` table in `.codex/config.toml`.


### PR DESCRIPTION
## Summary

- Add `outputs.codex.config.model-providers.<id>` map. Each provider declares how Codex talks to a model backend (name, base-url, wire-api, api-key-env, env-key).
- Emits as `[model_providers.<id>]` TOML tables sorted by id for deterministic output.
- Profiles already gained a `model-provider` field in the parent PR (#181) to reference these entries.

**Stacked on #181 (codex profiles + notify).** Targets `feat/codex-profiles` so the diff stays focused. Once #181 lands, this auto-retargets to `main`.

Refs #177 — Codex config audit ("`model_providers.<id>` blocks (openai, oss, custom endpoints)").

## Why

Profiles are useless without provider definitions. Pairing `model-provider: ollama` in a profile with the matching `[model_providers.ollama]` block is the canonical Codex pattern for multi-backend setups. Without first-class support, users have to hand-edit `.codex/config.toml` after every sync.

## Test plan

- [x] `go test ./internal/adapters/codex/...` — 33 pass (1 new)
- [x] `go test ./...` — 702 pass
- [x] `go run ./cmd/schemagen` — schema regenerated
- [x] Providers emit sorted by id
- [x] Empty providers map produces no `[model_providers.*]` block