### PR TITLE
fix(claude): preserve overlay in capture mode + ordered import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ### Changed
 
 ### Fixed
+- `doctor` and `doctor --fix` now read the settings overlay in capture mode just like a real sync. Previously a clean sync would be flagged as drift and `--fix` would silently delete overlay-supplied keys (`enabledPlugins`, `statusLine`) from `.claude/settings.json`. Import overlay capture also keeps source key order via `OrderedJSON`. Closes #215.
 
 ### Removed
 

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -32,6 +32,17 @@ import (
 // emit tree can consume capture output.
 type CapturedFile = emit.CapturedFile
 
+// OrderedJSON mirrors emit.OrderedJSON so the CLI layer can read and
+// write settings.json overlays without losing source key order.
+type OrderedJSON = emit.OrderedJSON
+
+// NewOrderedJSON returns an empty OrderedJSON ready for Set / Get.
+func NewOrderedJSON() *OrderedJSON { return emit.NewOrderedJSON() }
+
+// MarshalJSONIndent renders v as indented JSON without HTML escaping,
+// preserving OrderedJSON insertion order when v is an OrderedJSON.
+func MarshalJSONIndent(v any) ([]byte, error) { return emit.MarshalJSONIndent(v) }
+
 // WrittenFile mirrors emit.WrittenFile so callers outside the internal
 // emit tree can consume detailed recording output.
 type WrittenFile = emit.WrittenFile

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -215,10 +215,13 @@ func orderedConfigKeys(m map[string]any) []string {
 // `.agnostic-ai/overlays/claude.settings.json`. Returns (doc, true, nil)
 // when the overlay exists and parses, (nil, false, nil) when it is
 // absent, and (nil, false, err) on a parse failure or unexpected read
-// error. Skips disk in dryRun and capture modes so deterministic check
-// passes do not depend on the working tree.
+// error. Skips disk in dryRun so `--dry-run` previews remain pure.
+// Capture mode (used by `sync --check` and `doctor`) still reads the
+// overlay because it is a project-source input under `.agnostic-ai/`,
+// not a previously emitted output — skipping it would cause capture
+// output to diverge from real sync output and trigger false drift.
 func loadSettingsOverlay(dryRun bool) (*emit.OrderedJSON, bool, error) {
-	if dryRun || emit.IsCapturing() {
+	if dryRun {
 		return nil, false, nil
 	}
 	data, err := os.ReadFile(settingsOverlayPath)

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
@@ -769,6 +770,70 @@ func TestEmit_SettingsJSONIsByteStableAcrossSyncs(t *testing.T) {
 	}
 	if string(first) != string(second) {
 		t.Errorf("settings.json drifts on second sync (doctor/sync loop).\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestEmit_CapturePreservesOverlay regresses #215. The capture path
+// (used by `sync --check` and `doctor`) must read the overlay just
+// like a real sync so the captured bytes match the on-disk file.
+// Previously `loadSettingsOverlay` short-circuited on emit.IsCapturing()
+// and dropped overlay-supplied keys (statusLine, enabledPlugins), causing
+// `doctor --fix` to silently delete user data and `doctor` to report
+// false drift right after a clean sync.
+func TestEmit_CapturePreservesOverlay(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	overlayPath := filepath.Join(dir, ".agnostic-ai/overlays/claude.settings.json")
+	if err := os.MkdirAll(filepath.Dir(overlayPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	overlay := `{
+  "enabledPlugins": {"plugin-a": true},
+  "statusLine": {"type": "command", "command": "echo status"}
+}
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := []spec.Entry{
+		{Kind: spec.KindHook, Name: "h1", Meta: map[string]any{
+			"event": "PostToolUse", "matcher": "Edit", "command": "echo hi",
+		}},
+	}
+
+	// Real sync first, capture disk bytes.
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatalf("sync emit: %v", err)
+	}
+	disk, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture-mode emit, compare against disk.
+	emit.StartCapture()
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		emit.StopCapture()
+		t.Fatalf("capture emit: %v", err)
+	}
+	files := emit.StopCapture()
+	var captured string
+	for _, f := range files {
+		if filepath.Base(f.Path) == "settings.json" {
+			captured = f.Content
+			break
+		}
+	}
+	if captured == "" {
+		t.Fatalf("capture produced no settings.json; files=%+v", files)
+	}
+	if string(disk) != captured {
+		t.Errorf("capture diverges from disk\nDISK:\n%s\nCAPTURE:\n%s", disk, captured)
+	}
+	for _, key := range []string{`"enabledPlugins"`, `"statusLine"`, `"hooks"`} {
+		if !strings.Contains(captured, key) {
+			t.Errorf("captured output missing %s:\n%s", key, captured)
+		}
 	}
 }
 

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
@@ -109,6 +110,76 @@ func TestDoctor_Fix_BackupPreservesHandEdits(t *testing.T) {
 	}
 	if string(bak) != string(handEdit) {
 		t.Errorf("backup mismatch: got %q, want %q", bak, handEdit)
+	}
+}
+
+// TestDoctor_NoFalseDriftAfterSyncWithOverlay regresses #215. After a
+// clean sync that materializes statusLine and enabledPlugins from the
+// settings overlay, doctor must read the overlay too (capture mode is
+// not allowed to skip source inputs) so its captured bytes match the
+// disk bytes. Otherwise it reports false drift and `--fix` deletes the
+// overlay-supplied keys.
+func TestDoctor_NoFalseDriftAfterSyncWithOverlay(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	overlayPath := filepath.Join(dir, ".agnostic-ai/overlays/claude.settings.json")
+	if err := os.MkdirAll(filepath.Dir(overlayPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	overlay := `{
+  "enabledPlugins": {"plugin-a": true},
+  "statusLine": {"type": "command", "command": "echo status"}
+}
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hooksDir := filepath.Join(dir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "h1.yaml"),
+		[]byte("name: h1\nevent: PostToolUse\nmatcher: Edit\ncommand: echo hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"doctor", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Errorf("doctor reports false drift immediately after sync: %v", err)
+	}
+
+	settings, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"enabledPlugins"`, `"statusLine"`, `"hooks"`} {
+		if !strings.Contains(string(settings), key) {
+			t.Errorf("post-sync settings.json missing %s:\n%s", key, settings)
+		}
+	}
+
+	// `doctor --fix` must be a no-op here. Run it; settings.json bytes
+	// must be unchanged so we don't lose overlay-supplied keys.
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"doctor", "-t", "claude", "--fix"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("doctor --fix: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(settings) != string(after) {
+		t.Errorf("doctor --fix mutated settings.json:\nBEFORE:\n%s\nAFTER:\n%s", settings, after)
 	}
 }
 

--- a/internal/cli/import_claude_settings.go
+++ b/internal/cli/import_claude_settings.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
 )
 
 const (
@@ -49,15 +51,15 @@ func importClaudeSettingsOverlay(root string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", src, err)
 	}
-	var doc map[string]any
-	if err := json.Unmarshal(data, &doc); err != nil {
+	doc := adapters.NewOrderedJSON()
+	if err := json.Unmarshal(data, doc); err != nil {
 		return fmt.Errorf("parse %s: %w", src, err)
 	}
-	delete(doc, "hooks")
-	if len(doc) == 0 {
+	doc.Delete("hooks")
+	if doc.Len() == 0 {
 		return nil
 	}
-	raw, err := json.MarshalIndent(doc, "", "  ")
+	raw, err := adapters.MarshalJSONIndent(doc)
 	if err != nil {
 		return fmt.Errorf("marshal overlay: %w", err)
 	}

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -393,6 +393,48 @@ func TestImportFromClaude_WritesSettingsOverlay(t *testing.T) {
 	}
 }
 
+// TestImportFromClaude_OverlayPreservesKeyOrder regresses #215.
+// importClaudeSettingsOverlay used to round-trip through map[string]any,
+// which alpha-sorts every key on json.Marshal. The captured overlay
+// therefore lost the user's authored key order, and downstream
+// `doctor --fix` writes propagated the alpha-sorted form back.
+// OrderedJSON adoption keeps statusLine before enabledPlugins, and
+// inner statusLine fields type before command, byte-for-byte.
+func TestImportFromClaude_OverlayPreservesKeyOrder(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "statusLine": {"type": "command", "command": "echo status"},
+  "enabledPlugins": {"plugin-a": true},
+  "hooks": {}
+}`
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), settings)
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".agnostic-ai/overlays/claude.settings.json"))
+	if err != nil {
+		t.Fatalf("missing overlay: %v", err)
+	}
+	s := string(raw)
+	idxStatus := strings.Index(s, `"statusLine"`)
+	idxPlugins := strings.Index(s, `"enabledPlugins"`)
+	if idxStatus < 0 || idxPlugins <= idxStatus {
+		t.Errorf("overlay re-ordered top-level keys (want statusLine before enabledPlugins):\n%s", s)
+	}
+	statusBlock := s
+	if i := strings.Index(s, `"statusLine"`); i >= 0 {
+		statusBlock = s[i:]
+		if j := strings.Index(statusBlock, "}"); j >= 0 {
+			statusBlock = statusBlock[:j+1]
+		}
+	}
+	idxType := strings.Index(statusBlock, `"type"`)
+	idxCmd := strings.Index(statusBlock, `"command"`)
+	if idxType < 0 || idxCmd <= idxType {
+		t.Errorf("statusLine inner keys re-ordered (want type before command):\n%s", statusBlock)
+	}
+}
+
 func TestImportFromClaude_OnlyHooks_NoOverlay(t *testing.T) {
 	dir := t.TempDir()
 	settings := `{


### PR DESCRIPTION
## Summary

- Drop `emit.IsCapturing()` short-circuit in `loadSettingsOverlay` so doctor/check read the overlay like a real sync. Closes the drift loop + silent data loss in `doctor --fix`.
- Switch `importClaudeSettingsOverlay` from `map[string]any` to `emit.OrderedJSON` (via a new `adapters.NewOrderedJSON` re-export). Captured overlay keeps the user's key order instead of alpha-sorting.
- Three regression tests:
  - `TestEmit_CapturePreservesOverlay` — capture bytes match disk bytes (overlay-supplied keys present).
  - `TestDoctor_NoFalseDriftAfterSyncWithOverlay` — `doctor` and `doctor --fix` are no-ops after a clean sync, settings.json bytes unchanged.
  - `TestImportFromClaude_OverlayPreservesKeyOrder` — imported overlay keeps statusLine before enabledPlugins and inner `type` before `command`.

Closes #215.

## Test plan

- [x] `go test ./...` — 760 pass (up from 757).
- [x] `go vet ./...` clean.
- [x] `gofmt -l .` clean.
- [x] Manual repro on the manuscript fixture confirms `doctor` reports no drift after sync and `doctor --fix` does not strip `enabledPlugins` / `statusLine`.