### PR TITLE
feat(init): prompt for gitignore.enabled on TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ## [Unreleased]
 
 ### Added
+- `init` prompts on TTY to enable the gitignore managed block, persisting `gitignore.enabled: true` to the rendered config when the user opts in. Non-interactive runs default to off; pass `--gitignore` to flip on without a prompt.
 
 ### Changed
 - `sync` footer reports only files that actually changed in both default and `-v` modes. Detailed recording (which short-circuits identical content) is now the sole counter. The previous over-count (every write attempt, even no-op rewrites) is gone.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -269,6 +269,12 @@ The managed block is delimited by `# >>> agnostic-ai (managed) >>>` and `# <<< a
 
 Override per-run with `--gitignore on|off` on `sync`.
 
+### Picking the default at `init`
+
+`agnostic-ai init` asks whether to enable the managed block when stdin is a TTY. Pick "No" (default) to commit emitted target files; pick "Yes" to treat them as build artifacts. Non-interactive runs (CI, piped stdin) skip the prompt — pass `--gitignore` to opt in:
+
+    agnostic-ai init --all --gitignore
+
 ## Claude settings
 
 The `outputs.claude.settings` block declares first-class

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -21,7 +21,7 @@ const defaultBaseDir = ".agnostic-ai"
 var demoFS embed.FS
 
 func newInitCmd() *cobra.Command {
-	var demo, all, dryRun bool
+	var demo, all, dryRun, gitignore bool
 	var preset, fromCLI string
 	cmd := &cobra.Command{
 		Use:   "init [dir]",
@@ -86,7 +86,15 @@ func newInitCmd() *cobra.Command {
 					targets = picked
 				}
 			}
-			if err := scaffold(".", base, demo, preset, targets, dryRun); err != nil {
+			gitignoreEnabled := gitignore
+			if !cmd.Flags().Lookup("gitignore").Changed && !all {
+				picked, err := promptGitignoreEnable(cmd.InOrStdin(), cmd.ErrOrStderr())
+				if err != nil {
+					return err
+				}
+				gitignoreEnabled = picked
+			}
+			if err := scaffold(".", base, demo, preset, targets, dryRun, gitignoreEnabled); err != nil {
 				return err
 			}
 			if fromCLI == "" || dryRun {
@@ -109,6 +117,8 @@ func newInitCmd() *cobra.Command {
 		"Print files that would be scaffolded without writing.")
 	cmd.Flags().StringVar(&fromCLI, "from", "",
 		"After scaffolding, import existing config from this CLI (e.g. claude, cursor, all).")
+	cmd.Flags().BoolVar(&gitignore, "gitignore", false,
+		"Persist gitignore.enabled=true so `sync` keeps a managed .gitignore block of every emitted target path. When unset and stdin is a TTY, init prompts.")
 	_ = cmd.RegisterFlagCompletionFunc("preset", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return availablePresets(), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -29,9 +29,11 @@ func newInitCmd() *cobra.Command {
 		Long: "Creates agnostic-ai.yaml plus source folders. " +
 			"Default base dir is .agnostic-ai/. Pass a positional argument " +
 			"to override (use \".\" for the legacy root-level layout). " +
-			"When stdin is a terminal, init prompts for which targets to enable; " +
-			"pipe a comma-separated list to skip the prompt, or pass --all / -a " +
-			"to enable every supported target without prompting. " +
+			"When stdin is a terminal, init prompts for which targets to enable " +
+			"and whether to keep a managed .gitignore block of every emitted target path; " +
+			"pipe a comma-separated list to skip the target prompt, or pass --all / -a " +
+			"to skip both prompts and enable every supported target. " +
+			"Pass --gitignore to opt into the managed .gitignore block without a prompt. " +
 			"Pass --demo to seed each source folder with a minimal example spec. " +
 			"Pass --preset <name> to seed idiomatic specs for a stack (go, ts-react, python). " +
 			"Pass --from <cli> to scaffold and then import existing CLI config in one step.",
@@ -49,6 +51,9 @@ func newInitCmd() *cobra.Command {
 
   # Non-interactive: pipe the target list
   echo "claude,codex" | agnostic-ai init
+
+  # Enable the managed .gitignore block without prompting
+  agnostic-ai init --all --gitignore
 
   # Seed each source folder with one minimal example spec
   agnostic-ai init --demo
@@ -86,15 +91,19 @@ func newInitCmd() *cobra.Command {
 					targets = picked
 				}
 			}
-			gitignoreEnabled := gitignore
-			if !cmd.Flags().Lookup("gitignore").Changed && !all {
-				picked, err := promptGitignoreEnable(cmd.InOrStdin(), cmd.ErrOrStderr())
-				if err != nil {
-					return err
-				}
-				gitignoreEnabled = picked
+			gitignoreEnabled, err := resolveGitignoreChoice(cmd, all, gitignore)
+			if err != nil {
+				return err
 			}
-			if err := scaffold(".", base, demo, preset, targets, dryRun, gitignoreEnabled); err != nil {
+			if err := scaffold(scaffoldOptions{
+				Root:             ".",
+				Base:             base,
+				Targets:          targets,
+				Preset:           preset,
+				Demo:             demo,
+				DryRun:           dryRun,
+				GitignoreEnabled: gitignoreEnabled,
+			}); err != nil {
 				return err
 			}
 			if fromCLI == "" || dryRun {
@@ -123,4 +132,18 @@ func newInitCmd() *cobra.Command {
 		return availablePresets(), cobra.ShellCompDirectiveNoFileComp
 	})
 	return cmd
+}
+
+// resolveGitignoreChoice picks the effective gitignore.enabled value
+// for a single init invocation:
+//
+//   - explicit --gitignore wins (any value the user typed sticks),
+//   - --all skips the prompt and falls back to the flag default,
+//   - otherwise the TTY confirm prompt drives the choice; non-TTY stdin
+//     silently defaults to false so CI flows stay deterministic.
+func resolveGitignoreChoice(cmd *cobra.Command, all, flagValue bool) (bool, error) {
+	if cmd.Flags().Changed("gitignore") || all {
+		return flagValue, nil
+	}
+	return promptGitignoreEnable(cmd.InOrStdin())
 }

--- a/internal/cli/init_interactive.go
+++ b/internal/cli/init_interactive.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/x/term"
 )
 
 // This file holds the canonical target list and the selection helpers
@@ -134,6 +135,38 @@ func runInteractivePrompt(stderr io.Writer, preselected []string) ([]string, err
 		pickedSet[n] = true
 	}
 	return filterToCanonicalOrder(pickedSet), nil
+}
+
+// promptGitignoreEnable asks the user whether to enable
+// gitignore.enabled in the rendered config. Only TTY stdin runs the
+// confirm widget; piped or closed stdin falls back to false so CI
+// flows stay deterministic (use the --gitignore flag to flip it on
+// non-interactively).
+func promptGitignoreEnable(in io.Reader, stderr io.Writer) (bool, error) {
+	f, ok := in.(*os.File)
+	if !ok || !term.IsTerminal(f.Fd()) {
+		return false, nil
+	}
+	return runGitignoreConfirm(stderr)
+}
+
+// runGitignoreConfirm drives the huh confirm widget. Defaults to false
+// because most teams commit emitted target files (CLAUDE.md, AGENTS.md,
+// .cursor/, ...) so non-agnostic-ai users still see the project
+// conventions without running `sync`.
+func runGitignoreConfirm(stderr io.Writer) (bool, error) {
+	_ = stderr
+	picked := false
+	form := huh.NewConfirm().
+		Title("Ignore generated target files in .gitignore?").
+		Description("`sync` will keep a managed block of every emitted target path. Off by default; flip on if your team treats emitted files as build artifacts.").
+		Affirmative("Yes, ignore them").
+		Negative("No, commit them").
+		Value(&picked)
+	if err := form.Run(); err != nil {
+		return false, err
+	}
+	return picked, nil
 }
 
 // targetMarkers maps each canonical target to filesystem paths that

--- a/internal/cli/init_interactive.go
+++ b/internal/cli/init_interactive.go
@@ -142,20 +142,15 @@ func runInteractivePrompt(stderr io.Writer, preselected []string) ([]string, err
 // confirm widget; piped or closed stdin falls back to false so CI
 // flows stay deterministic (use the --gitignore flag to flip it on
 // non-interactively).
-func promptGitignoreEnable(in io.Reader, stderr io.Writer) (bool, error) {
+//
+// Defaults to false because most teams commit emitted target files
+// (CLAUDE.md, AGENTS.md, .cursor/, ...) so non-agnostic-ai users still
+// see the project conventions without running `sync`.
+func promptGitignoreEnable(in io.Reader) (bool, error) {
 	f, ok := in.(*os.File)
 	if !ok || !term.IsTerminal(f.Fd()) {
 		return false, nil
 	}
-	return runGitignoreConfirm(stderr)
-}
-
-// runGitignoreConfirm drives the huh confirm widget. Defaults to false
-// because most teams commit emitted target files (CLAUDE.md, AGENTS.md,
-// .cursor/, ...) so non-agnostic-ai users still see the project
-// conventions without running `sync`.
-func runGitignoreConfirm(stderr io.Writer) (bool, error) {
-	_ = stderr
 	picked := false
 	form := huh.NewConfirm().
 		Title("Ignore generated target files in .gitignore?").

--- a/internal/cli/init_preset_test.go
+++ b/internal/cli/init_preset_test.go
@@ -47,7 +47,7 @@ func TestInit_PresetPythonSeeds(t *testing.T) {
 func assertPresetSeeds(t *testing.T, preset string) {
 	t.Helper()
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, preset, allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Preset: preset, Targets: allTargetNames()}); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 	got := walkFiles(t, filepath.Join(dir, ".agnostic-ai"))
@@ -89,7 +89,7 @@ func TestInit_PresetUnknownErrors(t *testing.T) {
 
 func TestInit_PresetComposesWithDemo(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", true, "go", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Demo: true, Preset: "go", Targets: allTargetNames()}); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 	got := walkFiles(t, filepath.Join(dir, ".agnostic-ai"))
@@ -139,7 +139,7 @@ func TestInit_PresetDoesNotOverwriteExistingFiles(t *testing.T) {
 func TestInit_PresetSuggestsSyncInNextSteps(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "go", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Preset: "go", Targets: allTargetNames()}); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 	out := buf.String()

--- a/internal/cli/init_preset_test.go
+++ b/internal/cli/init_preset_test.go
@@ -47,7 +47,7 @@ func TestInit_PresetPythonSeeds(t *testing.T) {
 func assertPresetSeeds(t *testing.T, preset string) {
 	t.Helper()
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, preset, allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, preset, allTargetNames(), false, false); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 	got := walkFiles(t, filepath.Join(dir, ".agnostic-ai"))
@@ -89,7 +89,7 @@ func TestInit_PresetUnknownErrors(t *testing.T) {
 
 func TestInit_PresetComposesWithDemo(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", true, "go", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", true, "go", allTargetNames(), false, false); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 	got := walkFiles(t, filepath.Join(dir, ".agnostic-ai"))
@@ -139,7 +139,7 @@ func TestInit_PresetDoesNotOverwriteExistingFiles(t *testing.T) {
 func TestInit_PresetSuggestsSyncInNextSteps(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "go", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, "go", allTargetNames(), false, false); err != nil {
 		t.Fatalf("scaffold: %v", err)
 	}
 	out := buf.String()

--- a/internal/cli/init_scaffold.go
+++ b/internal/cli/init_scaffold.go
@@ -13,7 +13,9 @@ import (
 // renderConfig builds agnostic-ai.yaml with source paths nested under
 // base and the given targets list. base="." writes paths at the
 // project root. Targets are emitted in the order provided.
-func renderConfig(base string, targets []string) string {
+// gitignoreEnabled adds `gitignore: { enabled: true }` so `sync` writes
+// the managed block listing every adapter-emitted path.
+func renderConfig(base string, targets []string, gitignoreEnabled bool) string {
 	prefix := ""
 	if base != "" && base != "." {
 		prefix = filepath.ToSlash(base) + "/"
@@ -33,6 +35,9 @@ func renderConfig(base string, targets []string) string {
 		fmt.Fprintf(&sb, "  - %s\n", t)
 	}
 	sb.WriteString("\non-unsupported: warn\n")
+	if gitignoreEnabled {
+		sb.WriteString("\ngitignore:\n  enabled: true\n")
+	}
 	return sb.String()
 }
 
@@ -40,7 +45,9 @@ func renderConfig(base string, targets []string) string {
 // under base. targets is written verbatim to the targets: block;
 // callers must supply at least one entry. When dryRun is true, no files
 // are written and the planned paths are printed instead.
-func scaffold(root, base string, demo bool, preset string, targets []string, dryRun bool) error {
+// gitignoreEnabled is persisted into the rendered config so `sync` keeps
+// the .gitignore managed block in sync with emitted target paths.
+func scaffold(root, base string, demo bool, preset string, targets []string, dryRun, gitignoreEnabled bool) error {
 	cfgPath := filepath.Join(root, config.ConfigFileName)
 	if !dryRun {
 		if _, err := os.Stat(cfgPath); err == nil {
@@ -77,7 +84,7 @@ func scaffold(root, base string, demo bool, preset string, targets []string, dry
 			return err
 		}
 	}
-	if err := os.WriteFile(cfgPath, []byte(renderConfig(base, targets)), 0o644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte(renderConfig(base, targets, gitignoreEnabled)), 0o644); err != nil {
 		return err
 	}
 	if err := ensureLineInGitignore(root, config.LocalOverrideFileName); err != nil {

--- a/internal/cli/init_scaffold.go
+++ b/internal/cli/init_scaffold.go
@@ -41,78 +41,130 @@ func renderConfig(base string, targets []string, gitignoreEnabled bool) string {
 	return sb.String()
 }
 
-// scaffold creates agnostic-ai.yaml at root and the source-folder tree
-// under base. targets is written verbatim to the targets: block;
-// callers must supply at least one entry. When dryRun is true, no files
-// are written and the planned paths are printed instead.
-// gitignoreEnabled is persisted into the rendered config so `sync` keeps
-// the .gitignore managed block in sync with emitted target paths.
-func scaffold(root, base string, demo bool, preset string, targets []string, dryRun, gitignoreEnabled bool) error {
-	cfgPath := filepath.Join(root, config.ConfigFileName)
-	if !dryRun {
-		if _, err := os.Stat(cfgPath); err == nil {
-			return fmt.Errorf("%s already exists", config.ConfigFileName)
-		}
-		if _, err := os.Stat(filepath.Join(root, config.LegacyConfigFileName)); err == nil {
-			return fmt.Errorf("%s already exists (legacy name; rename to %s)",
-				config.LegacyConfigFileName, config.ConfigFileName)
-		}
+// scaffoldOptions groups the knobs scaffold uses to materialize a fresh
+// project. Bundled in a struct so call sites (the init command and a
+// dozen tests) self-document via named fields rather than a positional
+// list of bools.
+type scaffoldOptions struct {
+	// Root is the project directory that receives agnostic-ai.yaml and
+	// the .gitignore lines. Almost always ".".
+	Root string
+	// Base is the parent directory for the source-folder tree
+	// (agents/, skills/, ...). Empty defaults to defaultBaseDir;
+	// "." writes the folders at Root.
+	Base string
+	// Targets is written verbatim to the targets: block. Callers must
+	// supply at least one entry.
+	Targets []string
+	// Preset, when set, seeds idiomatic specs for a stack ("go",
+	// "ts-react", "python"). Composes with Demo.
+	Preset string
+	// Demo seeds one minimal example spec per source folder.
+	Demo bool
+	// DryRun prints the planned filesystem changes without touching
+	// disk.
+	DryRun bool
+	// GitignoreEnabled persists gitignore.enabled: true into the
+	// rendered config so subsequent `sync` runs maintain the managed
+	// .gitignore block.
+	GitignoreEnabled bool
+}
+
+// scaffoldKinds is the source-folder set every scaffold creates. Order
+// does not matter on disk but is preserved for stable dry-run output.
+var scaffoldKinds = []string{"agents", "skills", "rules", "hooks", "mcps", "commands"}
+
+// scaffold creates agnostic-ai.yaml at Root and the source-folder tree
+// under Base. See scaffoldOptions for the per-field contract.
+func scaffold(opts scaffoldOptions) error {
+	if opts.Base == "" {
+		opts.Base = defaultBaseDir
 	}
-	if base == "" {
-		base = defaultBaseDir
-	}
-	kinds := []string{"agents", "skills", "rules", "hooks", "mcps", "commands"}
-	if dryRun {
-		fmt.Printf("create: %s\n", cfgPath)
-		for _, k := range kinds {
-			fmt.Printf("mkdir:  %s\n", filepath.Join(root, base, k))
-		}
-		if demo {
-			if err := listDemoFiles(filepath.Join(root, base)); err != nil {
-				return err
-			}
-		}
-		if preset != "" {
-			if err := listPresetFiles(filepath.Join(root, base), preset); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	for _, k := range kinds {
-		if err := os.MkdirAll(filepath.Join(root, base, k), 0o755); err != nil {
+	cfgPath := filepath.Join(opts.Root, config.ConfigFileName)
+	if !opts.DryRun {
+		if err := ensureNoExistingConfig(opts.Root, cfgPath); err != nil {
 			return err
 		}
 	}
-	if err := os.WriteFile(cfgPath, []byte(renderConfig(base, targets, gitignoreEnabled)), 0o644); err != nil {
-		return err
+	if opts.DryRun {
+		return scaffoldDryRun(opts, cfgPath)
 	}
-	if err := ensureLineInGitignore(root, config.LocalOverrideFileName); err != nil {
-		return err
+	return scaffoldWrite(opts, cfgPath)
+}
+
+// ensureNoExistingConfig refuses to overwrite an existing project. The
+// legacy filename gets a tailored rename hint.
+func ensureNoExistingConfig(root, cfgPath string) error {
+	if _, err := os.Stat(cfgPath); err == nil {
+		return fmt.Errorf("%s already exists", config.ConfigFileName)
 	}
-	if err := ensureLineInGitignore(root, ".agnostic-ai/.sync-state"); err != nil {
-		return err
+	if _, err := os.Stat(filepath.Join(root, config.LegacyConfigFileName)); err == nil {
+		return fmt.Errorf("%s already exists (legacy name; rename to %s)",
+			config.LegacyConfigFileName, config.ConfigFileName)
 	}
-	if err := ensureLineInGitignore(root, packsDir+"/"); err != nil {
-		return err
+	return nil
+}
+
+// scaffoldDryRun prints the filesystem changes scaffold would make
+// without touching disk.
+func scaffoldDryRun(opts scaffoldOptions, cfgPath string) error {
+	fmt.Printf("create: %s\n", cfgPath)
+	for _, k := range scaffoldKinds {
+		fmt.Printf("mkdir:  %s\n", filepath.Join(opts.Root, opts.Base, k))
 	}
-	if demo {
-		if err := writeDemoFiles(filepath.Join(root, base)); err != nil {
+	baseDir := filepath.Join(opts.Root, opts.Base)
+	if opts.Demo {
+		if err := listDemoFiles(baseDir); err != nil {
 			return err
 		}
 	}
-	if preset != "" {
-		if err := writePresetFiles(filepath.Join(root, base), preset); err != nil {
+	if opts.Preset != "" {
+		if err := listPresetFiles(baseDir, opts.Preset); err != nil {
 			return err
 		}
 	}
-	if demo {
+	return nil
+}
+
+// scaffoldWrite materializes the scaffold on disk and prints the
+// post-scaffold guidance.
+func scaffoldWrite(opts scaffoldOptions, cfgPath string) error {
+	baseDir := filepath.Join(opts.Root, opts.Base)
+	for _, k := range scaffoldKinds {
+		if err := os.MkdirAll(filepath.Join(baseDir, k), 0o755); err != nil {
+			return err
+		}
+	}
+	cfgBody := renderConfig(opts.Base, opts.Targets, opts.GitignoreEnabled)
+	if err := os.WriteFile(cfgPath, []byte(cfgBody), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", cfgPath, err)
+	}
+	for _, entry := range []string{
+		config.LocalOverrideFileName,
+		".agnostic-ai/.sync-state",
+		packsDir + "/",
+	} {
+		if err := ensureLineInGitignore(opts.Root, entry); err != nil {
+			return err
+		}
+	}
+	if opts.Demo {
+		if err := writeDemoFiles(baseDir); err != nil {
+			return err
+		}
+	}
+	if opts.Preset != "" {
+		if err := writePresetFiles(baseDir, opts.Preset); err != nil {
+			return err
+		}
+	}
+	if opts.Demo {
 		summaryf("seeded one example spec per source folder. delete or edit to taste.\n")
 	}
-	if preset != "" {
-		summaryf("seeded preset %q. review and tune the rules to match your house style.\n", preset)
+	if opts.Preset != "" {
+		summaryf("seeded preset %q. review and tune the rules to match your house style.\n", opts.Preset)
 	}
-	printNextSteps(root, base, targets, demo || preset != "")
+	printNextSteps(opts.Root, opts.Base, opts.Targets, opts.Demo || opts.Preset != "")
 	return nil
 }
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -23,7 +23,7 @@ func captureSummary(t *testing.T) *bytes.Buffer {
 
 func TestScaffold_DefaultBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -42,7 +42,7 @@ func TestScaffold_DefaultBaseDir(t *testing.T) {
 
 func TestScaffold_CustomBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "specs", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "specs", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -61,7 +61,7 @@ func TestScaffold_CustomBaseDir(t *testing.T) {
 
 func TestScaffold_BaseDirDot_WritesAtRoot(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, ".", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, ".", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -80,7 +80,7 @@ func TestScaffold_BaseDirDot_WritesAtRoot(t *testing.T) {
 
 func TestScaffold_NestedBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, filepath.Join("config", "ai"), false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, filepath.Join("config", "ai"), false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "config", "ai", "agents")); err != nil {
@@ -127,7 +127,7 @@ func TestInitCmd_DefaultsToAgnosticAi(t *testing.T) {
 
 func TestScaffold_GitignoreContainsLocalOverrideAndSyncState(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -147,7 +147,7 @@ func TestScaffold_GitignoreIdempotent(t *testing.T) {
 		[]byte("node_modules/\n.agnostic-ai/.sync-state\nagnostic-ai.local.yaml\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -176,7 +176,7 @@ func TestInitCmd_RejectsExtraArgs(t *testing.T) {
 
 func TestScaffold_Demo_SeedsOneFilePerKind(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", true, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", true, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	wantFiles := map[string]string{
@@ -208,7 +208,7 @@ func TestScaffold_Demo_DoesNotOverwriteExistingFiles(t *testing.T) {
 	if err := os.WriteFile(custom, []byte("user content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", true, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", true, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(custom)
@@ -222,7 +222,7 @@ func TestScaffold_Demo_DoesNotOverwriteExistingFiles(t *testing.T) {
 
 func TestScaffold_NoDemo_LeavesFoldersEmpty(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, kind := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -257,13 +257,13 @@ func TestScaffold_RefusesIfConfigExists(t *testing.T) {
 		[]byte("version: 1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", false, "", allTargetNames(), false); err == nil {
+	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err == nil {
 		t.Error("expected error when config already exists")
 	}
 }
 
 func TestRenderConfig_DefaultTargetsListAllThirteen(t *testing.T) {
-	got := renderConfig("", allTargetNames())
+	got := renderConfig("", allTargetNames(), false)
 	for _, name := range []string{
 		"claude", "codex", "gemini", "cursor", "copilot",
 		"aider", "cline", "windsurf", "continue", "amp",
@@ -279,7 +279,7 @@ func TestRenderConfig_DefaultTargetsListAllThirteen(t *testing.T) {
 }
 
 func TestRenderConfig_TrimmedTargetsList(t *testing.T) {
-	got := renderConfig("", []string{"claude", "codex"})
+	got := renderConfig("", []string{"claude", "codex"}, false)
 	if !strings.Contains(got, "  - claude\n") || !strings.Contains(got, "  - codex\n") {
 		t.Errorf("missing chosen targets:\n%s", got)
 	}
@@ -289,10 +289,63 @@ func TestRenderConfig_TrimmedTargetsList(t *testing.T) {
 }
 
 func TestRenderConfig_ContainsSchemaComment(t *testing.T) {
-	got := renderConfig("", []string{"claude"})
+	got := renderConfig("", []string{"claude"}, false)
 	want := "# yaml-language-server: $schema=https://raw.githubusercontent.com/Chemaclass/agnostic-ai/main/docs/schemas/config.schema.json"
 	if !strings.HasPrefix(got, want) {
 		t.Errorf("renderConfig output should start with schema comment, got:\n%s", got)
+	}
+}
+
+func TestRenderConfig_GitignoreDisabledOmitsBlock(t *testing.T) {
+	got := renderConfig("", []string{"claude"}, false)
+	if strings.Contains(got, "gitignore:") {
+		t.Errorf("expected no gitignore block when disabled, got:\n%s", got)
+	}
+}
+
+func TestRenderConfig_GitignoreEnabledWritesBlock(t *testing.T) {
+	got := renderConfig("", []string{"claude"}, true)
+	if !strings.Contains(got, "gitignore:\n  enabled: true\n") {
+		t.Errorf("expected gitignore block, got:\n%s", got)
+	}
+}
+
+func TestInitCmd_GitignoreFlagPersistsEnabled(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"init", "--all", "--gitignore"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "agnostic-ai.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(cfg), "gitignore:\n  enabled: true\n") {
+		t.Errorf("expected gitignore enabled block in config:\n%s", cfg)
+	}
+}
+
+func TestInitCmd_NonTTY_NoPromptDefaultsDisabled(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetIn(strings.NewReader("claude\n"))
+	root.SetArgs([]string{"init"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "agnostic-ai.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(cfg), "gitignore:") {
+		t.Errorf("non-TTY init without --gitignore must not write gitignore block:\n%s", cfg)
 	}
 }
 
@@ -418,7 +471,7 @@ func TestInitCmd_Interactive_PipedUnknownTarget(t *testing.T) {
 func TestScaffold_PrintsNextStepsGuidance(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -437,7 +490,7 @@ func TestScaffold_PrintsNextStepsGuidance(t *testing.T) {
 func TestScaffold_PrintsCustomBaseInGuidance(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "specs", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "specs", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), "✓ initialized agnostic-ai project at specs/") {
@@ -448,7 +501,7 @@ func TestScaffold_PrintsCustomBaseInGuidance(t *testing.T) {
 func TestScaffold_PrintsRootBaseInGuidance(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, ".", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, ".", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), "✓ initialized agnostic-ai project at ./") {
@@ -459,7 +512,7 @@ func TestScaffold_PrintsRootBaseInGuidance(t *testing.T) {
 func TestScaffold_DemoAndPresetLinesPrintBeforeNextSteps(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", true, "go", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", true, "go", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -477,7 +530,7 @@ func TestScaffold_DemoAndPresetLinesPrintBeforeNextSteps(t *testing.T) {
 func TestScaffold_EchoesEnabledTargets(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "", []string{"claude", "codex"}, false); err != nil {
+	if err := scaffold(dir, "", false, "", []string{"claude", "codex"}, false, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), "  enabled: claude, codex\n") {
@@ -488,7 +541,7 @@ func TestScaffold_EchoesEnabledTargets(t *testing.T) {
 func TestScaffold_SeededSuggestsSyncNotImport(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", true, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", true, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -507,7 +560,7 @@ func TestScaffold_DetectsExistingTargetsAndSuggestsImports(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "", allTargetNames(), false); err != nil {
+	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -23,7 +23,7 @@ func captureSummary(t *testing.T) *bytes.Buffer {
 
 func TestScaffold_DefaultBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -42,7 +42,7 @@ func TestScaffold_DefaultBaseDir(t *testing.T) {
 
 func TestScaffold_CustomBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "specs", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "specs", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -61,7 +61,7 @@ func TestScaffold_CustomBaseDir(t *testing.T) {
 
 func TestScaffold_BaseDirDot_WritesAtRoot(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, ".", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: ".", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	for _, d := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -80,7 +80,7 @@ func TestScaffold_BaseDirDot_WritesAtRoot(t *testing.T) {
 
 func TestScaffold_NestedBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, filepath.Join("config", "ai"), false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: filepath.Join("config", "ai"), Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "config", "ai", "agents")); err != nil {
@@ -127,7 +127,7 @@ func TestInitCmd_DefaultsToAgnosticAi(t *testing.T) {
 
 func TestScaffold_GitignoreContainsLocalOverrideAndSyncState(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -147,7 +147,7 @@ func TestScaffold_GitignoreIdempotent(t *testing.T) {
 		[]byte("node_modules/\n.agnostic-ai/.sync-state\nagnostic-ai.local.yaml\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -176,7 +176,7 @@ func TestInitCmd_RejectsExtraArgs(t *testing.T) {
 
 func TestScaffold_Demo_SeedsOneFilePerKind(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", true, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Demo: true, Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	wantFiles := map[string]string{
@@ -208,7 +208,7 @@ func TestScaffold_Demo_DoesNotOverwriteExistingFiles(t *testing.T) {
 	if err := os.WriteFile(custom, []byte("user content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", true, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Demo: true, Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(custom)
@@ -222,7 +222,7 @@ func TestScaffold_Demo_DoesNotOverwriteExistingFiles(t *testing.T) {
 
 func TestScaffold_NoDemo_LeavesFoldersEmpty(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	for _, kind := range []string{"agents", "skills", "rules", "hooks", "mcps", "commands"} {
@@ -257,7 +257,7 @@ func TestScaffold_RefusesIfConfigExists(t *testing.T) {
 		[]byte("version: 1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err == nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err == nil {
 		t.Error("expected error when config already exists")
 	}
 }
@@ -471,7 +471,7 @@ func TestInitCmd_Interactive_PipedUnknownTarget(t *testing.T) {
 func TestScaffold_PrintsNextStepsGuidance(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -490,7 +490,7 @@ func TestScaffold_PrintsNextStepsGuidance(t *testing.T) {
 func TestScaffold_PrintsCustomBaseInGuidance(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "specs", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "specs", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), "✓ initialized agnostic-ai project at specs/") {
@@ -501,7 +501,7 @@ func TestScaffold_PrintsCustomBaseInGuidance(t *testing.T) {
 func TestScaffold_PrintsRootBaseInGuidance(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, ".", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: ".", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), "✓ initialized agnostic-ai project at ./") {
@@ -512,7 +512,7 @@ func TestScaffold_PrintsRootBaseInGuidance(t *testing.T) {
 func TestScaffold_DemoAndPresetLinesPrintBeforeNextSteps(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", true, "go", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Demo: true, Preset: "go", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -530,7 +530,7 @@ func TestScaffold_DemoAndPresetLinesPrintBeforeNextSteps(t *testing.T) {
 func TestScaffold_EchoesEnabledTargets(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "", []string{"claude", "codex"}, false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: []string{"claude", "codex"}}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), "  enabled: claude, codex\n") {
@@ -541,7 +541,7 @@ func TestScaffold_EchoesEnabledTargets(t *testing.T) {
 func TestScaffold_SeededSuggestsSyncNotImport(t *testing.T) {
 	dir := t.TempDir()
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", true, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Demo: true, Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -560,7 +560,7 @@ func TestScaffold_DetectsExistingTargetsAndSuggestsImports(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := captureSummary(t)
-	if err := scaffold(dir, "", false, "", allTargetNames(), false, false); err != nil {
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()


### PR DESCRIPTION
## Summary
- `agnostic-ai init` now asks (TTY only) whether to keep a managed `.gitignore` block of every adapter-emitted path. Default is **No** so projects that commit emitted files (CLAUDE.md, AGENTS.md, `.cursor/`, ...) keep current behavior.
- Picking **Yes** persists `gitignore.enabled: true` into the rendered `agnostic-ai.yaml`, so subsequent `sync` runs maintain the managed block automatically.
- New `--gitignore` flag opts in without a TTY (CI, piped stdin, `--all`). `--all` skips both the target picker and the gitignore prompt.

## Why
Emitted target files were never auto-ignored, but the underlying `gitignore.enabled` config has been wired into `sync` for a while. `init` now surfaces the choice up front instead of leaving users to discover the YAML knob later.

## Test plan
- [x] `go test ./...` (799 passed)
- [x] `go vet ./...` clean
- [ ] Manual: `agnostic-ai init` in a TTY → confirm prompt appears, both branches write the right config
- [ ] Manual: `echo "claude" | agnostic-ai init` → no prompt, no `gitignore:` block
- [ ] Manual: `agnostic-ai init --all --gitignore` → `gitignore.enabled: true` block in `agnostic-ai.yaml`