### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## v0.18.0 - 2026-05-15
+
+### Added
 - `doctor --check-globs`: opt-in flag rules whose `globs:` matches no path in the working tree. Closes #208.
 - `cleanup --backups`: removes `*.bak` left by `sync --backup`. Closes #197.
 - `outputs.codex.shared-subagents` (default `true`): set `false` in claude+codex setups to drop the duplicate `.agents/skills/` tree. Closes #194.
@@ -313,4 +323,5 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - Docs, examples, integration tests, dogfood specs.
 - OSS scaffolding: CONTRIBUTING, COC, GOVERNANCE, issue/PR templates, CI, GoReleaser, golangci-lint, Dockerfile, lefthook, Taskfile, dependabot/renovate.
 
-[Unreleased]: https://github.com/Chemaclass/agnostic-ai/compare/HEAD...HEAD
+[Unreleased]: https://github.com/Chemaclass/agnostic-ai/compare/v0.18.0...HEAD
+[v0.18.0]: https://github.com/Chemaclass/agnostic-ai/compare/v0.17.0...v0.18.0

--- a/cmd/agnostic-ai/main.go
+++ b/cmd/agnostic-ai/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/cli"
 )
 
-var version = "0.17.0"
+var version = "0.18.0"
 
 func main() {
 	if err := cli.NewRootCmd(version).Execute(); err != nil {


### PR DESCRIPTION
## Summary

- Bump version from v0.17.0 to v0.18.0 (minor release).
- Promote `[Unreleased]` changelog section to `v0.18.0 - 2026-05-15`.
- Reset `[Unreleased]` to empty subsections.
- Update CHANGELOG.md link refs: `[Unreleased]` now points to `v0.18.0...HEAD`; add `[v0.18.0]` ref.

## What's in this release

Added: `doctor --check-globs`, `cleanup --backups`, `outputs.codex.shared-subagents`, `spec.Entry.MetaKeys`.

Changed: frontmatter key-order preservation, ordered JSON emit for settings files, capability warning collapsing, `import --dry-run` output format, `doctor` drift classification.

Fixed: trailing newline normalization, `doctor` false-positive on `.claude/settings.json`.

## Test plan

- [x] `go test ./...` passes (757 tests).
- [x] `make preflight` passes (fmt-check, vet, lint, test).
- [x] `go run ./cmd/schemagen` produces no diff.
- [ ] Merge PR, then cut annotated GPG tag `v0.18.0` on main and push; GoReleaser workflow builds artifacts.