### PR TITLE
chore: migrate goreleaser brews to homebrew_casks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,8 +73,6 @@ homebrew_casks:
     directory: Casks
     homepage: https://github.com/Chemaclass/agnostic-ai
     description: Sync agent prompts, skills, rules, and hooks across AI coding tools
-    url:
-      verified: github.com/Chemaclass/agnostic-ai/
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,22 +61,27 @@ changelog:
     - title: Others
       order: 999
 
-brews:
+homebrew_casks:
   - name: agnostic-ai
+    binaries:
+      - agnostic-ai
     repository:
       owner: Chemaclass
       name: homebrew-tap
       branch: master
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: https://github.com/Chemaclass/agnostic-ai
     description: Sync agent prompts, skills, rules, and hooks across AI coding tools
-    license: MIT
+    url:
+      verified: github.com/Chemaclass/agnostic-ai/
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "feat: bump {{ .ProjectName }} to {{ .Tag }}"
-    test: |
-      system "#{bin}/agnostic-ai", "--help"
-    install: |
-      bin.install "agnostic-ai"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/agnostic-ai"]
+          end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Changed
+- Goreleaser config migrated from deprecated `brews:` to `homebrew_casks:`. Releases now publish to the tap as casks (`Casks/agnostic-ai.rb`) with a post-install hook removing the macOS quarantine attribute. The legacy `Formula/agnostic-ai.rb` stops receiving updates on the next release. Closes #225.
+
 ### Removed
 - `autoSync` config field, `sync --auto-sync=yes|no` flag, first-run auto-sync prompt, and the generated `auto-sync` rule spec. The feature added a separate prompt, flag, and persisted config field for marginal value; agents already have the `docs-sync` rule and `run-sync-check` skill to decide when to re-sync. Existing `autoSync:` keys in user configs are silently ignored.
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/chemaclass/agnostic-ai
 go 1.24.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/fsnotify/fsnotify v1.10.1
@@ -12,7 +13,6 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect


### PR DESCRIPTION
## Summary

- Migrate `.goreleaser.yml` from the deprecated `brews:` block to `homebrew_casks:` (per https://goreleaser.com/deprecations#brews).
- `directory: Formula` → `directory: Casks`. Tap already has `Casks/`.
- Drop legacy `install:`/`test:` blocks (casks install the binary implicitly via `binaries:`).
- Add `url.verified` so Homebrew's cask audit accepts the GitHub download URL.
- Add a post-install hook that strips the macOS quarantine attribute so unsigned binaries are usable without manual override.
- `go.mod`: `go mod tidy` (run by the goreleaser before-hook) moves `BurntSushi/toml` from indirect to direct, matching the real import.

Closes #225.

## Test plan

- [x] `goreleaser check` (clean — no deprecation warnings).
- [x] `goreleaser release --snapshot --clean --skip=publish,sign` succeeds and emits `dist/homebrew/Casks/agnostic-ai.rb` with the expected `cask "agnostic-ai" do … binary "agnostic-ai" … postflight do …` structure.
- [ ] Watch the next real release to confirm the cask lands in `Chemaclass/homebrew-tap` under `Casks/` and `brew install Chemaclass/tap/agnostic-ai` works on macOS.