### PR TITLE
fix(emit): preserve quotes and avoid line-wrap in frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Fixed
 - `doctor` and `doctor --fix` now read the settings overlay in capture mode just like a real sync. Previously a clean sync would be flagged as drift and `--fix` would silently delete overlay-supplied keys (`enabledPlugins`, `statusLine`) from `.claude/settings.json`. Import overlay capture also keeps source key order via `OrderedJSON`. Closes #215.
+- Frontmatter emit no longer strips quotes from scalars containing angle brackets and no longer line-wraps long descriptions at 80 cols. Plain scalars are promoted to double-quoted when they contain `<`/`>` or exceed the wrap threshold, keeping byte-stable round-trip with hand-authored CLI configs. Closes #218.
 
 ### Removed
 

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -463,21 +463,58 @@ func orderedMetaKeys(meta map[string]any, hint []string) []string {
 	return append(out, rest...)
 }
 
-// preferDoubleQuotes walks a yaml.Node tree and promotes single-quoted
-// scalars to double-quoted. yaml.v3's default style for a scalar that
-// needs quoting (e.g. one starting with `[`) is single quotes; CLI
-// configs typically author them as double quotes, so the round-trip
-// diff stays clean.
+// preferDoubleQuotes walks a yaml.Node tree and normalises scalar style
+// for round-trip stability with hand-authored CLI configs:
+//
+//   - Single-quoted scalars are promoted to double-quoted (yaml.v3
+//     defaults to single quotes when a scalar must be quoted, e.g.
+//     starts with `[`; CLI authors typically use double quotes).
+//   - Plain scalars whose value contains angle brackets are promoted
+//     to double-quoted. Authors commonly wrap things like
+//     `<feature-or-problem-statement>` in quotes for readability;
+//     yaml.v3 would otherwise emit them as bare plain scalars and
+//     break the byte-for-byte round trip. (Closes part of #218.)
+//   - Plain scalars longer than wrapWidthThreshold are promoted to
+//     double-quoted so the encoder does not line-wrap them at the
+//     default 80-col limit. Quoted-style scalars bypass auto-wrap in
+//     yaml.v3 even though there is no public SetWidth knob. (Closes
+//     part of #218.)
 func preferDoubleQuotes(n *yaml.Node) {
 	if n == nil {
 		return
 	}
-	if n.Kind == yaml.ScalarNode && n.Style == yaml.SingleQuotedStyle {
-		n.Style = yaml.DoubleQuotedStyle
+	if n.Kind == yaml.ScalarNode {
+		switch {
+		case n.Style == yaml.SingleQuotedStyle:
+			n.Style = yaml.DoubleQuotedStyle
+		case n.Style == 0:
+			// Plain style is the zero value in yaml.v3.
+			if needsDoubleQuotePromotion(n.Value) {
+				n.Style = yaml.DoubleQuotedStyle
+			}
+		}
 	}
 	for _, c := range n.Content {
 		preferDoubleQuotes(c)
 	}
+}
+
+// wrapWidthThreshold is the length at which we promote a plain scalar
+// to a double-quoted scalar so yaml.v3 does not line-wrap it. Held
+// well below the encoder's 80-col default to account for the leading
+// `key: ` and the surrounding indent of nested mappings.
+const wrapWidthThreshold = 60
+
+// needsDoubleQuotePromotion reports whether a plain scalar value should
+// be re-emitted as double-quoted to keep the round trip byte-stable.
+// Triggers on angle brackets (commonly hand-quoted in CLI configs) and
+// on values long enough that yaml.v3 would otherwise insert a line
+// wrap.
+func needsDoubleQuotePromotion(s string) bool {
+	if len(s) > wrapWidthThreshold {
+		return true
+	}
+	return strings.ContainsAny(s, "<>")
 }
 
 // Warner accepts capability warnings. Defaults to writing to os.Stderr.

--- a/internal/adapters/internal/emit/emit_test.go
+++ b/internal/adapters/internal/emit/emit_test.go
@@ -139,6 +139,40 @@ func TestFrontmatterOrdered_PromotesSingleToDoubleQuotes(t *testing.T) {
 	}
 }
 
+// TestFrontmatterOrdered_QuotesScalarsWithAngleBrackets regresses
+// DEFECT 5 of #218. yaml.v3 would otherwise emit a hand-quoted
+// "<feature-or-problem-statement>" as a bare plain scalar, breaking
+// byte-stable round-trip with source files that wrap such values in
+// quotes for readability.
+func TestFrontmatterOrdered_QuotesScalarsWithAngleBrackets(t *testing.T) {
+	got := FrontmatterOrdered(
+		map[string]any{"argument-hint": "<feature-or-problem-statement>"},
+		[]string{"argument-hint"},
+	)
+	if !strings.Contains(got, `"<feature-or-problem-statement>"`) {
+		t.Errorf("expected angle-bracket scalar wrapped in double quotes, got:\n%s", got)
+	}
+}
+
+// TestFrontmatterOrdered_DoesNotWrapLongDescriptions regresses
+// DEFECT 6 of #218. yaml.v3's encoder wraps plain scalars at 80
+// columns; promoting long values to double-quoted style suppresses the
+// wrap so a single-line description: stays on one line round-trip.
+func TestFrontmatterOrdered_DoesNotWrapLongDescriptions(t *testing.T) {
+	long := "Execute the implementation planning workflow using the plan template to generate design artifacts."
+	got := FrontmatterOrdered(
+		map[string]any{"description": long},
+		[]string{"description"},
+	)
+	// One single line per key, no continuation indent.
+	if strings.Contains(got, "\n  to generate") {
+		t.Errorf("description line-wrapped (yaml continuation indent leaked):\n%s", got)
+	}
+	if !strings.Contains(got, `"`+long+`"`) {
+		t.Errorf("expected long description wrapped in double quotes, got:\n%s", got)
+	}
+}
+
 func TestFrontmatterOrdered_UnhintedKeysAppendAlphabetically(t *testing.T) {
 	meta := map[string]any{"zeta": 1, "alpha": 2, "name": "foo"}
 	got := FrontmatterOrdered(meta, []string{"name"})


### PR DESCRIPTION
## Summary

Frontmatter emit was breaking byte-stable round-trip on two yaml.v3 defaults:

1. `argument-hint: "<feature-or-problem-statement>"` → emitted as bare plain scalar (quotes dropped).
2. `description: <100+ chars on one line>` → wrapped at 80 cols with continuation indent.

Promote plain scalars to `DoubleQuotedStyle` in `preferDoubleQuotes` when:

- value contains `<` or `>` (commonly hand-quoted in CLI configs), or
- value length > 60 (would otherwise trigger yaml.v3's auto-wrap; yaml.v3 has no public SetWidth knob, but double-quoted scalars bypass wrap entirely).

Two regression tests cover each defect.

Closes #218.

## Test plan

- [x] `go test ./...` — 767 pass (up from 765).
- [x] `go vet ./...` clean.
- [x] `gofmt -l .` clean.
- [x] Existing goldens still pass — fixtures don't contain `<...>` or long descriptions, so no regen needed.