### PR TITLE
fix(cleanup): default to .bak removal without --backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - `revert --force`: delete adapter-emitted files that lack a `.bak`. Restores the pre-#217 default for users who relied on it. Closes #217.
 
 ### Changed
+- `cleanup` no longer requires `--backups`. Bare `cleanup` now runs the .bak removal that used to need an explicit flag. `--backups` stays as an explicit alias for scripts. Closes #219.
 - `revert` no longer deletes files that lack a `.bak`. Default now preserves user-authored content that happens to share a path with adapter output (helper scripts next to `SKILL.md`, propagated templates, etc.). Pass `--force` for the old delete-without-bak behavior. Closes #217.
 - `outputs.codex.shared-subagents` default is now conditional: `false` when `claude` is also enabled (avoids duplicating `.claude/skills/` under `.agents/skills/`), `true` when codex is the only target. Explicit setting still wins. Closes #216.
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -111,7 +111,7 @@ CLIs, run each `import` + commit pair before the final `sync`.
 
 Tip: `agnostic-ai sync --backup` keeps a `.bak` next to each
 overwritten file so you can `revert` if the regeneration looks wrong.
-Clear them once you are happy with `agnostic-ai cleanup --backups`.
+Clear them once you are happy with `agnostic-ai cleanup`.
 
 #### What `import` does NOT capture
 

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -10,11 +10,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newCleanupCmd builds `agnostic-ai cleanup`, currently scoped to
-// removing the `.bak` files `sync --backup` leaves on disk. Reserved
-// for future cleanup modes (orphan generated files, stale sync-state,
-// etc.); pass `--backups` explicitly so a future invocation without
-// flags can either bundle every mode or stay a no-op.
+// newCleanupCmd builds `agnostic-ai cleanup`. With no flags it removes
+// `.bak` files left by `sync --backup` (currently the only cleanup
+// mode). `--backups` stays as an explicit opt-in for scripts that want
+// the legacy flag form; it has no effect on behavior today. When more
+// cleanup modes ship in the future, a bare `cleanup` may opt into
+// running every mode while the explicit `--backups` flag continues to
+// scope cleanup to .bak removal.
 func newCleanupCmd() *cobra.Command {
 	var (
 		backups bool
@@ -25,24 +27,25 @@ func newCleanupCmd() *cobra.Command {
 		Short: "Remove agnostic-ai-generated leftovers (currently: .bak files).",
 		Long: `cleanup removes housekeeping leftovers from previous agnostic-ai runs.
 
-Today only --backups is supported. It walks the project root, finds every
-file ending in '.bak' (the form ` + "`sync --backup`" + ` writes), and removes
-them. ` + "`.git/`" + ` and ` + "`.agnostic-ai/`" + ` are skipped.
+Today only .bak cleanup is supported. It walks the project root, finds
+every file ending in '.bak' (the form ` + "`sync --backup`" + ` writes), and
+removes them. ` + "`.git/`" + ` and ` + "`.agnostic-ai/`" + ` are skipped.
 
 Pair with --dry-run to preview the deletions without touching disk.`,
 		Example: `  # Preview which .bak files would be removed
-  agnostic-ai cleanup --backups --dry-run
+  agnostic-ai cleanup --dry-run
 
-  # Remove every .bak under the project root
+  # Remove every .bak under the project root (no flag needed)
+  agnostic-ai cleanup
+
+  # Explicit form for scripts that prefer to spell the mode out
   agnostic-ai cleanup --backups`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !backups {
-				return fmt.Errorf("nothing to do: pass --backups (other modes not yet implemented)")
-			}
+			_ = backups
 			return runCleanupBackups(".", dryRun)
 		},
 	}
-	cmd.Flags().BoolVar(&backups, "backups", false, "Remove *.bak files left by `sync --backup`")
+	cmd.Flags().BoolVar(&backups, "backups", false, "Explicit form of the default cleanup mode (.bak removal). Kept for scripts; bare `cleanup` does the same thing today.")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report intended deletions without touching disk")
 	return cmd
 }

--- a/internal/cli/cleanup_test.go
+++ b/internal/cli/cleanup_test.go
@@ -54,6 +54,30 @@ func TestRunCleanupBackups_DryRunListsButDoesNotDelete(t *testing.T) {
 	}
 }
 
+// TestCleanupCmd_BareInvocationRemovesBakFiles regresses #219.
+// Pre-#219, `agnostic-ai cleanup` errored out with "nothing to do:
+// pass --backups". Since --backups is the only mode, bare cleanup
+// should just do the default thing.
+func TestCleanupCmd_BareInvocationRemovesBakFiles(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	path := filepath.Join(dir, "CLAUDE.md.bak")
+	if err := os.WriteFile(path, []byte("backup"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"cleanup"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("bare cleanup should succeed, got: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected .bak removed by bare cleanup, err=%v", err)
+	}
+}
+
 func TestRunCleanupBackups_SkipsGitAndAgnosticDirs(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)


### PR DESCRIPTION
## Summary

`agnostic-ai cleanup` used to refuse to run without `--backups`. Since that is the only cleanup mode, the friction has no upside. Bare `cleanup` now does the default thing; `--backups` stays as an explicit alias.

- `internal/cli/cleanup.go`: drop the early-return; refresh docstring + examples.
- `TestCleanupCmd_BareInvocationRemovesBakFiles` covers the new default.
- `docs/user/getting-started.md`: drop the `--backups` from the tip.

Closes #219.

## Test plan

- [x] `go test ./...` — 768 pass.
- [x] `go vet ./...` clean.
- [x] Manual: bare `agnostic-ai cleanup` removes `.bak` files; `--backups` still works.