### PR TITLE
docs(changelog): tighten unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
-- `sync --plan`: per-target added/changed counts without writing files. (#161)
-- `sync`: atomic transaction — partial writes roll back on any adapter failure. (#162)
-- `sync.collision-policy` config key: `prompt` (default), `prefer-spec`, `fail`. Per-target override via `outputs.<target>.collision-policy`. (#167)
-- `import all`: detects every AI CLI config present and imports each in one shot. (#160)
-- `init --from <cli>`: scaffold + import from an existing CLI in one command. (#160)
-- `init --dry-run` / `import --dry-run`: preview without writing. (#158)
-- `agnostic-ai lint`: semantic checks — LINT001 empty spec, LINT002 hook collision, LINT003 duplicate name, LINT004 dead spec, LINT005 matcher on non-tool event. `--strict` for CI. (#171, #177)
-- `agnostic-ai doctor`: unified 6-step diagnostic with subcommands `mcp`, `install`, `config`. `--json` for machine-readable output. (#159)
-- `agnostic-ai install-hook`: installs `.git/hooks/pre-commit` running `sync --check`. `--shared` commits the hook via `.githooks/`. (#169)
-- MCP spec: `description`, `disabled`, and `roots` frontmatter fields. (#177)
-- Codex: `outputs.codex.config` block for `sandbox`, `approval-policy`, `model`, `model-reasoning-effort`, `model-reasoning-summary`, `history-persistence`. (#177)
-- Golden snapshot tests for every built-in adapter. Regenerate with `UPDATE_GOLDEN=1 go test ./tests/integration/ -run TestGolden`. (#166)
+- `sync --plan`: per-target diff summary without writing (#161).
+- `sync`: atomic transaction; partial writes roll back on failure (#162).
+- `sync.collision-policy`: `prompt`, `prefer-spec`, `fail` (#167).
+- `import all`: detect and import every installed CLI in one shot (#160).
+- `init --from <cli>`: scaffold + import in one command (#160).
+- `init --dry-run`, `import --dry-run`: preview without writing (#158).
+- `agnostic-ai lint`: LINT001–LINT005 semantic checks, `--strict` (#171, #177).
+- `agnostic-ai doctor`: diagnostic with `mcp`, `install`, `config` subcommands, `--json` (#159).
+- `agnostic-ai install-hook`: pre-commit hook running `sync --check`, `--shared` for `.githooks/` (#169).
+- MCP spec: `description`, `disabled`, `roots` (#177).
+- Codex `outputs.codex.config`: first-class block for native `.codex/config.toml` keys (#177).
+- Golden snapshot tests for every built-in adapter (#166).
 
 ## v0.13.0 - 2026-05-15
 


### PR DESCRIPTION
## Summary

- Compact each Unreleased bullet to one short line.
- Drop inline option lists and command-syntax details — those belong in `docs/user/`, not the changelog.
- Same set of PR refs; same coverage. Easier to scan, easier to promote at release time.