### PR TITLE
feat(cli): add upgrade command with install-method detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- `agnostic-ai upgrade` command: detects how the running binary was installed (Homebrew, `go install`, raw binary) and prints (or, with `--run`, execs) the matching upgrade command. `--check` mode reports detection details and warns about other `agnostic-ai` binaries on `PATH` shadowing the resolved executable, the common cause of "I already upgraded but `--version` still shows the old release". Best-effort GitHub API check pins down the latest published tag so the report can tell you you are already current.
+- README + `docs/user/cli-reference.md`: documented the new command and the install-method detection rules.
 - README: document `brew upgrade Chemaclass/tap/agnostic-ai` for upgrading existing installs.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ brew upgrade Chemaclass/tap/agnostic-ai                              # upgrade l
 go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest  # Go
 ```
 
-Or grab a prebuilt binary from the [latest release](https://github.com/Chemaclass/agnostic-ai/releases/latest).
+Or grab a prebuilt binary from the [releases page](https://github.com/Chemaclass/agnostic-ai/releases).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest  # Go
 
 Or grab a prebuilt binary from the [releases page](https://github.com/Chemaclass/agnostic-ai/releases).
 
+Already installed? `agnostic-ai upgrade` detects how the binary was installed (Homebrew, `go install`, raw binary) and prints the matching upgrade command. Add `--run` to exec it, `--check` to diagnose `PATH` shadowing when an older copy of the binary keeps winning lookup.
+
 ## Quickstart
 
 ```bash

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -444,6 +444,24 @@ After installing, restart your shell (or `source` the completion file). Tab-comp
 
 Run `agnostic-ai completion <shell> --help` for shell-specific setup instructions.
 
