### PR TITLE
docs(231): surface v0.22 import-side changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 - `agnostic-ai upgrade` command: prints the right upgrade command for the install method (Homebrew, `go install`, binary). `--run` execs it. `--check` flags `PATH`-shadowed copies.
 - README: `brew upgrade` line + releases page link.
+- Docs: `targets.md`, `configuration.md`, and `cli-reference.md` now describe the v0.22 import-side changes (`import codex` reading `.codex/prompts/*.md` + capturing `.codex/config.toml` into `.agnostic-ai/overlays/codex.config.toml`, `import claude` reading `.mcp.json`) with overlay-precedence rules called out per target.
+- Import summary now prints a `→ <overlay> seeded from <native>` line for both `import claude` (claude settings overlay) and `import codex` (codex config overlay) when the overlay file is actually written. Closes #231.
 
 ### Changed
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -46,8 +46,8 @@ Translate an existing AI CLI configuration into agnostic specs. Reads
 into those directories.
 
 ```bash
-agnostic-ai import claude         # CLAUDE.md, .claude/{agents,skills,settings.json}
-agnostic-ai import codex          # AGENTS.md (root + nested)
+agnostic-ai import claude         # CLAUDE.md, .claude/{agents,skills,commands,settings.json,rules}, .mcp.json
+agnostic-ai import codex          # AGENTS.md (root + nested), .codex/{prompts,config.toml}
 agnostic-ai import claude codex   # multiple sources; AGNOSTIC_AI.md reflects the last (last-wins)
 agnostic-ai import cursor         # .cursor/rules/*.mdc
 agnostic-ai import cline          # .clinerules/
@@ -75,11 +75,14 @@ CLI present in the project.
 | `CLAUDE.md` (any form) | `.agnostic-ai/AGNOSTIC_AI.md` (byte-identical copy) |
 | `.claude/agents/*.md` | `<agents>/<name>.md` (byte-identical copy) |
 | `.claude/skills/<name>/SKILL.md` | `<skills>/<name>/SKILL.md` |
+| `.claude/commands/*.md` | `<commands>/<name>.md` (byte-identical copy) |
 | `.claude/settings.json` hooks | `<hooks>/<event>[-<matcher-slug>]-<hash8>.yaml` (filename derived from event, matcher, and commands so re-imports converge on the same path) |
+| `.claude/settings.json` non-hook keys | `.agnostic-ai/overlays/claude.settings.json` (captures statusLine, enabledPlugins, model overrides, and any other top-level keys so `sync -t claude` reproduces the full settings.json after `.claude/` is wiped) |
+| `.mcp.json` (`mcpServers.<name>`) | `<mcps>/<name>.yaml` (one spec per server; round-trips to every MCP-aware target on the next `sync`) |
 
 When `.claude/rules/` exists, slicing `CLAUDE.md` is skipped entirely (even if the directory is empty) so the on-disk rules layout is the single source of truth for rule files. `.agnostic-ai/AGNOSTIC_AI.md` is still written from `CLAUDE.md` so the project keeps a CLI-agnostic top-level instructions file under the managed directory alongside `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` at the project root.
 
-`import codex` walks the project for `AGENTS.md` files at any depth:
+`import codex` walks the project for `AGENTS.md` files at any depth and reads the rest of the Codex tree:
 
 | Source | Becomes |
 |--------|---------|
@@ -88,8 +91,21 @@ When `.claude/rules/` exists, slicing `CLAUDE.md` is skipped entirely (even if t
 | `<dir>/AGENTS.md` (nested) | `<rules>/<slug>.md` with inferred `globs: <dir>/**` |
 | `## Conventions` / `## Agents` / `## Skills` wrapper sections | unwrapped: their `### children` become the rules |
 | Single-line italic (`_text_`) immediately under a rule heading | extracted into the rule's `description` (and removed from the body) |
+| `.agents/agents/*.toml` | `<agents>/<name>.md` |
+| `.agents/skills/<name>/SKILL.md` (+ `agents/openai.yaml`, asset folders) | `<skills>/<name>/SKILL.md` (+ nested assets, exec bits preserved) |
+| `.codex/config.toml` `[[hooks.<event>]]` | `<hooks>/<event>-<hash8>.yaml` (one spec per entry) |
+| `.codex/config.toml` `[mcp_servers.<name>]` | `<mcps>/<name>.yaml` |
+| `.codex/config.toml` remaining keys (model, sandbox, approval_policy, notify, `[history]`, `[profiles.*]`, `[model_providers.*]`, …) | `.agnostic-ai/overlays/codex.config.toml` (`hooks` + `mcp_servers` stripped; the codex emitter prepends this overlay before the spec-derived sections on each sync) |
+| `.codex/prompts/*.md` | `<commands>/<name>.md` (byte-identical copy) |
 
 Slug collisions across files are deduplicated (`style.md`, `style-2.md`). Hidden directories, the configured source directories, `node_modules/`, and `vendor/` are skipped during the walk to avoid picking up unrelated `AGENTS.md` files.
+
+**Overlay precedence.**
+
+- **Codex**: when both the captured overlay and `outputs.codex.config.*` declare the same key (`model`, `sandbox`, `approval_policy`, `notify`, `[history]`, `[profiles.*]`, `[model_providers.*]`), the overlay wins on conflict and the first-class key is dropped to avoid a TOML duplicate-key error.
+- **Claude**: the opposite. `outputs.claude.settings.*` overrides the overlay for any key it declares, so changes you make in `agnostic-ai.yaml` always reach `.claude/settings.json`. Re-run `import claude` to refresh the overlay whenever you hand-edit `.claude/settings.json`.
+
+Keys declared in only one place are passed through unchanged either way.
 
 `import cursor`:
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -317,7 +317,10 @@ outputs:
 | `permissions` | object | `allow`, `deny`, `ask` lists of tool-pattern strings. |
 
 Any setting not declared here still round-trips through the overlay
-captured during `agnostic-ai import claude`.
+captured during `agnostic-ai import claude` (written to
+`.agnostic-ai/overlays/claude.settings.json`). When both the overlay
+and `outputs.claude.settings.*` declare the same key, the
+first-class config block wins.
 
 ## Codex config
 
@@ -358,6 +361,16 @@ outputs:
 | `notify` | string array | External program Codex invokes on session events. First element is the executable; rest are arguments. |
 | `profiles` | map | Named `[profiles.<name>]` blocks. Each entry overrides top-level fields when Codex runs with `--profile <name>`. Supported keys: `model`, `sandbox`, `approval-policy`, `model-reasoning-effort`, `model-reasoning-summary`, `model-provider`. |
 | `model-providers` | map | Named `[model_providers.<id>]` blocks declaring backends Codex can call. Supported keys: `name`, `base-url`, `wire-api`, `api-key-env`, `env-key`. Reference an `id` from `profiles.<name>.model-provider`. |
+
+The codex emitter also reads `.agnostic-ai/overlays/codex.config.toml`
+(captured by `agnostic-ai import codex`) and prepends its body before
+the spec-derived `[[hooks.*]]` and `[mcp_servers.*]` sections. The
+overlay carries every other `.codex/config.toml` key the user has
+configured (`model`, `sandbox`, `approval_policy`, `notify`,
+`[history]`, `[profiles.*]`, `[model_providers.*]`, …) so a wipe of
+`.codex/` between `import` and `sync` no longer drops them. On
+conflict with `outputs.codex.config.*` the overlay wins and the
+first-class key is dropped to keep the TOML valid.
 
 ## Path semantics
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -82,6 +82,8 @@ Commands emit one file per spec under `.claude/commands/`. Each command becomes 
 
 `agnostic-ai import claude` captures the non-`hooks` portion of `.claude/settings.json` (statusLine, enabledPlugins, any other top-level key) into `.agnostic-ai/overlays/claude.settings.json`. `sync -t claude` reads that overlay and layers the spec-derived `hooks` key on top, so a re-sync from a fresh checkout reproduces the full settings.json even after `.claude/` has been wiped. Re-run `import claude` whenever you add a key to settings.json by hand.
 
+`import claude` also reads `.mcp.json` and writes one spec under `<mcps>/<name>.yaml` per `mcpServers.<name>` entry. The next `sync` then distributes those MCP servers to every other target that supports them (codex, copilot, cursor, continue, amp, zed, warp, gemini, opencode).
+
 `outputs.claude.settings.*` declares first-class settings keys (model, outputStyle, statusLine, permissions, enabledPlugins, env, apiKeyHelper, cleanupPeriodDays, includeCoAuthoredBy). They merge on top of the captured overlay and below the spec-derived hooks block. See [Claude settings](configuration.md#claude-settings).
 
 Config keys: `outputs.claude.dir` (default `.claude`), `outputs.claude.rules-dir` (default `.claude/rules`), `outputs.claude.rules-file` (unset; setting it switches back to the legacy concatenated single-file layout, typically `CLAUDE.md`), `outputs.claude.commands-dir` (default `.claude/commands`), `outputs.claude.mcp-file` (default `.mcp.json`), `outputs.claude.settings` (first-class settings block).
@@ -106,6 +108,8 @@ Skills follow the [Codex skills layout](https://developers.openai.com/codex/skil
 Hooks and MCP servers both land in `.codex/config.toml`. Hook specs route by their `event` frontmatter (e.g. `SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact`, `PostCompact`) into `[[hooks.<event>]]` array-of-tables entries with `matcher` and `command`. MCP servers emit as `[mcp_servers.<name>]` tables — stdio uses `command`/`args`/`env`; HTTP/SSE uses `url`/`bearer_token_env_var`/`http_headers`. The project-tier config.toml is agnostic-ai-managed (overwritten on each sync); add unmanaged Codex config to `~/.codex/config.toml` user-global instead.
 
 Commands emit one file per spec under `.codex/prompts/` (project-tier mirror of `~/.codex/prompts/`). Each becomes a Codex slash prompt. Frontmatter passes through; the body is the prompt template.
+
+`agnostic-ai import codex` captures `.codex/config.toml` minus the `hooks` and `mcp_servers` keys (which round-trip through specs) into `.agnostic-ai/overlays/codex.config.toml`. `sync -t codex` prepends that overlay before the spec-derived hook and MCP sections, so `model`, `sandbox`, `approval_policy`, `notify`, `[history]`, `[profiles.*]`, `[model_providers.*]`, and any other Codex key survive a wipe of `.codex/` between import and sync. On conflict with `outputs.codex.config.*` the overlay wins and the first-class key is dropped to keep TOML valid. `import codex` also reads `.codex/prompts/*.md` and writes them byte-for-byte to `<commands>/`, so user-authored slash prompts round-trip instead of being silently overwritten on the next sync.
 
 ### Gemini CLI (`gemini`)
 

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -55,7 +55,8 @@ func importFromClaude(root string, src config.Sources) error {
 	if c.commands, err = importClaudeCommands(root, filepath.Join(root, src.Commands)); err != nil {
 		return err
 	}
-	if err := importClaudeSettingsOverlay(root); err != nil {
+	overlaySeeded, err := importClaudeSettingsOverlay(root)
+	if err != nil {
 		return err
 	}
 	if err := mirrorClaudeMainFile(root); err != nil {
@@ -65,6 +66,10 @@ func importFromClaude(root string, src config.Sources) error {
 		c.rules, c.agents, c.skills, c.hooks, c.mcps, c.commands)
 	summaryf("  → %s seeded from %s (commit this file — sync distributes it to all targets)\n",
 		agnosticMainFile, claudeMainFile)
+	if overlaySeeded {
+		summaryf("  → %s seeded from %s/settings.json (carries non-hook settings across re-syncs)\n",
+			claudeOverlayRelPath(), claudeDir)
+	}
 	printImportNextSteps(root, "claude")
 	return nil
 }

--- a/internal/cli/import_claude_settings.go
+++ b/internal/cli/import_claude_settings.go
@@ -45,20 +45,21 @@ func claudeOverlayPath(root string) string {
 // overwrites the sentinel with the spec-derived hook map on every sync,
 // keeping hooks at the position the user authored (#227).
 //
-// Returns nil when settings.json is missing or contains only `hooks`,
-// so a fresh project does not get a surprise empty overlay file.
-func importClaudeSettingsOverlay(root string) error {
+// Returns (false, nil) when settings.json is missing or contains only
+// `hooks`, so a fresh project does not get a surprise empty overlay
+// file. Returns (true, nil) when the overlay was actually written.
+func importClaudeSettingsOverlay(root string) (bool, error) {
 	src := filepath.Join(root, claudeDir, "settings.json")
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
-		return nil
+		return false, nil
 	}
 	if err != nil {
-		return fmt.Errorf("read %s: %w", src, err)
+		return false, fmt.Errorf("read %s: %w", src, err)
 	}
 	doc := adapters.NewOrderedJSON()
 	if err := json.Unmarshal(data, doc); err != nil {
-		return fmt.Errorf("parse %s: %w", src, err)
+		return false, fmt.Errorf("parse %s: %w", src, err)
 	}
 	hadHooks := false
 	if _, ok := doc.Get("hooks"); ok {
@@ -66,18 +67,24 @@ func importClaudeSettingsOverlay(root string) error {
 		doc.SetRaw("hooks", json.RawMessage(`null`))
 	}
 	if doc.Len() == 0 || (hadHooks && doc.Len() == 1) {
-		return nil
+		return false, nil
 	}
 	raw, err := adapters.MarshalJSONIndent(doc)
 	if err != nil {
-		return fmt.Errorf("marshal overlay: %w", err)
+		return false, fmt.Errorf("marshal overlay: %w", err)
 	}
 	dst := claudeOverlayPath(root)
 	if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
 	if err := importWriteFile(dst, append(raw, '\n'), 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", dst, err)
+		return false, fmt.Errorf("write %s: %w", dst, err)
 	}
-	return nil
+	return true, nil
+}
+
+// claudeOverlayRelPath returns the overlay path relative to the project
+// root, suitable for printing in import summary lines.
+func claudeOverlayRelPath() string {
+	return filepath.Join(claudeOverlayDir, claudeOverlayFile)
 }

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -40,7 +40,8 @@ func importFromCodex(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := importCodexConfigOverlay(root); err != nil {
+	overlaySeeded, err := importCodexConfigOverlay(root)
+	if err != nil {
 		return err
 	}
 	if err := mirrorMainFile(root, "AGENTS.md"); err != nil {
@@ -48,6 +49,10 @@ func importFromCodex(root string, src config.Sources) error {
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks, %d mcps, %d commands\n",
 		rules, agents, skills, hooks, mcps, commands)
+	if overlaySeeded {
+		summaryf("  → %s seeded from %s (carries model/sandbox/profiles/etc. across re-syncs)\n",
+			codexOverlayRelPath(), codexConfigTOML)
+	}
 	printImportNextSteps(root, "codex")
 	return nil
 }

--- a/internal/cli/import_codex_overlay.go
+++ b/internal/cli/import_codex_overlay.go
@@ -31,6 +31,12 @@ func codexOverlayPath(root string) string {
 	return filepath.Join(root, codexOverlayDir, codexOverlayFile)
 }
 
+// codexOverlayRelPath returns the overlay path relative to the project
+// root, suitable for printing in import summary lines.
+func codexOverlayRelPath() string {
+	return filepath.Join(codexOverlayDir, codexOverlayFile)
+}
+
 // importCodexConfigOverlay reads `.codex/config.toml` under root, drops
 // the `hooks` and `mcp_servers` keys (the spec-derived sections), and
 // writes the remainder to `.agnostic-ai/overlays/codex.config.toml`.
@@ -43,37 +49,38 @@ func codexOverlayPath(root string) string {
 // MCP sections. Without the overlay, a wipe of `.codex/` between
 // import and sync would destroy every non-managed key.
 //
-// Returns nil when config.toml is missing or contains only `hooks`
-// and/or `mcp_servers`, so a fresh project does not get a surprise
-// empty overlay file.
-func importCodexConfigOverlay(root string) error {
+// Returns (false, nil) when config.toml is missing or contains only
+// `hooks` and/or `mcp_servers`, so a fresh project does not get a
+// surprise empty overlay file. Returns (true, nil) when the overlay
+// was actually written.
+func importCodexConfigOverlay(root string) (bool, error) {
 	src := filepath.Join(root, codexConfigTOML)
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
-		return nil
+		return false, nil
 	}
 	if err != nil {
-		return fmt.Errorf("read %s: %w", src, err)
+		return false, fmt.Errorf("read %s: %w", src, err)
 	}
 	doc := map[string]any{}
 	if _, err := toml.Decode(string(data), &doc); err != nil {
-		return fmt.Errorf("parse %s: %w", src, err)
+		return false, fmt.Errorf("parse %s: %w", src, err)
 	}
 	delete(doc, "hooks")
 	delete(doc, "mcp_servers")
 	if len(doc) == 0 {
-		return nil
+		return false, nil
 	}
 	var buf bytes.Buffer
 	if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
-		return fmt.Errorf("encode overlay: %w", err)
+		return false, fmt.Errorf("encode overlay: %w", err)
 	}
 	dst := codexOverlayPath(root)
 	if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
 	if err := importWriteFile(dst, buf.Bytes(), 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", dst, err)
+		return false, fmt.Errorf("write %s: %w", dst, err)
 	}
-	return nil
+	return true, nil
 }


### PR DESCRIPTION
## Summary

- Document the three import-side capabilities added in v0.22 that the release skipped over: `import codex` reading `.codex/prompts/*.md` into the commands source dir, `import codex` capturing `.codex/config.toml` (minus `hooks` + `mcp_servers`) into `.agnostic-ai/overlays/codex.config.toml`, and `import claude` reading `.mcp.json` into the mcps source dir.
- Spell out overlay precedence per target. Codex: overlay wins over `outputs.codex.config.*` and the first-class key is dropped to keep TOML valid. Claude: opposite — `outputs.claude.settings.*` wins over the overlay so changes you make in `agnostic-ai.yaml` always reach `.claude/settings.json`.
- Import summary lines now print `→ <overlay> seeded from <native>` whenever the overlay is actually written, mirroring the existing AGNOSTIC_AI.md mirror notice on `import claude`. `importCodexConfigOverlay` and `importClaudeSettingsOverlay` returns are widened to `(bool, error)` so the caller knows whether to emit the line.

Files: `docs/user/cli-reference.md`, `docs/user/targets.md`, `docs/user/configuration.md`, `internal/cli/import_codex.go`, `internal/cli/import_codex_overlay.go`, `internal/cli/import_claude.go`, `internal/cli/import_claude_settings.go`, `CHANGELOG.md`.

`go run ./cmd/schemagen` was a no-op (struct unchanged); CI gate already covered.

Closes #231.

## Test plan

- [x] `go test ./...` — 775 passed across 27 packages
- [x] `golangci-lint run ./...` clean
- [x] `go run ./cmd/schemagen` produces no diff against committed schema