### PR TITLE
fix(revert): preserve unbacked files by default; add --force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+### Added
+- `revert --force`: delete adapter-emitted files that lack a `.bak`. Restores the pre-#217 default for users who relied on it. Closes #217.
+
 ### Changed
+- `revert` no longer deletes files that lack a `.bak`. Default now preserves user-authored content that happens to share a path with adapter output (helper scripts next to `SKILL.md`, propagated templates, etc.). Pass `--force` for the old delete-without-bak behavior. Closes #217.
 - `outputs.codex.shared-subagents` default is now conditional: `false` when `claude` is also enabled (avoids duplicating `.claude/skills/` under `.agents/skills/`), `true` when codex is the only target. Explicit setting still wins. Closes #216.
 
 ### Fixed

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -311,7 +311,11 @@ Each entry in `writes` and `skipped` has: `target` (string), `path` (string), `a
 ## revert
 
 Undo a previous sync. For every file an adapter would emit, restores
-`<path>.bak` if present (and removes the .bak), otherwise removes the file.
+`<path>.bak` when present (and removes the .bak). When there is no
+`.bak`, the file is left in place by default so user-authored content
+that happens to share a path with adapter output (helper scripts next
+to `SKILL.md`, templates inside a propagated skill folder, etc.) is
+not silently deleted. Pass `--force` to delete those unbacked files.
 
 ```bash
 agnostic-ai revert [flags]
@@ -323,21 +327,26 @@ agnostic-ai revert [flags]
 | `--only <list>` | Revert only these targets (comma-separated). Mutually exclusive with `--except`. Errors on unknown names. |
 | `--except <list>` | Revert all configured targets except these (comma-separated). Mutually exclusive with `--only`. Errors on unknown names. |
 | `--dry-run` | Report intended actions without touching disk |
+| `--force` | Also delete adapter-emitted files that lack a `.bak`. Use with care: removes user-authored files that share a path with adapter output. |
 | `--json` | Output as JSON instead of plain text. |
 
 ```bash
 agnostic-ai sync --backup              # 1. snapshot existing files
 # ...edits or experiments...
-agnostic-ai revert                     # 2. roll back to the snapshot
-agnostic-ai revert --only claude       # 3. roll back only claude
-agnostic-ai revert --except codex      # 4. roll back everything except codex
+agnostic-ai revert                     # 2. restore .bak files, leave unbacked alone
+agnostic-ai revert --force             # 3. also delete generated files without .bak
+agnostic-ai revert --only claude       # roll back only claude
+agnostic-ai revert --except codex      # roll back everything except codex
 agnostic-ai revert --json              # machine-readable output
 ```
 
-The `--json` output uses the same schema as `sync --json`. Actions are `"restore"` (`.bak` was applied), `"remove"` (file was deleted), or `"skip"` (file was already absent).
+The `--json` output uses the same schema as `sync --json`. Actions are
+`"restore"` (`.bak` was applied), `"remove"` (file was deleted),
+`"preserve"` (file kept because no `.bak` exists and `--force` was not
+set), or `"skip"` (file was already absent).
 
-Without a prior `--backup`, `revert` removes the generated files;
-nothing is restored.
+Without a prior `--backup`, `revert` becomes a no-op unless `--force`
+is also passed — protecting helper files from accidental deletion.
 
 ## doctor
 

--- a/internal/cli/json_output_test.go
+++ b/internal/cli/json_output_test.go
@@ -259,7 +259,7 @@ func TestRevertJSON_Shape(t *testing.T) {
 	}
 
 	root = NewRootCmd("test")