+## upgrade
+
+Detect how the running binary was installed and report (or run) the matching upgrade command. Does not self-replace the binary: package managers stay in charge of installed versions.
+
+```bash
+agnostic-ai upgrade           # print the upgrade command for the current install
+agnostic-ai upgrade --check   # diagnose install location + PATH shadowing, exit
+agnostic-ai upgrade --run     # exec the detected upgrade command
+```
+
+Detection:
+
+- `*/Cellar/*`, `*/Caskroom/*`, `/opt/homebrew/*`, `/home/linuxbrew/.linuxbrew/*` → `brew update && brew upgrade Chemaclass/tap/agnostic-ai`
+- `$GOBIN` or `$GOPATH/bin` (defaults to `$HOME/go/bin`) → `go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest`
+- Anything else → manual download from the [releases page](https://github.com/Chemaclass/agnostic-ai/releases).
+
+If another `agnostic-ai` binary on `PATH` shadows the resolved executable, `upgrade` lists each shadow so you can remove the stale copy. Common cause: a Homebrew install behind an older `~/go/bin/agnostic-ai` or `/usr/local/bin/agnostic-ai`, where `brew upgrade` correctly reports the brew copy is current but `agnostic-ai --version` keeps resolving to the older binary.
+
 ## help
 
 ```bash

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,6 +78,7 @@ func NewRootCmd(version string) *cobra.Command {
 		newWhyCmd(),
 		newGraphCmd(),
 		newLSPCmd(),
+		newUpgradeCmd(),
 	)
 	root.InitDefaultCompletionCmd()
 	return root

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// installMethod identifies how the running agnostic-ai binary was
+// installed. The detector inspects os.Executable() and matches against
+// well-known path prefixes per platform.
+type installMethod int
+
+const (
+	installUnknown installMethod = iota
+	installHomebrew
+	installGoInstall
+	installBinary
+)
+
+func (m installMethod) String() string {
+	switch m {
+	case installHomebrew:
+		return "homebrew"
+	case installGoInstall:
+		return "go install"
+	case installBinary:
+		return "binary"
+	}
+	return "unknown"
+}
+
+// upgradeInfo summarizes what `upgrade` knows about the current install.
+// Path is the resolved executable path; Method is the detected install
+// channel; Command is the shell command that would refresh the binary;
+// Shadows lists any other agnostic-ai binaries on PATH that would beat
+// the current one (or be beaten by it), so the user can spot a stale
+// shadow before running the upgrade.
+type upgradeInfo struct {
+	Path    string
+	Method  installMethod
+	Version string
+	Latest  string
+	Command string
+	Shadows []string
+	Notes   []string
+}
+
+func newUpgradeCmd() *cobra.Command {
+	var (
+		run       bool
+		checkOnly bool
+	)
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Report (or run) the right command to upgrade agnostic-ai.",
+		Long: `upgrade detects how the running agnostic-ai binary was installed
+(Homebrew, ` + "`go install`" + `, or a raw prebuilt binary) and prints the
+matching upgrade command. It does not replace its own binary; package
+managers are still the source of truth for installed versions.
+
+Pass --run to exec the detected command. Pass --check to print the
+detection result and exit without running anything. Both flags are
+no-ops when the install method is unknown.`,
+		Example: `  # Show the upgrade command for the current install
+  agnostic-ai upgrade
+
+  # Run the upgrade command directly
+  agnostic-ai upgrade --run
+
+  # Diagnose install location + PATH shadowing
+  agnostic-ai upgrade --check`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runUpgrade(cmd.OutOrStdout(), run, checkOnly, cmd.Root().Version)
+		},
+	}
+	cmd.Flags().BoolVar(&run, "run", false, "Execute the detected upgrade command")
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Print detection details and exit without running")
+	return cmd
+}
+
+func runUpgrade(out io.Writer, doRun, checkOnly bool, currentVersion string) error {
+	info, err := detectUpgrade(currentVersion)
+	if err != nil {
+		return err
+	}
+	printUpgradeInfo(out, info)
+	if checkOnly {
+		return nil
+	}
+	if info.Latest != "" && info.Version != "" && versionsEqual(info.Version, info.Latest) {
+		fmt.Fprintf(out, "\nAlready on latest (%s). Nothing to do.\n", info.Latest)
+		return nil
+	}
+	if !doRun {
+		if info.Command != "" {
+			fmt.Fprintf(out, "\nRun: %s\n", info.Command)
+			fmt.Fprintf(out, "Or re-run with --run to execute.\n")
+		}
+		return nil
+	}
+	if info.Command == "" {
+		return fmt.Errorf("upgrade: install method unknown; download a release from https://github.com/Chemaclass/agnostic-ai/releases")
+	}
+	fmt.Fprintf(out, "\n→ %s\n", info.Command)
+	return execShell(info.Command)
+}
+
+func detectUpgrade(currentVersion string) (upgradeInfo, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return upgradeInfo{}, fmt.Errorf("locate executable: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err == nil {
+		exe = resolved
+	}
+	info := upgradeInfo{
+		Path:    exe,
+		Method:  detectInstallMethod(exe),
+		Version: strings.TrimSpace(currentVersion),
+	}
+	info.Command = upgradeCommandFor(info.Method)
+	info.Shadows = otherInstancesOnPATH(exe)
+	if latest, err := fetchLatestRelease(2 * time.Second); err == nil {
+		info.Latest = latest
+	}
+	if info.Method == installUnknown {
+		info.Notes = append(info.Notes,
+			"install location does not match Homebrew, $GOPATH/bin, or common binary dirs;",
+			"download a release tarball: https://github.com/Chemaclass/agnostic-ai/releases")
+	}
+	if len(info.Shadows) > 0 {
+		info.Notes = append(info.Notes,
+			"another agnostic-ai is on PATH. The shadowing binary may be an older",
+			"install (e.g. go install + brew, or a stale /usr/local/bin copy). Remove it",
+			"so `agnostic-ai --version` resolves to the upgraded binary.")
+	}
+	return info, nil
+}
+
+// detectInstallMethod classifies an executable path. Homebrew layouts
+// vary by platform: macOS Apple silicon under /opt/homebrew, Intel
+// under /usr/local/Cellar, Linuxbrew under /home/linuxbrew/.linuxbrew.
+// Casks land under Caskroom on macOS. Go installs land under $GOBIN
+// (when set) or $GOPATH/bin (default $HOME/go/bin). Anything else is
+// treated as a raw binary install.
+func detectInstallMethod(exe string) installMethod {
+	p := filepath.ToSlash(exe)
+	for _, marker := range []string{
+		"/Cellar/", "/Caskroom/", "/opt/homebrew/", "/linuxbrew/", "/homebrew/",
+	} {
+		if strings.Contains(p, marker) {
+			return installHomebrew
+		}
+	}
+	if gobin := os.Getenv("GOBIN"); gobin != "" {
+		if sameDir(filepath.Dir(exe), gobin) {
+			return installGoInstall
+		}
+	}
+	if gopath := os.Getenv("GOPATH"); gopath != "" {
+		if sameDir(filepath.Dir(exe), filepath.Join(gopath, "bin")) {
+			return installGoInstall
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if sameDir(filepath.Dir(exe), filepath.Join(home, "go", "bin")) {
+			return installGoInstall
+		}
+	}
+	if exe != "" {
+		return installBinary
+	}
+	return installUnknown
+}
+
+func upgradeCommandFor(m installMethod) string {
+	switch m {
+	case installHomebrew:
+		return "brew update && brew upgrade Chemaclass/tap/agnostic-ai"
+	case installGoInstall:
+		return "go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest"
+	case installBinary:
+		return ""
+	}
+	return ""
+}
+
+// otherInstancesOnPATH returns absolute paths of every agnostic-ai
+// binary on PATH that is not the running one. A non-empty result hints
+// at a shadowing problem: PATH lookup may pick an older copy even after
+// the brew install is up-to-date. Paths are resolved through symlinks
+// so a symlink + its target collapse to one entry.
+func otherInstancesOnPATH(self string) []string {
+	binName := "agnostic-ai"
+	if runtime.GOOS == "windows" {
+		binName = "agnostic-ai.exe"
+	}
+	selfResolved, _ := filepath.EvalSymlinks(self)
+	if selfResolved == "" {
+		selfResolved = self
+	}
+	seen := map[string]bool{selfResolved: true}
+	var out []string
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, binName)
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			resolved = candidate
+		}
+		if seen[resolved] {
+			continue
+		}
+		seen[resolved] = true
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func sameDir(a, b string) bool {
+	ap, err := filepath.Abs(a)
+	if err != nil {
+		return false
+	}
+	bp, err := filepath.Abs(b)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(ap) == filepath.Clean(bp)
+}
+
+// fetchLatestRelease queries the GitHub releases API for the tag of the
+// latest published release. Best-effort: a network failure returns an
+// error and the caller proceeds without a "Latest" hint.
+func fetchLatestRelease(timeout time.Duration) (string, error) {
+	client := &http.Client{Timeout: timeout}
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/Chemaclass/agnostic-ai/releases/latest", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases api: %s", resp.Status)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(strings.TrimSpace(body.TagName), "v"), nil
+}
+
+func versionsEqual(a, b string) bool {
+	return strings.TrimPrefix(strings.TrimSpace(a), "v") == strings.TrimPrefix(strings.TrimSpace(b), "v")
+}
+
+func execShell(command string) error {
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+func printUpgradeInfo(out io.Writer, info upgradeInfo) {
+	fmt.Fprintf(out, "Install method: %s\n", info.Method)
+	fmt.Fprintf(out, "Binary:         %s\n", info.Path)
+	if info.Version != "" {
+		fmt.Fprintf(out, "Installed:      %s\n", info.Version)
+	}
+	if info.Latest != "" {
+		fmt.Fprintf(out, "Latest:         %s\n", info.Latest)
+	}
+	if len(info.Shadows) > 0 {
+		fmt.Fprintf(out, "PATH shadows:\n")
+		for _, s := range info.Shadows {
+			fmt.Fprintf(out, "  - %s\n", s)
+		}
+	}
+	for _, n := range info.Notes {
+		fmt.Fprintf(out, "! %s\n", n)
+	}
+}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -98,20 +98,20 @@ func runUpgrade(out io.Writer, doRun, checkOnly bool, currentVersion string) err
 		return nil
 	}
 	if info.Latest != "" && info.Version != "" && versionsEqual(info.Version, info.Latest) {
-		fmt.Fprintf(out, "\nAlready on latest (%s). Nothing to do.\n", info.Latest)
+		_, _ = fmt.Fprintf(out, "\nAlready on latest (%s). Nothing to do.\n", info.Latest)
 		return nil
 	}
 	if !doRun {
 		if info.Command != "" {
-			fmt.Fprintf(out, "\nRun: %s\n", info.Command)
-			fmt.Fprintf(out, "Or re-run with --run to execute.\n")
+			_, _ = fmt.Fprintf(out, "\nRun: %s\n", info.Command)
+			_, _ = fmt.Fprintf(out, "Or re-run with --run to execute.\n")
 		}
 		return nil
 	}
 	if info.Command == "" {
 		return fmt.Errorf("upgrade: install method unknown; download a release from https://github.com/Chemaclass/agnostic-ai/releases")
 	}
-	fmt.Fprintf(out, "\n→ %s\n", info.Command)
+	_, _ = fmt.Fprintf(out, "\n→ %s\n", info.Command)
 	return execShell(info.Command)
 }
 
@@ -260,7 +260,7 @@ func fetchLatestRelease(timeout time.Duration) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("github releases api: %s", resp.Status)
 	}
@@ -286,21 +286,21 @@ func execShell(command string) error {
 }
 
 func printUpgradeInfo(out io.Writer, info upgradeInfo) {
-	fmt.Fprintf(out, "Install method: %s\n", info.Method)
-	fmt.Fprintf(out, "Binary:         %s\n", info.Path)
+	_, _ = fmt.Fprintf(out, "Install method: %s\n", info.Method)
+	_, _ = fmt.Fprintf(out, "Binary:         %s\n", info.Path)
 	if info.Version != "" {
-		fmt.Fprintf(out, "Installed:      %s\n", info.Version)
+		_, _ = fmt.Fprintf(out, "Installed:      %s\n", info.Version)
 	}
 	if info.Latest != "" {
-		fmt.Fprintf(out, "Latest:         %s\n", info.Latest)
+		_, _ = fmt.Fprintf(out, "Latest:         %s\n", info.Latest)
 	}
 	if len(info.Shadows) > 0 {
-		fmt.Fprintf(out, "PATH shadows:\n")
+		_, _ = fmt.Fprintf(out, "PATH shadows:\n")
 		for _, s := range info.Shadows {
-			fmt.Fprintf(out, "  - %s\n", s)
+			_, _ = fmt.Fprintf(out, "  - %s\n", s)
 		}
 	}
 	for _, n := range info.Notes {
-		fmt.Fprintf(out, "! %s\n", n)
+		_, _ = fmt.Fprintf(out, "! %s\n", n)
 	}
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDetectInstallMethod_Homebrew(t *testing.T) {
+	cases := []string{
+		"/opt/homebrew/bin/agnostic-ai",
+		"/opt/homebrew/Caskroom/agnostic-ai/0.22.0/agnostic-ai",
+		"/usr/local/Cellar/agnostic-ai/0.22.0/bin/agnostic-ai",
+		"/home/linuxbrew/.linuxbrew/bin/agnostic-ai",
+	}
+	for _, p := range cases {
+		if got := detectInstallMethod(p); got != installHomebrew {
+			t.Errorf("detectInstallMethod(%q) = %v, want homebrew", p, got)
+		}
+	}
+}
+
+func TestDetectInstallMethod_GoInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path semantics differ on windows")
+	}
+	tmp := t.TempDir()
+	gobin := filepath.Join(tmp, "gobin")
+	if err := os.MkdirAll(gobin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOBIN", gobin)
+	t.Setenv("GOPATH", "")
+
+	exe := filepath.Join(gobin, "agnostic-ai")
+	if got := detectInstallMethod(exe); got != installGoInstall {
+		t.Errorf("GOBIN install: got %v, want go install", got)
+	}
+
+	t.Setenv("GOBIN", "")
+	gopath := filepath.Join(tmp, "gopath")
+	if err := os.MkdirAll(filepath.Join(gopath, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOPATH", gopath)
+	exe2 := filepath.Join(gopath, "bin", "agnostic-ai")
+	if got := detectInstallMethod(exe2); got != installGoInstall {
+		t.Errorf("GOPATH/bin install: got %v, want go install", got)
+	}
+}
+
+func TestDetectInstallMethod_Binary(t *testing.T) {
+	t.Setenv("GOBIN", "")
+	t.Setenv("GOPATH", "/nowhere")
+	// HOME guarded too: $HOME/go/bin should not match an unrelated path.
+	t.Setenv("HOME", "/nowhere")
+	if got := detectInstallMethod("/usr/local/bin/agnostic-ai"); got != installBinary {
+		t.Errorf("raw binary: got %v, want binary", got)
+	}
+}
+
+func TestUpgradeCommandFor(t *testing.T) {
+	cases := map[installMethod]string{
+		installHomebrew:  "brew update && brew upgrade Chemaclass/tap/agnostic-ai",
+		installGoInstall: "go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest",
+		installBinary:    "",
+		installUnknown:   "",
+	}
+	for m, want := range cases {
+		if got := upgradeCommandFor(m); got != want {
+			t.Errorf("upgradeCommandFor(%v) = %q, want %q", m, got, want)
+		}
+	}
+}
+
+func TestVersionsEqual(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.22.0", "v0.22.0", true},
+		{" 0.22.0 ", "0.22.0", true},
+		{"0.22.0", "0.21.0", false},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		if got := versionsEqual(c.a, c.b); got != c.want {
+			t.Errorf("versionsEqual(%q,%q)=%v want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestOtherInstancesOnPATH_FindsShadow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH separator + exe extension differ on windows")
+	}
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a")
+	dirB := filepath.Join(tmp, "b")
+	for _, d := range []string{dirA, dirB} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	self := filepath.Join(dirA, "agnostic-ai")
+	other := filepath.Join(dirB, "agnostic-ai")
+	if err := os.WriteFile(self, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(other, []byte("y"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dirA+string(os.PathListSeparator)+dirB)
+
+	got := otherInstancesOnPATH(self)
+	if len(got) != 1 || got[0] != other {
+		t.Errorf("shadows = %v, want [%s]", got, other)
+	}
+}
+
+func TestOtherInstancesOnPATH_NoShadow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics differ on windows")
+	}
+	tmp := t.TempDir()
+	self := filepath.Join(tmp, "agnostic-ai")
+	if err := os.WriteFile(self, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmp)
+	if got := otherInstancesOnPATH(self); len(got) != 0 {
+		t.Errorf("expected no shadows, got %v", got)
+	}
+}
+
+func TestPrintUpgradeInfo_RendersAllFields(t *testing.T) {
+	var buf bytes.Buffer
+	printUpgradeInfo(&buf, upgradeInfo{
+		Path:    "/opt/homebrew/bin/agnostic-ai",
+		Method:  installHomebrew,
+		Version: "0.20.0",
+		Latest:  "0.22.0",
+		Shadows: []string{"/usr/local/bin/agnostic-ai"},
+		Notes:   []string{"shadow detected"},
+	})
+	out := buf.String()
+	for _, want := range []string{
+		"Install method: homebrew",
+		"Binary:         /opt/homebrew/bin/agnostic-ai",
+		"Installed:      0.20.0",
+		"Latest:         0.22.0",
+		"PATH shadows",
+		"/usr/local/bin/agnostic-ai",
+		"shadow detected",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunUpgrade_CheckOnlyPrintsAndReturns(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runUpgrade(&buf, false, true, "0.22.0"); err != nil {
+		t.Fatalf("check-only: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Install method:") {
+		t.Errorf("expected install method line, got:\n%s", buf.String())
+	}
+}
+
+func TestUpgradeCmd_RegistersOnRoot(t *testing.T) {
+	root := NewRootCmd("test")
+	var found bool
+	for _, c := range root.Commands() {
+		if c.Name() == "upgrade" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("upgrade command not registered on root")
+	}
+}


### PR DESCRIPTION
## Summary

- New `agnostic-ai upgrade` command. Detects how the running binary was installed (Homebrew, `go install`, or a raw prebuilt binary) via `os.Executable()` and prints the matching upgrade command. `--run` execs it; `--check` exits after printing the diagnostic.
- Diagnoses **PATH shadowing**: every other `agnostic-ai` binary found on `PATH` is listed. Catches the common case where `brew upgrade` correctly reports the brew copy is current but `agnostic-ai --version` keeps resolving to an older `~/go/bin/agnostic-ai` or `/usr/local/bin/agnostic-ai` left from a previous install. The README install instructions also now spell out `brew upgrade Chemaclass/tap/agnostic-ai` for first-time upgraders, and the prebuilt-binary link points at `/releases` instead of `/releases/latest` so the link itself never goes stale across release cuts.
- Best-effort GitHub API call adds a `Latest:` line to the report so the command can also tell you you are already on the latest tag. Network failure is non-fatal; the rest of the report still prints.

## Why a command instead of true self-update

Self-replacing the running binary is brittle when the install is owned by Homebrew (Caskroom layout, brew's tracking) or `go install`. Letting each package manager stay authoritative and surfacing the right invocation is the smallest change that fixes the actual problem users hit: not knowing why `brew install` is a no-op or which command actually moves them forward.

## Test plan

- [x] `go test ./...` — 775 passed across 27 packages.
- [x] `go vet ./...` clean, `gofmt -l` clean on new files.
- [x] Unit tests cover the four install-method classifications (Homebrew layouts incl. Caskroom + Linuxbrew, `$GOBIN`, `$GOPATH/bin`, raw binary), shadow detection (with and without a second copy on PATH), `upgradeCommandFor` per method, `versionsEqual` (handles `v`-prefix + whitespace), `printUpgradeInfo` field rendering, `runUpgrade --check`, and that `upgrade` is registered on the root command.
- [ ] Manual smoke: run `agnostic-ai upgrade` from the brew install on a second laptop; confirm it reports the brew copy + lists the stale shadow.