### PR TITLE
fix(emit): preserve plain description scalars on round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Fixed
+- Frontmatter emit no longer force-quotes plain `description:` scalars. yaml.v3 does not auto-wrap plain scalars, so long descriptions round-trip on one line without added quotes. Closes #226.
+
 ## v0.19.0 - 2026-05-16
 
 ### Added

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -474,11 +474,12 @@ func orderedMetaKeys(meta map[string]any, hint []string) []string {
 //     `<feature-or-problem-statement>` in quotes for readability;
 //     yaml.v3 would otherwise emit them as bare plain scalars and
 //     break the byte-for-byte round trip. (Closes part of #218.)
-//   - Plain scalars longer than wrapWidthThreshold are promoted to
-//     double-quoted so the encoder does not line-wrap them at the
-//     default 80-col limit. Quoted-style scalars bypass auto-wrap in
-//     yaml.v3 even though there is no public SetWidth knob. (Closes
-//     part of #218.)
+//
+// Plain scalars otherwise stay plain. yaml.v3 does not auto-wrap plain
+// scalars at any column width, so long descriptions emit on one line
+// without quotes. Forcing them to double-quoted broke round-trip with
+// hand-authored sources that use plain scalars for `description:`
+// (#226).
 func preferDoubleQuotes(n *yaml.Node) {
 	if n == nil {
 		return
@@ -489,7 +490,7 @@ func preferDoubleQuotes(n *yaml.Node) {
 			n.Style = yaml.DoubleQuotedStyle
 		case 0:
 			// Plain style is the zero value in yaml.v3.
-			if needsDoubleQuotePromotion(n.Value) {
+			if strings.ContainsAny(n.Value, "<>") {
 				n.Style = yaml.DoubleQuotedStyle
 			}
 		}
@@ -497,24 +498,6 @@ func preferDoubleQuotes(n *yaml.Node) {
 	for _, c := range n.Content {
 		preferDoubleQuotes(c)
 	}
-}
-
-// wrapWidthThreshold is the length at which we promote a plain scalar
-// to a double-quoted scalar so yaml.v3 does not line-wrap it. Held
-// well below the encoder's 80-col default to account for the leading
-// `key: ` and the surrounding indent of nested mappings.
-const wrapWidthThreshold = 60
-
-// needsDoubleQuotePromotion reports whether a plain scalar value should
-// be re-emitted as double-quoted to keep the round trip byte-stable.
-// Triggers on angle brackets (commonly hand-quoted in CLI configs) and
-// on values long enough that yaml.v3 would otherwise insert a line
-// wrap.
-func needsDoubleQuotePromotion(s string) bool {
-	if len(s) > wrapWidthThreshold {
-		return true
-	}
-	return strings.ContainsAny(s, "<>")
 }
 
 // Warner accepts capability warnings. Defaults to writing to os.Stderr.

--- a/internal/adapters/internal/emit/emit_test.go
+++ b/internal/adapters/internal/emit/emit_test.go
@@ -154,22 +154,37 @@ func TestFrontmatterOrdered_QuotesScalarsWithAngleBrackets(t *testing.T) {
 	}
 }
 
-// TestFrontmatterOrdered_DoesNotWrapLongDescriptions regresses
-// DEFECT 6 of #218. yaml.v3's encoder wraps plain scalars at 80
-// columns; promoting long values to double-quoted style suppresses the
-// wrap so a single-line description: stays on one line round-trip.
-func TestFrontmatterOrdered_DoesNotWrapLongDescriptions(t *testing.T) {
+// TestFrontmatterOrdered_PreservesPlainScalar regresses #226. A short
+// hand-authored plain scalar must round-trip unchanged through the
+// emitter (no double quotes, no folding).
+func TestFrontmatterOrdered_PreservesPlainScalar(t *testing.T) {
+	got := FrontmatterOrdered(
+		map[string]any{"description": "Review code changes for quality."},
+		[]string{"description"},
+	)
+	if !strings.Contains(got, "description: Review code changes for quality.\n") {
+		t.Errorf("expected plain scalar preserved, got:\n%s", got)
+	}
+	if strings.Contains(got, `description: "`) {
+		t.Errorf("plain scalar was force-quoted, got:\n%s", got)
+	}
+}
+
+// TestFrontmatterOrdered_PreservesLongPlainDescriptions regresses #226.
+// Long plain scalars stay plain on round-trip: yaml.v3 v3.0.1 does not
+// auto-wrap plain scalars, so promoting them to double-quoted would
+// only add noise to byte-stable diffs after `import -> sync`.
+func TestFrontmatterOrdered_PreservesLongPlainDescriptions(t *testing.T) {
 	long := "Execute the implementation planning workflow using the plan template to generate design artifacts."
 	got := FrontmatterOrdered(
 		map[string]any{"description": long},
 		[]string{"description"},
 	)
-	// One single line per key, no continuation indent.
-	if strings.Contains(got, "\n  to generate") {
-		t.Errorf("description line-wrapped (yaml continuation indent leaked):\n%s", got)
+	if strings.Contains(got, `"`+long+`"`) {
+		t.Errorf("long plain description was force-quoted, want plain:\n%s", got)
 	}
-	if !strings.Contains(got, `"`+long+`"`) {
-		t.Errorf("expected long description wrapped in double quotes, got:\n%s", got)
+	if !strings.Contains(got, "description: "+long+"\n") {
+		t.Errorf("expected plain `description: <long>` on one line, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Drop length-based promotion of plain scalars to double-quoted in `internal/adapters/internal/emit/emit.go`.
- yaml.v3 v3.0.1 does not auto-wrap plain scalars; the #218 workaround was adding noise (every long plain `description:` round-tripped to a quoted form).
- Angle-bracket promotion and single→double promotion kept.

## Acceptance
- `git diff HEAD -- .claude/skills .claude/commands | grep -c '^+description: "'` on the manuscript fixture drops to 0.
- Existing #218 tests for angle brackets and single→double still pass.
- New `TestFrontmatterOrdered_PreservesPlainScalar` and `TestFrontmatterOrdered_PreservesLongPlainDescriptions` lock in the new contract.

## Out of scope
- Multi-line/folded source style preservation. Without plumbing a `*yaml.Node` through `spec.Entry` and adapters, source `>-` collapses to a single plain line. The acceptance gate from #226 still hits 0 (no added quotes).

Closes #226.

## Test plan
- [x] `go test ./... -count=1` — 770 pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean