### PR TITLE
feat(watch): re-emit on captured overlay edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - README: `brew upgrade` line + releases page link.
 - Docs: `targets.md`, `configuration.md`, and `cli-reference.md` now describe the v0.22 import-side changes (`import codex` reading `.codex/prompts/*.md` + capturing `.codex/config.toml` into `.agnostic-ai/overlays/codex.config.toml`, `import claude` reading `.mcp.json`) with overlay-precedence rules called out per target.
 - Import summary now prints a `→ <overlay> seeded from <native>` line for both `import claude` (claude settings overlay) and `import codex` (codex config overlay) when the overlay file is actually written. Closes #231.
+- `sync --watch` now watches `.agnostic-ai/overlays/` so hand-edits to `claude.settings.json` or `codex.config.toml` trigger a re-emit within the 50 ms debounce window. Documented as a watched input in `cli-reference.md` + `configuration.md`. Closes #234.
 
 ### Changed
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -262,7 +262,7 @@ agnostic-ai sync [flags]
 | `--check` | Compare emitted output to disk; exit non-zero on drift. Writes nothing. |
 | `--backup` | Copy each existing target file to `<path>.bak` before overwriting. Pair with `revert` to restore. |
 | `--gitignore <on\|off>` | Override `gitignore.enabled` for this run. |
