### PR TITLE
fix(emit): normalize trailing newline in WriteFile

### DIFF
--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -220,6 +220,10 @@ func Rollback() error {
 // action (create/update/skip) is determined by comparing against existing
 // content; unchanged files are skipped and not rewritten.
 func WriteFile(path, content string, dryRun bool) error {
+	// Normalize to exactly one trailing newline so the emitter does not
+	// produce spurious blank-line diffs when marshaled content already
+	// ends with "\n".
+	content = strings.TrimRight(content, "\n") + "\n"
 	return writeFileWithMode(path, content, filePerm, dryRun)
 }
 


### PR DESCRIPTION
## Summary
`emit.WriteFile` writes content to disk as-is, but marshaled content from adapters may already end with `\n`. When an adapter marshals a document that already has a trailing newline, the emitted file ends up with two trailing newlines, which `diff` reports as an inserted blank line (`+` line). This affects every file emitted by every adapter.

Fixes #195

## Root Cause
In `internal/adapters/internal/emit/emit.go`, the `WriteFile` function passes content directly to `writeFileWithMode` without normalizing trailing whitespace. Adapters that marshal content with `strings.TrimRight(content, "\n") + "\n"` at their layer are fine, but not all adapters do this — and the normalization belongs in the shared emission layer.

## Fix
Add `content = strings.TrimRight(content, "\n") + "\n"` at the top of `WriteFile`, ensuring every emitted file ends with exactly one newline regardless of upstream formatting.

## Changes
- `internal/adapters/internal/emit/emit.go` — `WriteFile` normalizes trailing newline before writing (+4 lines)

## Testing
- ✅ Existing unit tests continue to pass (the change is a no-op when content already has exactly one trailing newline)
- ✅ Content ending with `\n\n` is normalized to `\n`
- ✅ Content with no trailing newline is unchanged structurally (one newline appended)