-	root.SetArgs([]string{"revert", "-t", "claude", "--json"})
+	root.SetArgs([]string{"revert", "-t", "claude", "--json", "--force"})
 	out := &bytes.Buffer{}
 	root.SetOut(out)
 	if err := root.Execute(); err != nil {

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -13,7 +13,7 @@ import (
 
 func newRevertCmd() *cobra.Command {
 	var targets, only, except []string
-	var dryRun, jsonOut bool
+	var dryRun, jsonOut, force bool
 
 	cmd := &cobra.Command{
 		Use:   "revert",
@@ -21,14 +21,19 @@ func newRevertCmd() *cobra.Command {
 		Long: "revert reverses the effect of `sync` for every target.\n" +
 			"For each file the matching adapter would emit:\n" +
 			"  - if <path>.bak exists, the .bak content is restored and the .bak removed\n" +
-			"  - otherwise the file is removed (it did not exist before sync)\n" +
-			"Pair with `sync --backup` so the .bak trail exists. Without backups,\n" +
-			"revert simply deletes the generated files.",
+			"  - otherwise the file is left in place to protect user-authored content\n" +
+			"    that happens to share a path with an adapter-emitted file (e.g. a\n" +
+			"    helper script next to SKILL.md). Pass --force to delete unbacked files.\n" +
+			"Pair with `sync --backup` so the .bak trail exists for the files you want\n" +
+			"restored to their pre-sync content.",
 		Example: `  # Preview what would be reverted
   agnostic-ai revert --dry-run
 
-  # Restore .bak files where they exist; remove generated files otherwise
+  # Restore .bak files where they exist; leave unbacked files alone
   agnostic-ai revert
+
+  # Also remove files that have no .bak (old default behavior)
+  agnostic-ai revert --force
 
   # Revert only Claude and Cursor
   agnostic-ai revert --only claude,cursor
@@ -56,7 +61,7 @@ func newRevertCmd() *cobra.Command {
 			}
 
 			if jsonOut {
-				return runRevertJSON(cmd, effective, dryRun)
+				return runRevertJSON(cmd, effective, dryRun, force)
 			}
 
 			for _, t := range effective {
@@ -75,11 +80,26 @@ func newRevertCmd() *cobra.Command {
 				}
 				files := adapters.StopCapture()
 				summaryf("← revert %s\n", t)
+				var restored, removed, preserved int
 				for _, f := range files {
-					if _, err := revertOne(f.Path, dryRun); err != nil {
+					action, err := revertOne(f.Path, dryRun, force)
+					if err != nil {
 						return fmt.Errorf("%s: %w", t, err)
 					}
+					switch action {
+					case "restore":
+						restored++
+					case "remove":
+						removed++
+					case "preserve":
+						preserved++
+					}
 				}
+				if preserved > 0 {
+					summaryf("    %d file(s) preserved (no .bak; pass --force to delete)\n", preserved)
+				}
+				_ = restored
+				_ = removed
 			}
 			return nil
 		},
@@ -89,14 +109,20 @@ func newRevertCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&except, "except", nil, "Revert all configured targets except these (comma-separated); mutually exclusive with --only")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report intended actions without touching disk")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for machine consumption")
+	cmd.Flags().BoolVar(&force, "force", false, "Also delete adapter-emitted files that lack a .bak (use with care: removes user-authored files that share a path with adapter output)")
 	registerTargetCompletion(cmd)
 	return cmd
 }
 
-// revertOne restores path from path+".bak" if the backup exists, else
-// removes path. Missing files at either location are ignored.
-// Returns the action taken: "restore", "remove", or "skip" (file absent).
-func revertOne(path string, dryRun bool) (string, error) {
+// revertOne restores path from path+".bak" when the backup exists. When
+// there is no .bak the default is to leave path alone ("preserve") so a
+// user-authored file that happens to share a path with adapter output
+// (e.g. a helper script propagated into a skill folder) is not silently
+// deleted. Pass force=true to delete unbacked files (old behavior).
+// Missing source files are reported as "skip".
+//
+// Returns the action taken: "restore", "remove", "preserve", or "skip".
+func revertOne(path string, dryRun, force bool) (string, error) {
 	bak := path + ".bak"
 	data, err := os.ReadFile(bak)
 	switch {
@@ -117,6 +143,14 @@ func revertOne(path string, dryRun bool) (string, error) {
 		return "", fmt.Errorf("read backup %s: %w", bak, err)
 	}
 
+	if !force {
+		if _, statErr := os.Stat(path); errors.Is(statErr, fs.ErrNotExist) {
+			return "skip", nil
+		}
+		verbosef("    preserve: %s (no .bak; pass --force to delete)\n", path)
+		return "preserve", nil
+	}
+
 	if dryRun {
 		verbosef("    remove:  %s\n", path)
 		return "remove", nil
@@ -132,8 +166,8 @@ func revertOne(path string, dryRun bool) (string, error) {
 }
 
 // runRevertJSON performs the revert and emits a JSON result describing each
-// file restored, removed, or skipped per target.
-func runRevertJSON(cmd *cobra.Command, targets []string, dryRun bool) error {
+// file restored, removed, preserved, or skipped per target.
+func runRevertJSON(cmd *cobra.Command, targets []string, dryRun, force bool) error {
 	cfg, b, err := loadProject(".")
 	if err != nil {
 		return err
@@ -154,13 +188,13 @@ func runRevertJSON(cmd *cobra.Command, targets []string, dryRun bool) error {
 		}
 		files := adapters.StopCapture()
 		for _, f := range files {
-			action, err := revertOne(f.Path, dryRun)
+			action, err := revertOne(f.Path, dryRun, force)
 			if err != nil {
 				out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
 				continue
 			}
 			rec := fileRecord{Target: t, Path: f.Path, Action: action, Bytes: 0}
-			if action == "skip" {
+			if action == "skip" || action == "preserve" {
 				out.Skipped = append(out.Skipped, rec)
 			} else {
 				out.Writes = append(out.Writes, rec)

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -19,7 +19,7 @@ func TestRevertOne_RestoresFromBak(t *testing.T) {
 	if err := os.WriteFile(path+".bak", []byte("original"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := revertOne(path, false); err != nil {
+	if _, err := revertOne(path, false, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(path)
@@ -34,7 +34,36 @@ func TestRevertOne_RestoresFromBak(t *testing.T) {
 	}
 }
 
-func TestRevertOne_RemovesWhenNoBak(t *testing.T) {
+// TestRevertOne_PreservesWhenNoBak regresses #217. The pre-#217 default
+// removed any adapter-emitted file lacking a .bak, which also wiped
+// user-authored helpers (check.mjs, *.template) that share a path with
+// adapter output. The new default preserves those files; pass --force
+// to opt back into delete-without-bak.
+func TestRevertOne_PreservesWhenNoBak(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	path := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(path, []byte("user-authored"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	action, err := revertOne(path, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action != "preserve" {
+		t.Errorf("expected preserve, got %q", action)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file was removed despite no --force: %v", err)
+	}
+	if string(got) != "user-authored" {
+		t.Errorf("file content changed: %q", got)
+	}
+}
+
+func TestRevertOne_ForceRemovesWhenNoBak(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)
 
@@ -42,11 +71,15 @@ func TestRevertOne_RemovesWhenNoBak(t *testing.T) {
 	if err := os.WriteFile(path, []byte("generated"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := revertOne(path, false); err != nil {
+	action, err := revertOne(path, false, true)
+	if err != nil {
 		t.Fatal(err)
 	}
+	if action != "remove" {
+		t.Errorf("expected remove, got %q", action)
+	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Errorf("expected file removed, got err=%v", err)
+		t.Errorf("expected file removed under --force, got err=%v", err)
 	}
 }
 
@@ -58,7 +91,7 @@ func TestRevertOne_DryRunNoSideEffects(t *testing.T) {
 	if err := os.WriteFile(path, []byte("generated"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := revertOne(path, true); err != nil {
+	if _, err := revertOne(path, true, true); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(path); err != nil {
@@ -70,12 +103,12 @@ func TestRevertOne_MissingFileIsNoop(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)
 
-	if _, err := revertOne(filepath.Join(dir, "ghost.md"), false); err != nil {
+	if _, err := revertOne(filepath.Join(dir, "ghost.md"), false, false); err != nil {
 		t.Errorf("unexpected error reverting missing file: %v", err)
 	}
 }
 
-func TestRevertCmd_RemovesGeneratedRules(t *testing.T) {
+func TestRevertCmd_ForceRemovesGeneratedRules(t *testing.T) {
 	dir := setupFixture(t)
 	testutil.Chdir(t, dir)
 	silence(t)
@@ -97,12 +130,55 @@ func TestRevertCmd_RemovesGeneratedRules(t *testing.T) {
 	}
 
 	root = NewRootCmd("test")
-	root.SetArgs([]string{"revert", "-t", "claude"})
+	root.SetArgs([]string{"revert", "-t", "claude", "--force"})
 	if err := root.Execute(); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(rulePath); !os.IsNotExist(err) {
-		t.Errorf("expected claude rule removed after revert, err=%v", err)
+		t.Errorf("expected claude rule removed after revert --force, err=%v", err)
+	}
+}
+
+// TestRevertCmd_PreservesUserAuthoredHelpers regresses #217. A helper
+// file that lives in a skill folder alongside SKILL.md (e.g. check.mjs)
+// gets propagated to the emit dir by sync and therefore appears in the
+// capture list at revert time. Without a .bak, the old default
+// silently deleted those files. The new default leaves them in place.
+func TestRevertCmd_PreservesUserAuthoredHelpers(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	skillSrc := filepath.Join(dir, "skills", "i18n-parity")
+	if err := os.MkdirAll(skillSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillSrc, "SKILL.md"),
+		[]byte("---\nname: i18n-parity\ndescription: parity\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillSrc, "check.mjs"),
+		[]byte("// user helper\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	emitted := filepath.Join(dir, ".claude/skills/i18n-parity/check.mjs")
+	if _, err := os.Stat(emitted); err != nil {
+		t.Fatalf("sync did not propagate helper: %v", err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"revert", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(emitted); err != nil {
+		t.Errorf("revert deleted user-authored helper without --force: %v", err)
 	}
 }
 

--- a/internal/cli/sync_filter_test.go
+++ b/internal/cli/sync_filter_test.go
@@ -119,15 +119,16 @@ func TestRevert_Only_RevertsSubset(t *testing.T) {
 		t.Fatalf("expected claude rule after sync: %v", err)
 	}
 
-	// revert only claude
+	// revert only claude (with --force so adapter-emitted rules without
+	// .bak are deleted; without --force the new default preserves them)
 	root = NewRootCmd("test")
-	root.SetArgs([]string{"revert", "--only", "claude"})
+	root.SetArgs([]string{"revert", "--only", "claude", "--force"})
 	if err := root.Execute(); err != nil {
 		t.Fatal(err)
 	}
 
 	if _, err := os.Stat(claudeRule); !os.IsNotExist(err) {
-		t.Errorf("expected claude rule removed after revert --only claude, err=%v", err)
+		t.Errorf("expected claude rule removed after revert --only claude --force, err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`revert` used to delete any adapter-emitted file that lacked a `.bak`, which wiped user-authored helpers (`check.mjs`, `*.template`) that share a path with adapter output (propagated into the emit dir alongside `SKILL.md`).

- Default `revert` now **preserves** unbacked files (action `"preserve"`).
- `revert --force` keeps the old delete-without-bak behavior.
- Regression test `TestRevertCmd_PreservesUserAuthoredHelpers` covers a helper file living inside a skill folder.
- Docs updated (`docs/user/cli-reference.md`), CHANGELOG note under both Added (`--force`) and Changed (default policy).

Closes #217.

## Test plan

- [x] `go test ./...` — 765 pass.
- [x] `go vet ./...` clean.
- [x] Existing JSON shape test now exercises `revert --force` (the original delete behavior).
- [x] `revert --only`, `revert --except`, `revert --dry-run`, `revert --json` paths all updated.