-| `--watch` | Keep the process alive and re-emit on spec or config changes. Uses OS file events (fsnotify) with a 50 ms debounce; falls back to a 200 ms poll on filesystems where fsnotify fails. Ctrl+C exits cleanly. Incompatible with `--check`. |
+| `--watch` | Keep the process alive and re-emit on spec, config, or overlay changes. Watched roots: `agnostic-ai.yaml` + `agnostic-ai.local.yaml`, every `sources.*` directory, `.agnostic-ai.local/`, and `.agnostic-ai/overlays/` (so a hand-edit to `claude.settings.json` / `codex.config.toml` re-emits). Uses OS file events (fsnotify) with a 50 ms debounce; falls back to a 200 ms poll on filesystems where fsnotify fails. Ctrl+C exits cleanly. Incompatible with `--check`. |
 | `--watch-poll` | Force the polling backend (200 ms) even when fsnotify is available. Use on network mounts or container volumes where fsnotify misses events. Requires `--watch`. |
 | `--all` | Emit every configured target without running the first-sync target picker. Useful for ad-hoc full emission or scripted runs that should bypass interactive prompts. |
 | `--json` | Output as JSON instead of plain text. Stable schema; breaking changes bump `version`. |

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -372,6 +372,17 @@ configured (`model`, `sandbox`, `approval_policy`, `notify`,
 conflict with `outputs.codex.config.*` the overlay wins and the
 first-class key is dropped to keep the TOML valid.
 
+## Watched inputs
+
+`sync --watch` re-emits whenever any of the following change on disk:
+
+- `agnostic-ai.yaml` (and `agnostic-ai.local.yaml` when present)
+- every directory listed under `sources` (agents, skills, rules, hooks, mcps, commands)
+- `.agnostic-ai.local/` (the project-user spec layer)
+- `.agnostic-ai/overlays/` — captured per-target settings (`claude.settings.json`, `codex.config.toml`). Hand-edit the overlay to change something the spec layer does not own (Claude `statusLine`, Codex `[profiles.*]`, …) and watch re-runs `sync` within the 50 ms debounce window.
+
+See [`sync --watch`](cli-reference.md#sync) for the polling fallback and debounce details.
+
 ## Path semantics
 
 - All `sources`/`outputs` paths are relative to the directory holding `agnostic-ai.yaml`.

--- a/internal/cli/import_claude_settings.go
+++ b/internal/cli/import_claude_settings.go
@@ -12,16 +12,16 @@ import (
 )
 
 const (
-	// claudeOverlayDir is the project-relative directory where importers
-	// stash captured per-target settings so they survive a wipe of the
-	// native config tree between `import` and `sync`.
-	claudeOverlayDir = ".agnostic-ai/overlays"
 	// claudeOverlayFile is the captured non-hooks portion of
 	// `.claude/settings.json`. The emitter uses it as the base document
 	// when writing settings.json, layering the spec-derived `hooks` key
 	// on top.
 	claudeOverlayFile = "claude.settings.json"
 )
+
+// claudeOverlayDir is an alias for the shared overlay directory.
+// Kept as a separate identifier so call sites read claude-scoped.
+const claudeOverlayDir = agnosticOverlayDir
 
 // claudeOverlayPath returns the project-relative path to the captured
 // Claude settings overlay.

--- a/internal/cli/import_codex_overlay.go
+++ b/internal/cli/import_codex_overlay.go
@@ -12,10 +12,6 @@ import (
 )
 
 const (
-	// codexOverlayDir is the project-relative directory where importers
-	// stash captured per-target settings so they survive a wipe of the
-	// native config tree between `import` and `sync`.
-	codexOverlayDir = ".agnostic-ai/overlays"
 	// codexOverlayFile is the captured non-hooks/non-mcp-servers portion
 	// of `.codex/config.toml`. The emitter loads it and concatenates it
 	// before the spec-derived hooks + mcp_servers sections so a re-sync
@@ -24,6 +20,10 @@ const (
 	// other top-level keys the user had configured.
 	codexOverlayFile = "codex.config.toml"
 )
+
+// codexOverlayDir is an alias for the shared overlay directory. Kept
+// as a separate identifier so call sites read codex-scoped.
+const codexOverlayDir = agnosticOverlayDir
 
 // codexOverlayPath returns the project-relative path to the captured
 // Codex config overlay.

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -18,6 +18,12 @@ import (
 // rename-into-place, multi-file save) into a single re-sync.
 const debounceWindow = 50 * time.Millisecond
 
+// agnosticOverlayDir is the project-relative directory where importers
+// stash captured per-target settings so they survive a wipe of the
+// native config tree between `import` and `sync`. Watched by `sync
+// --watch` so hand-edits to the overlay trigger a re-emit.
+const agnosticOverlayDir = ".agnostic-ai/overlays"
+
 // watchSync runs an initial sync, then re-runs whenever a watched path
 // changes. When forcePoll is false it tries fsnotify and falls back to
 // polling if the watcher cannot be created.
@@ -210,6 +216,9 @@ func isIgnoredEvent(ev fsnotify.Event) bool {
 }
 
 // watchDirs returns the config file and source directories to watch.
+// Includes `.agnostic-ai/overlays/` so hand-edits to the captured
+// per-target overlays (claude.settings.json, codex.config.toml) trigger
+// a re-emit just like spec changes do.
 func watchDirs(root string, cfg *config.Config) []string {
 	paths := []string{}
 	if cfgPath, _, err := config.ResolveConfigPath(root); err == nil {
@@ -233,6 +242,10 @@ func watchDirs(root string, cfg *config.Config) []string {
 	pu := filepath.Join(root, defaultProjectUser)
 	if dirExists(pu) {
 		paths = append(paths, pu)
+	}
+	overlay := filepath.Join(root, agnosticOverlayDir)
+	if dirExists(overlay) {
+		paths = append(paths, overlay)
 	}
 	return paths
 }

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,6 +189,131 @@ func TestWatchSync_PollFallback(t *testing.T) {
 	}
 	if _, err := os.Stat(claudeMD); err != nil {
 		t.Error("polling watch did not re-emit claude rule after spec change")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWatchDirs_IncludesOverlayDir asserts that watchDirs lists the
+// captured overlay directory so hand-edits to claude.settings.json /
+// codex.config.toml trigger a re-emit in `sync --watch`.
+func TestWatchDirs_IncludesOverlayDir(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+
+	if err := os.MkdirAll(filepath.Join(dir, agnosticOverlayDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _, err := loadProject(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(".", agnosticOverlayDir)
+	found := false
+	for _, p := range watchDirs(".", cfg) {
+		if p == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("watchDirs missing %s\ngot %v", want, watchDirs(".", cfg))
+	}
+}
+
+// TestWatchDirs_OmitsOverlayDirWhenAbsent makes sure we do not register
+// a non-existent overlay dir (would surface as a setup error on some
+// platforms). Only watch when the directory has actually been created.
+func TestWatchDirs_OmitsOverlayDirWhenAbsent(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+
+	cfg, _, err := loadProject(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(".", agnosticOverlayDir)
+	for _, p := range watchDirs(".", cfg) {
+		if p == want {
+			t.Errorf("watchDirs should not list %s when it does not exist", want)
+		}
+	}
+}
+
+// TestWatchSync_ReEmitsOnCodexOverlayChange exercises the end-to-end
+// watch loop: edit the codex config overlay and confirm the codex
+// adapter re-emits .codex/config.toml within the debounce window. Pinned
+// to the polling backend so the test is deterministic on every platform
+// (fsnotify event delivery on Linux CI is occasionally flaky).
+func TestWatchSync_ReEmitsOnCodexOverlayChange(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	overlay := filepath.Join(dir, agnosticOverlayDir)
+	if err := os.MkdirAll(overlay, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	overlayFile := filepath.Join(overlay, codexOverlayFile)
+	if err := os.WriteFile(overlayFile, []byte("model = \"o4-mini\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		// forcePoll=true: deterministic across platforms.
+		done <- watchSync(ctx, 20*time.Millisecond, ".", []string{"codex"}, false, false, "off", true)
+	}()
+
+	codexConfig := filepath.Join(dir, ".codex", "config.toml")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(codexConfig); err == nil && len(data) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	first, err := os.ReadFile(codexConfig)
+	if err != nil {
+		t.Fatalf("initial sync did not produce codex config: %v", err)
+	}
+	if !strings.Contains(string(first), "o4-mini") {
+		t.Fatalf("initial codex config missing overlay content:\n%s", first)
+	}
+
+	// Remove the emitted file so we can verify re-emit fires.
+	if err := os.Remove(codexConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	// Edit the overlay → polling backend should detect the mtime change.
+	time.Sleep(30 * time.Millisecond)
+	if err := os.WriteFile(overlayFile, []byte("model = \"o4-2025\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(codexConfig); err == nil && strings.Contains(string(data), "o4-2025") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	data, err := os.ReadFile(codexConfig)
+	if err != nil {
+		t.Fatalf("watch did not re-emit codex config after overlay edit: %v", err)
+	}
+	if !strings.Contains(string(data), "o4-2025") {
+		t.Errorf("re-emitted codex config still has old overlay content:\n%s", data)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary

- `watchDirs` now lists `.agnostic-ai/overlays/` so hand-edits to the per-target overlays captured by `import` (`claude.settings.json`, `codex.config.toml`) re-trigger sync within the 50 ms debounce window. Before this, editing the overlay only took effect on the next manual `sync` — the watch loop missed the very files that hold model preferences, Codex profiles, Claude `statusLine`, etc.
- The two duplicate `.agnostic-ai/overlays` string constants collapse into a single `agnosticOverlayDir` declared in `watch.go` (the canonical owner now that watch references it). `claudeOverlayDir` and `codexOverlayDir` survive as named aliases so call sites still read target-scoped.
- Docs: `docs/user/cli-reference.md` sync table enumerates every watched root; `docs/user/configuration.md` gains a "Watched inputs" section that lists the overlay paths.

Closes #234.

## Test plan

- [x] `go test ./...` — 778 passed across 27 packages (3 new tests).
- [x] `TestWatchDirs_IncludesOverlayDir` confirms the overlay path lands in the watch list when present.
- [x] `TestWatchDirs_OmitsOverlayDirWhenAbsent` confirms we do not register a non-existent dir.
- [x] `TestWatchSync_ReEmitsOnCodexOverlayChange` runs the real watch loop, edits `codex.config.toml`, and asserts `.codex/config.toml` is re-emitted with the new content. Pinned to the polling backend for deterministic CI behaviour.
- [x] `golangci-lint run ./...` clean.