### PR TITLE
fix: round-trip safety pass on hook + overlay capture

### DIFF
--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -313,7 +313,7 @@ func hookSettingsJSON(hooks []spec.Entry) *emit.OrderedJSON {
 		for _, cmd := range cmds {
 			byKey[k] = append(byKey[k], hookCommandEntry{
 				Type:          "command",
-				Command:       cmd,
+				Command:       emit.RewriteHookPath(cmd, target),
 				Timeout:       timeout,
 				StatusMessage: statusMessage,
 			})

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -304,12 +304,19 @@ func hookSettingsJSON(hooks []spec.Entry) *emit.OrderedJSON {
 		if len(cmds) == 0 {
 			continue
 		}
+		timeout := hookIntMeta(h.Meta, "timeout")
+		statusMessage, _ := h.Meta["statusMessage"].(string)
 		k := matcherKey{event: event, matcher: matcher}
 		if _, seen := byKey[k]; !seen {
 			keyOrder = append(keyOrder, k)
 		}
 		for _, cmd := range cmds {
-			byKey[k] = append(byKey[k], hookCommandEntry{Type: "command", Command: cmd})
+			byKey[k] = append(byKey[k], hookCommandEntry{
+				Type:          "command",
+				Command:       cmd,
+				Timeout:       timeout,
+				StatusMessage: statusMessage,
+			})
 		}
 	}
 	byEvent := map[string][]matcherGroup{}
@@ -334,9 +341,16 @@ func hookSettingsJSON(hooks []spec.Entry) *emit.OrderedJSON {
 // expects inside a matcher group's `hooks` array. Using a struct lets
 // `encoding/json` emit the fields in declaration order rather than the
 // alpha-sorted order map iteration would produce.
+//
+// `Timeout` and `StatusMessage` are optional Claude schema fields that
+// propagate from the spec's `timeout` / `statusMessage` Meta keys. They
+// `omitempty` so specs that don't set them produce the historic minimal
+// `{type, command}` payload.
 type hookCommandEntry struct {
-	Type    string `json:"type"`
-	Command string `json:"command"`
+	Type          string `json:"type"`
+	Command       string `json:"command"`
+	Timeout       int    `json:"timeout,omitempty"`
+	StatusMessage string `json:"statusMessage,omitempty"`
 }
 
 // matcherGroup mirrors the `{matcher, hooks}` JSON object in
@@ -383,6 +397,29 @@ func orderedHookEvents(seen []string) []string {
 		}
 	}
 	return out
+}
+
+// hookIntMeta extracts an integer field from a hook spec's Meta map.
+// YAML decodes numerics as int/int64/float64 depending on representation,
+// so each plausible concrete type is checked. Returns 0 when the key is
+// absent, an unparseable string, or any other type.
+func hookIntMeta(meta map[string]any, key string) int {
+	switch v := meta[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		var n int
+		_, err := fmt.Sscanf(v, "%d", &n)
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
 }
 
 // hookCommands normalizes a `command:` field that may be a string or a

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -115,7 +115,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 // materializeHookScripts copies each hook's stashed script body from
 // `.agnostic-ai/scripts/` into `.<target>/hooks/`. The lookup keys off
 // the spec's original `command:` path so a script imported via claude
-// still materialises when the same hook syncs out to claude.
+// still materializes when the same hook syncs out to claude.
 //
 // Hooks whose command field is a free-form shell expression carry no
 // stashed body and skip silently — there is nothing to copy.

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -105,7 +105,32 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 
+	if err := materializeHookScripts(b.Hooks, dryRun); err != nil {
+		return err
+	}
+
 	return emit.WriteMCPFile(b.MCPs, emit.MCPSchemaServersMap, emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)
+}
+
+// materializeHookScripts copies each hook's stashed script body from
+// `.agnostic-ai/scripts/` into `.<target>/hooks/`. The lookup keys off
+// the spec's original `command:` path so a script imported via claude
+// still materialises when the same hook syncs out to claude.
+//
+// Hooks whose command field is a free-form shell expression carry no
+// stashed body and skip silently — there is nothing to copy.
+func materializeHookScripts(hooks []spec.Entry, dryRun bool) error {
+	for _, h := range hooks {
+		cmds := hookCommands(h.Meta["command"])
+		for _, raw := range cmds {
+			sourceTool, _ := emit.SourceToolFromHookCommand(raw)
+			rewritten := emit.RewriteHookPath(raw, target)
+			if err := emit.MaterializeHookScript(rewritten, target, sourceTool, dryRun); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // propagateSkillAssets mirrors every sibling file under the source

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -450,6 +450,39 @@ func TestEmit_HookTimeoutAndStatusMessagePropagate(t *testing.T) {
 	}
 }
 
+// A hook spec authored against another tool's hooks directory must
+// rewrite the `.<sibling>/hooks/` prefix to `.claude/hooks/` so the
+// emitted settings.json points at the path inside the Claude tree.
+func TestEmit_Hook_RewritesSiblingHookPathToClaude(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindHook,
+			Name: "h1",
+			Meta: map[string]any{
+				"event":   "PreToolUse",
+				"matcher": "Edit",
+				"command": ".codex/hooks/protect-files.sh",
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `".claude/hooks/protect-files.sh"`) {
+		t.Errorf("expected sibling codex path rewritten to .claude/hooks/, got:\n%s", raw)
+	}
+	if strings.Contains(string(raw), ".codex/hooks/") {
+		t.Errorf("emitted settings.json still references .codex/hooks/:\n%s", raw)
+	}
+}
+
 func TestEmit_MergesHooksBySameEventAndMatcher(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -394,6 +394,62 @@ func TestEmit_WritesHookSettings(t *testing.T) {
 	}
 }
 
+// Per-hook timeout (seconds) and statusMessage are first-class Claude
+// schema fields. When the spec carries them via Meta they must propagate
+// to every emitted `hooks[].{...}` object so behavior survives a
+// round-trip.
+func TestEmit_HookTimeoutAndStatusMessagePropagate(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindHook,
+			Name: "h1",
+			Meta: map[string]any{
+				"event":         "PostToolUse",
+				"matcher":       "Edit|Write",
+				"command":       []any{"a.sh", "b.sh"},
+				"timeout":       30,
+				"statusMessage": "Running formatters",
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type          string `json:"type"`
+				Command       string `json:"command"`
+				Timeout       int    `json:"timeout"`
+				StatusMessage string `json:"statusMessage"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse: %v\n%s", err, raw)
+	}
+	groups := doc.Hooks["PostToolUse"]
+	if len(groups) != 1 || len(groups[0].Hooks) != 2 {
+		t.Fatalf("expected 1 matcher group with 2 hooks, got: %s", raw)
+	}
+	for _, h := range groups[0].Hooks {
+		if h.Timeout != 30 {
+			t.Errorf("expected timeout=30 on every hook, got %d (%s)", h.Timeout, h.Command)
+		}
+		if h.StatusMessage != "Running formatters" {
+			t.Errorf("expected statusMessage to propagate, got %q (%s)", h.StatusMessage, h.Command)
+		}
+	}
+}
+
 func TestEmit_MergesHooksBySameEventAndMatcher(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/adapters/codex/agent_toml.go
+++ b/internal/adapters/codex/agent_toml.go
@@ -36,8 +36,17 @@ func agentTOML(a spec.Entry) string {
 		instructions = description
 	}
 
+	// Codex agent names use underscores by convention; the agnostic
+	// spec stores the canonical dash-cased filename. `x-codex.name`
+	// overrides the on-disk slug so the emitted TOML carries the
+	// runtime identifier (e.g. `changelog_keeper`) Codex expects.
+	runtimeName := a.Name
+	if v := xCodexString(a.Meta, "name"); v != "" {
+		runtimeName = v
+	}
+
 	var sb strings.Builder
-	emit.WriteTOMLString(&sb, "name", a.Name)
+	emit.WriteTOMLString(&sb, "name", runtimeName)
 	emit.WriteTOMLString(&sb, "description", description)
 	emit.WriteTOMLMultiline(&sb, "developer_instructions", instructions)
 
@@ -176,6 +185,17 @@ func toStringMap(m map[string]any) map[string]string {
 		}
 	}
 	return out
+}
+
+// xCodexString returns meta["x-codex"][key] as a string. Returns ""
+// when x-codex is absent, not a map, or the value is not a string.
+func xCodexString(meta map[string]any, key string) string {
+	x, ok := meta["x-codex"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	s, _ := x[key].(string)
+	return s
 }
 
 func stringOr(meta map[string]any, key, fallback string) string {

--- a/internal/adapters/codex/agent_toml_test.go
+++ b/internal/adapters/codex/agent_toml_test.go
@@ -13,6 +13,29 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
+// The on-disk spec filename canonicalises to dash-case (so claude and
+// codex collapse onto one file) but the emitted TOML must carry the
+// codex runtime identifier — typically an underscored name. `x-codex.name`
+// is the override hook for this divergence.
+func TestAgentTOML_UsesXCodexNameForRuntimeIdentifier(t *testing.T) {
+	a := spec.Entry{
+		Kind: spec.KindAgent,
+		Name: "changelog-keeper",
+		Body: "instructions",
+		Meta: map[string]any{
+			"description": "changelog agent",
+			"x-codex":     map[string]any{"name": "changelog_keeper"},
+		},
+	}
+	got := agentTOML(a)
+	if !strings.Contains(got, `name = "changelog_keeper"`) {
+		t.Errorf("expected x-codex.name to override emitted runtime name:\n%s", got)
+	}
+	if strings.Contains(got, `name = "changelog-keeper"`) {
+		t.Errorf("unexpected dashed name still emitted:\n%s", got)
+	}
+}
+
 func TestAgentTOML_EscapesQuotesAndBackslashes(t *testing.T) {
 	a := spec.Entry{
 		Kind: spec.KindAgent,

--- a/internal/adapters/codex/codex.go
+++ b/internal/adapters/codex/codex.go
@@ -112,7 +112,27 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 
-	return emitConfigTOML(b, cfg, dryRun)
+	if err := emitConfigTOML(b, cfg, dryRun); err != nil {
+		return err
+	}
+	return materializeHookScripts(b.Hooks, dryRun)
+}
+
+// materializeHookScripts copies each hook's stashed script body from
+// `.agnostic-ai/scripts/` into `.codex/hooks/` so the emitted
+// config.toml has the actual script alongside the path it references.
+func materializeHookScripts(hooks []spec.Entry, dryRun bool) error {
+	for _, h := range hooks {
+		cmds := hookCommands(h.Meta["command"])
+		for _, raw := range cmds {
+			sourceTool, _ := emit.SourceToolFromHookCommand(raw)
+			rewritten := emit.RewriteHookPath(raw, target)
+			if err := emit.MaterializeHookScript(rewritten, target, sourceTool, dryRun); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // codexEmitsSkills reports whether the codex adapter should write the

--- a/internal/adapters/codex/config_toml.go
+++ b/internal/adapters/codex/config_toml.go
@@ -288,7 +288,7 @@ func writeHookSection(sb *strings.Builder, event string, h spec.Entry) {
 		if matcher != "" {
 			emit.WriteTOMLString(sb, "matcher", matcher)
 		}
-		emit.WriteTOMLString(sb, "command", cmd)
+		emit.WriteTOMLString(sb, "command", emit.RewriteHookPath(cmd, target))
 		sb.WriteString("\n")
 	}
 }

--- a/internal/adapters/codex/config_toml.go
+++ b/internal/adapters/codex/config_toml.go
@@ -272,13 +272,54 @@ func groupHooksByEvent(hooks []spec.Entry) map[string][]spec.Entry {
 	return out
 }
 
+// writeHookSection emits one `[[hooks.<event>]]` array-of-tables block
+// per command. Codex's TOML hook schema accepts a single command per
+// entry, so a spec with `command: [a, b]` expands to two blocks sharing
+// the same matcher. A spec with no command at all is skipped — emitting
+// an empty block would corrupt the file.
 func writeHookSection(sb *strings.Builder, event string, h spec.Entry) {
-	sb.WriteString("[[hooks." + event + "]]\n")
-	if matcher, _ := h.Meta["matcher"].(string); matcher != "" {
-		emit.WriteTOMLString(sb, "matcher", matcher)
+	matcher, _ := h.Meta["matcher"].(string)
+	cmds := hookCommands(h.Meta["command"])
+	if len(cmds) == 0 {
+		return
 	}
-	if cmd, _ := h.Meta["command"].(string); cmd != "" {
+	for _, cmd := range cmds {
+		sb.WriteString("[[hooks." + event + "]]\n")
+		if matcher != "" {
+			emit.WriteTOMLString(sb, "matcher", matcher)
+		}
 		emit.WriteTOMLString(sb, "command", cmd)
+		sb.WriteString("\n")
 	}
-	sb.WriteString("\n")
+}
+
+// hookCommands normalizes a spec's `command:` value (string, []string,
+// or []any) into a slice of non-empty strings. Mirrors the helper used
+// by the claude + gemini adapters; kept private here to avoid a shared
+// import cycle.
+func hookCommands(raw any) []string {
+	switch v := raw.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, s := range v {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
 }

--- a/internal/adapters/codex/config_toml_test.go
+++ b/internal/adapters/codex/config_toml_test.go
@@ -149,6 +149,36 @@ func TestEmit_Hook_CommandArrayExpandsToMultipleBlocks(t *testing.T) {
 	}
 }
 
+// A hook spec authored against another tool's hooks directory must
+// rewrite the `.<sibling>/hooks/` prefix to `.codex/hooks/` so the
+// emitted config.toml points at a path that actually exists under the
+// codex tree.
+func TestEmit_Hook_RewritesSiblingHookPathToCodex(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindHook,
+			Name: "h1",
+			Meta: map[string]any{
+				"event":   "PreToolUse",
+				"matcher": "Edit",
+				"command": ".claude/hooks/protect-files.sh",
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	if !strings.Contains(got, `command = ".codex/hooks/protect-files.sh"`) {
+		t.Errorf("expected sibling claude path rewritten to .codex/hooks/, got:\n%s", got)
+	}
+	if strings.Contains(got, ".claude/hooks/") {
+		t.Errorf("emitted toml still references .claude/hooks/:\n%s", got)
+	}
+}
+
 // Hooks with no event are skipped.
 func TestEmit_Hook_SkipsWhenNoEvent(t *testing.T) {
 	dir := testutil.TempCwd(t)

--- a/internal/adapters/codex/config_toml_test.go
+++ b/internal/adapters/codex/config_toml_test.go
@@ -113,6 +113,42 @@ func TestEmit_Hook_GroupsByEvent(t *testing.T) {
 	}
 }
 
+// A hook spec carrying a command array emits one [[hooks.<event>]] block per command.
+// Same matcher + event share the array; codex's TOML schema has a single command field.
+func TestEmit_Hook_CommandArrayExpandsToMultipleBlocks(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindHook,
+			Name: "post-format",
+			Meta: map[string]any{
+				"event":   "PostToolUse",
+				"matcher": "Edit|Write",
+				"command": []any{".codex/hooks/format-php.sh", ".codex/hooks/format-phel.sh"},
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	for _, want := range []string{
+		`command = ".codex/hooks/format-php.sh"`,
+		`command = ".codex/hooks/format-phel.sh"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %s", want, got)
+		}
+	}
+	if strings.Count(got, "[[hooks.PostToolUse]]") != 2 {
+		t.Errorf("expected 2 [[hooks.PostToolUse]] blocks for 2-command array, got:\n%s", got)
+	}
+	if strings.Count(got, `matcher = "Edit|Write"`) != 2 {
+		t.Errorf("expected matcher repeated for each block, got:\n%s", got)
+	}
+}
+
 // Hooks with no event are skipped.
 func TestEmit_Hook_SkipsWhenNoEvent(t *testing.T) {
 	dir := testutil.TempCwd(t)

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -64,7 +64,27 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.EmitLegacyRulesFile(b, cfg, target, emit.MergedOpts{Title: "GEMINI.md"}, dryRun); err != nil {
 		return err
 	}
-	return emitSettings(b, emit.OutputMCPFile(cfg, target, defaultSettingsFile), dryRun)
+	if err := emitSettings(b, emit.OutputMCPFile(cfg, target, defaultSettingsFile), dryRun); err != nil {
+		return err
+	}
+	return materializeHookScripts(b.Hooks, dryRun)
+}
+
+// materializeHookScripts copies each hook's stashed script body from
+// `.agnostic-ai/scripts/` into `.gemini/hooks/` so the emitted
+// settings.json has the actual script alongside the path it references.
+func materializeHookScripts(hooks []spec.Entry, dryRun bool) error {
+	for _, h := range hooks {
+		cmds := hookCommands(h.Meta["command"])
+		for _, raw := range cmds {
+			sourceTool, _ := emit.SourceToolFromHookCommand(raw)
+			rewritten := emit.RewriteHookPath(raw, target)
+			if err := emit.MaterializeHookScript(rewritten, target, sourceTool, dryRun); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // emitSettings writes (or merges into) .gemini/settings.json with the

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -148,7 +148,7 @@ func buildHooks(hooks []spec.Entry) map[string]any {
 			continue
 		}
 		for _, cmd := range cmds {
-			entry := map[string]any{"command": cmd}
+			entry := map[string]any{"command": emit.RewriteHookPath(cmd, target)}
 			if matcher != "" {
 				entry["matcher"] = matcher
 			}

--- a/internal/adapters/internal/emit/hook_path.go
+++ b/internal/adapters/internal/emit/hook_path.go
@@ -1,0 +1,49 @@
+// Package emit hook_path normalises hook command paths so a spec
+// authored against one tool's hooks directory still runs when emitted
+// to a different target.
+//
+// Hook scripts conventionally live at `.<tool>/hooks/<basename>` (Claude
+// uses `.claude/hooks/`, Codex `.codex/hooks/`, Gemini `.gemini/hooks/`).
+// When the source-of-truth spec was imported from one tool it captures
+// that tool's prefix verbatim; without rewriting, a sync to a sibling
+// target would emit a settings file referencing a path that does not
+// exist under that target.
+//
+// `RewriteHookPath` rewrites the leading `.<other-tool>/hooks/` segment
+// to `.<target>/hooks/` whenever it sees a sibling-tool prefix. Paths
+// that do not start with one of the recognised prefixes pass through
+// unchanged so absolute paths, project-relative scripts (`scripts/x.sh`),
+// and arbitrary commands (`gofmt`, `bash -c '…'`) keep their author's
+// intent.
+package emit
+
+import "strings"
+
+// hookSiblingPrefixes enumerates the per-tool hook directories the
+// rewriter recognises. Anything outside this list is treated as user
+// content and left untouched.
+var hookSiblingPrefixes = []string{
+	".claude/hooks/",
+	".codex/hooks/",
+	".gemini/hooks/",
+}
+
+// RewriteHookPath returns cmd with a recognised sibling-tool hook
+// directory prefix replaced by `.<target>/hooks/`. When cmd does not
+// start with any recognised prefix it is returned unchanged so non-hook
+// commands stay verbatim.
+func RewriteHookPath(cmd, target string) string {
+	if cmd == "" || target == "" {
+		return cmd
+	}
+	for _, prefix := range hookSiblingPrefixes {
+		if strings.HasPrefix(cmd, prefix) {
+			return "." + target + "/hooks/" + cmd[len(prefix):]
+		}
+		quoted := `"` + prefix
+		if strings.HasPrefix(cmd, quoted) {
+			return `"` + "." + target + "/hooks/" + cmd[len(quoted):]
+		}
+	}
+	return cmd
+}

--- a/internal/adapters/internal/emit/hook_path.go
+++ b/internal/adapters/internal/emit/hook_path.go
@@ -1,4 +1,4 @@
-// Package emit hook_path normalises hook command paths so a spec
+// Package emit hook_path normalizes hook command paths so a spec
 // authored against one tool's hooks directory still runs when emitted
 // to a different target.
 //
@@ -11,7 +11,7 @@
 //
 // `RewriteHookPath` rewrites the leading `.<other-tool>/hooks/` segment
 // to `.<target>/hooks/` whenever it sees a sibling-tool prefix. Paths
-// that do not start with one of the recognised prefixes pass through
+// that do not start with one of the recognized prefixes pass through
 // unchanged so absolute paths, project-relative scripts (`scripts/x.sh`),
 // and arbitrary commands (`gofmt`, `bash -c '…'`) keep their author's
 // intent.
@@ -20,7 +20,7 @@ package emit
 import "strings"
 
 // hookSiblingPrefixes enumerates the per-tool hook directories the
-// rewriter recognises. Anything outside this list is treated as user
+// rewriter recognizes. Anything outside this list is treated as user
 // content and left untouched.
 var hookSiblingPrefixes = []string{
 	".claude/hooks/",
@@ -28,9 +28,9 @@ var hookSiblingPrefixes = []string{
 	".gemini/hooks/",
 }
 
-// RewriteHookPath returns cmd with a recognised sibling-tool hook
+// RewriteHookPath returns cmd with a recognized sibling-tool hook
 // directory prefix replaced by `.<target>/hooks/`. When cmd does not
-// start with any recognised prefix it is returned unchanged so non-hook
+// start with any recognized prefix it is returned unchanged so non-hook
 // commands stay verbatim.
 func RewriteHookPath(cmd, target string) string {
 	if cmd == "" || target == "" {

--- a/internal/adapters/internal/emit/hook_path_test.go
+++ b/internal/adapters/internal/emit/hook_path_test.go
@@ -1,0 +1,59 @@
+package emit
+
+import "testing"
+
+func TestRewriteHookPath_TranslatesSiblingPrefix(t *testing.T) {
+	cases := []struct {
+		name, cmd, target, want string
+	}{
+		{
+			name:   "claude to codex",
+			cmd:    ".claude/hooks/format-php.sh",
+			target: "codex",
+			want:   ".codex/hooks/format-php.sh",
+		},
+		{
+			name:   "codex to claude",
+			cmd:    ".codex/hooks/protect-files.sh",
+			target: "claude",
+			want:   ".claude/hooks/protect-files.sh",
+		},
+		{
+			name:   "gemini to claude",
+			cmd:    ".gemini/hooks/run.sh",
+			target: "claude",
+			want:   ".claude/hooks/run.sh",
+		},
+		{
+			name:   "same-target prefix is a no-op",
+			cmd:    ".claude/hooks/x.sh",
+			target: "claude",
+			want:   ".claude/hooks/x.sh",
+		},
+		{
+			name:   "non-hook command passes through",
+			cmd:    "gofmt && go vet ./...",
+			target: "claude",
+			want:   "gofmt && go vet ./...",
+		},
+		{
+			name:   "quoted sibling path keeps the quote",
+			cmd:    `".claude/hooks/x.sh"`,
+			target: "codex",
+			want:   `".codex/hooks/x.sh"`,
+		},
+		{
+			name:   "empty command stays empty",
+			cmd:    "",
+			target: "codex",
+			want:   "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RewriteHookPath(c.cmd, c.target); got != c.want {
+				t.Errorf("RewriteHookPath(%q, %q) = %q, want %q", c.cmd, c.target, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/internal/emit/hook_scripts.go
+++ b/internal/adapters/internal/emit/hook_scripts.go
@@ -1,4 +1,4 @@
-// Package emit hook_scripts materialises hook script bodies stored
+// Package emit hook_scripts materializes hook script bodies stored
 // under `.agnostic-ai/scripts/` into the target's `.<target>/hooks/`
 // directory at emit time. Pairing this with `RewriteHookPath` lets a
 // project keep `.<tool>/` gitignored: a fresh checkout reconstructs the
@@ -70,7 +70,7 @@ func MaterializeHookScript(cmd, target, sourceTool string, dryRun bool) error {
 }
 
 // SourceToolFromHookCommand extracts the leading `.<tool>/hooks/`
-// segment from cmd. Returns ("", false) when cmd is not a recognised
+// segment from cmd. Returns ("", false) when cmd is not a recognized
 // sibling-tool hook path. Used by adapters to remember the spec origin
 // before RewriteHookPath rewrites it to their own prefix.
 func SourceToolFromHookCommand(cmd string) (string, bool) {

--- a/internal/adapters/internal/emit/hook_scripts.go
+++ b/internal/adapters/internal/emit/hook_scripts.go
@@ -1,0 +1,158 @@
+// Package emit hook_scripts materialises hook script bodies stored
+// under `.agnostic-ai/scripts/` into the target's `.<target>/hooks/`
+// directory at emit time. Pairing this with `RewriteHookPath` lets a
+// project keep `.<tool>/` gitignored: a fresh checkout reconstructs the
+// per-tool hooks dir from the tracked scripts stash on every `sync`.
+//
+// Lookup precedence for a hook command of the form
+// `.<source-tool>/hooks/<basename>`:
+//
+//  1. `.agnostic-ai/scripts/<target>/<basename>`       — explicit
+//     target-specific variant (e.g. codex needs more privileges than
+//     claude on the same script).
+//  2. `.agnostic-ai/scripts/<source-tool>/<basename>`  — the body
+//     captured at the spec's origin.
+//  3. `.agnostic-ai/scripts/<basename>`                — unified
+//     variant shared across every target.
+//
+// When no candidate is on disk the helper is a no-op: hand-authored
+// hook commands (`gofmt`, `bash -c '…'`, absolute paths) carry no body
+// to ship.
+package emit
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// agnosticScriptsDir is the project-relative root for stashed hook
+// script bodies. Lives under the managed `.agnostic-ai/` tree so
+// gitignoring per-tool hook directories does not lose the bodies.
+const agnosticScriptsDir = ".agnostic-ai/scripts"
+
+// MaterializeHookScript copies the script body that backs cmd into the
+// target's hooks directory when a stashed copy exists. Returns nil and
+// writes nothing when cmd is not a sibling-tool hook path or no body is
+// stashed; surfaces every other read/write error so callers can fail
+// loudly on permission problems.
+//
+// `cmd` is the rewritten command path (post-RewriteHookPath), pointing
+// at `.<target>/hooks/<basename>`. `sourceTool` carries the spec
+// origin so the lookup falls back to that tool's stashed body when no
+// target-specific variant exists.
+func MaterializeHookScript(cmd, target, sourceTool string, dryRun bool) error {
+	basename, ok := hookBasename(cmd, target)
+	if !ok {
+		return nil
+	}
+	body, mode, ok, err := findHookScriptBody(basename, target, sourceTool)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	dst := "." + target + "/hooks/" + basename
+	if dryRun {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+	}
+	if err := os.WriteFile(dst, body, mode); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
+}
+
+// SourceToolFromHookCommand extracts the leading `.<tool>/hooks/`
+// segment from cmd. Returns ("", false) when cmd is not a recognised
+// sibling-tool hook path. Used by adapters to remember the spec origin
+// before RewriteHookPath rewrites it to their own prefix.
+func SourceToolFromHookCommand(cmd string) (string, bool) {
+	if !strings.HasPrefix(cmd, ".") {
+		return "", false
+	}
+	rest := cmd[1:]
+	slash := strings.IndexByte(rest, '/')
+	if slash <= 0 {
+		return "", false
+	}
+	tool := rest[:slash]
+	if !strings.HasPrefix(rest[slash:], "/hooks/") {
+		return "", false
+	}
+	return tool, true
+}
+
+// hookBasename returns the script filename portion of cmd when cmd
+// points at `.<target>/hooks/<basename>` (the post-rewrite form). The
+// basename must contain no further slashes so an absolute path or a
+// nested directory does not produce a misleading write target.
+func hookBasename(cmd, target string) (string, bool) {
+	prefix := "." + target + "/hooks/"
+	if !strings.HasPrefix(cmd, prefix) {
+		return "", false
+	}
+	rest := cmd[len(prefix):]
+	if rest == "" || strings.ContainsRune(rest, '/') {
+		return "", false
+	}
+	return rest, true
+}
+
+// findHookScriptBody walks the agnostic scripts stash in lookup order
+// and returns the first non-empty body found. The boolean reports
+// whether anything was loaded; the error channel surfaces real I/O
+// failures while a plain "no script stashed" is communicated via the
+// (nil, 0, false, nil) return.
+func findHookScriptBody(basename, target, sourceTool string) ([]byte, os.FileMode, bool, error) {
+	candidates := []string{
+		filepath.Join(agnosticScriptsDir, target, basename),
+	}
+	if sourceTool != "" && sourceTool != target {
+		candidates = append(candidates, filepath.Join(agnosticScriptsDir, sourceTool, basename))
+	}
+	candidates = append(candidates, filepath.Join(agnosticScriptsDir, basename))
+
+	for _, path := range candidates {
+		body, mode, ok, err := readHookCandidate(path)
+		if err != nil {
+			return nil, 0, false, err
+		}
+		if ok {
+			return body, mode, true, nil
+		}
+	}
+	return nil, 0, false, nil
+}
+
+// readHookCandidate reads path and returns (body, mode, true) when the
+// file exists. Returns (nil, 0, false, nil) when path is absent so the
+// caller can try the next candidate without special-casing fs.ErrNotExist
+// in every loop.
+func readHookCandidate(path string) ([]byte, os.FileMode, bool, error) {
+	info, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, 0, false, nil
+	}
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, 0, false, nil
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	mode := info.Mode().Perm()
+	if mode == 0 {
+		mode = 0o755
+	}
+	return body, mode, true, nil
+}

--- a/internal/adapters/internal/emit/hook_scripts_test.go
+++ b/internal/adapters/internal/emit/hook_scripts_test.go
@@ -1,0 +1,135 @@
+package emit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSourceToolFromHookCommand(t *testing.T) {
+	cases := []struct {
+		cmd, wantTool string
+		wantOK        bool
+	}{
+		{".claude/hooks/x.sh", "claude", true},
+		{".codex/hooks/x.sh", "codex", true},
+		{".gemini/hooks/x.sh", "gemini", true},
+		{"gofmt", "", false},
+		{".claude/agents/y.md", "", false},
+		{"./hooks/x.sh", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		tool, ok := SourceToolFromHookCommand(c.cmd)
+		if tool != c.wantTool || ok != c.wantOK {
+			t.Errorf("SourceToolFromHookCommand(%q) = (%q, %v), want (%q, %v)", c.cmd, tool, ok, c.wantTool, c.wantOK)
+		}
+	}
+}
+
+func TestMaterializeHookScript_CopiesSourceToolStashIntoTargetHooks(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := os.MkdirAll(".agnostic-ai/scripts/claude", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("#!/usr/bin/env bash\necho protect\n")
+	if err := os.WriteFile(".agnostic-ai/scripts/claude/protect-files.sh", body, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeHookScript(".codex/hooks/protect-files.sh", "codex", "claude", false); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join(dir, ".codex/hooks/protect-files.sh"))
+	if err != nil {
+		t.Fatalf("expected emitted hook script under .codex/hooks/: %v", err)
+	}
+	if string(out) != string(body) {
+		t.Errorf("body mismatch: %q vs %q", out, body)
+	}
+	info, err := os.Stat(filepath.Join(dir, ".codex/hooks/protect-files.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Errorf("expected executable bit preserved, got %v", info.Mode().Perm())
+	}
+}
+
+func TestMaterializeHookScript_TargetVariantWinsOverSourceTool(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := os.MkdirAll(".agnostic-ai/scripts/codex", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(".agnostic-ai/scripts/claude", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexBody := []byte("codex-specific\n")
+	claudeBody := []byte("claude-specific\n")
+	if err := os.WriteFile(".agnostic-ai/scripts/codex/protect-files.sh", codexBody, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(".agnostic-ai/scripts/claude/protect-files.sh", claudeBody, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeHookScript(".codex/hooks/protect-files.sh", "codex", "claude", false); err != nil {
+		t.Fatal(err)
+	}
+	out, err := os.ReadFile(filepath.Join(dir, ".codex/hooks/protect-files.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(codexBody) {
+		t.Errorf("expected target-specific variant to win, got %q", out)
+	}
+}
+
+func TestMaterializeHookScript_FallsBackToUnifiedScript(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := os.MkdirAll(".agnostic-ai/scripts", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("unified\n")
+	if err := os.WriteFile(".agnostic-ai/scripts/protect-files.sh", body, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeHookScript(".codex/hooks/protect-files.sh", "codex", "claude", false); err != nil {
+		t.Fatal(err)
+	}
+	out, err := os.ReadFile(filepath.Join(dir, ".codex/hooks/protect-files.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(body) {
+		t.Errorf("expected unified variant body, got %q", out)
+	}
+}
+
+func TestMaterializeHookScript_NoStashIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := MaterializeHookScript(".codex/hooks/missing.sh", "codex", "claude", false); err != nil {
+		t.Errorf("missing stash should be a no-op, got error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".codex/hooks/missing.sh")); !os.IsNotExist(err) {
+		t.Errorf("no body should be created when stash is empty, err=%v", err)
+	}
+}
+
+func TestMaterializeHookScript_IgnoresNonHookCommand(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := MaterializeHookScript("gofmt", "codex", "", false); err != nil {
+		t.Errorf("expected no-op for non-hook command, got %v", err)
+	}
+}

--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
@@ -23,6 +24,11 @@ import (
 // Targets that opted into the legacy concatenated rules-file layout
 // via `outputs.<target>.rules-file` are skipped: the adapter owns the
 // entry-point write in that case.
+//
+// A hand-authored entry-point file (no agnostic-ai provenance marker)
+// triggers a one-line warning before the overwrite so the user knows
+// their content is about to be replaced. This is the same heuristic
+// the importer uses to skip files it did not write.
 func writeAgnosticEntryPoints(cfg *config.Config, targets []string, dryRun bool) error {
 	body, err := resolveAgnosticBody(cfg, dryRun)
 	if err != nil {
@@ -39,11 +45,34 @@ func writeAgnosticEntryPoints(cfg *config.Config, targets []string, dryRun bool)
 			continue
 		}
 		seen[path] = true
+		warnOnHandAuthoredEntryPoint(path)
 		if err := adapters.WriteFile(path, rendered, dryRun); err != nil {
 			return fmt.Errorf("write entry-point %s: %w", path, err)
 		}
 	}
 	return nil
+}
+
+// warnOnHandAuthoredEntryPoint prints a single-line warning when path
+// exists, has non-empty content, and lacks the agnostic-ai provenance
+// marker. The marker is the same one `header.Has` uses to recognise a
+// generated file. Read errors are swallowed: sync proceeds with the
+// overwrite either way (preserving the historic behaviour) but a quiet
+// I/O failure does not block the user.
+func warnOnHandAuthoredEntryPoint(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	body := strings.TrimSpace(string(data))
+	if body == "" {
+		return
+	}
+	if header.Has(string(data)) {
+		return
+	}
+	summaryf("  ! %s appears hand-authored (no agnostic-ai header) — overwriting with the canonical pointer body. Move custom content into %s first to keep it.\n",
+		path, adapters.AgnosticEntryPointPath)
 }
 
 // resolveAgnosticBody returns the raw (no header) body for entry-point files.

--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -55,9 +55,9 @@ func writeAgnosticEntryPoints(cfg *config.Config, targets []string, dryRun bool)
 
 // warnOnHandAuthoredEntryPoint prints a single-line warning when path
 // exists, has non-empty content, and lacks the agnostic-ai provenance
-// marker. The marker is the same one `header.Has` uses to recognise a
+// marker. The marker is the same one `header.Has` uses to recognize a
 // generated file. Read errors are swallowed: sync proceeds with the
-// overwrite either way (preserving the historic behaviour) but a quiet
+// overwrite either way (preserving the historic behavior) but a quiet
 // I/O failure does not block the user.
 func warnOnHandAuthoredEntryPoint(path string) {
 	data, err := os.ReadFile(path)

--- a/internal/cli/entrypoint_test.go
+++ b/internal/cli/entrypoint_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,56 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
+
+// A hand-authored entry-point file (no agnostic-ai provenance marker)
+// must trigger a one-line warning before sync overwrites it so the
+// user knows their content is about to be replaced.
+func TestWriteAgnosticEntryPoints_WarnsBeforeOverwritingHandAuthored(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	// Pre-existing root CLAUDE.md without provenance header.
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("# My Hand-Written CLAUDE.md\n\nKeep me.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAgnosticFile(t, "# Pointer body\n")
+
+	var buf bytes.Buffer
+	prev := logOut
+	logOut = &buf
+	defer func() { logOut = prev }()
+
+	cfg := &config.Config{Targets: []string{"claude"}}
+	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "CLAUDE.md appears hand-authored") {
+		t.Errorf("expected hand-authored warning, got:\n%s", buf.String())
+	}
+}
+
+// A subsequent sync with a generated header on disk must NOT trigger
+// the warning — the file is already managed.
+func TestWriteAgnosticEntryPoints_NoWarnWhenGeneratedHeaderPresent(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	managed := header.With("# Pointer body\n", header.FormatMarkdown)
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(managed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAgnosticFile(t, "# Pointer body\n")
+
+	var buf bytes.Buffer
+	prev := logOut
+	logOut = &buf
+	defer func() { logOut = prev }()
+
+	cfg := &config.Config{Targets: []string{"claude"}}
+	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "appears hand-authored") {
+		t.Errorf("expected no warning on already-managed file, got:\n%s", buf.String())
+	}
+}
 
 func TestResolveAgnosticBody_SeedsTemplateWhenAbsent(t *testing.T) {
 	testutil.TempCwd(t)

--- a/internal/cli/import_aider.go
+++ b/internal/cli/import_aider.go
@@ -19,7 +19,7 @@ func importFromAider(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, aiderMainFile); err != nil {
+	if _, err := mirrorMainFile(root, aiderMainFile); err != nil {
 		return err
 	}
 	summaryf("imported %d rules\n", n)

--- a/internal/cli/import_amp.go
+++ b/internal/cli/import_amp.go
@@ -32,7 +32,7 @@ func importFromAmp(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, ampMainFile); err != nil {
+	if _, err := mirrorMainFile(root, ampMainFile); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -62,13 +62,16 @@ func importFromClaude(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorClaudeMainFile(root); err != nil {
+	mainSeeded, err := mirrorClaudeMainFile(root)
+	if err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks, %d mcps, %d commands\n",
 		c.rules, c.agents, c.skills, c.hooks, c.mcps, c.commands)
-	summaryf("  → %s seeded from %s (commit this file — sync distributes it to all targets)\n",
-		agnosticMainFile, claudeMainFile)
+	if mainSeeded {
+		summaryf("  → %s seeded from %s (commit this file — sync distributes it to all targets)\n",
+			agnosticMainFile, claudeMainFile)
+	}
 	if overlaySeeded {
 		summaryf("  → %s seeded from %s/settings.json (carries non-hook settings across re-syncs)\n",
 			claudeOverlayRelPath(), claudeDir)
@@ -78,43 +81,48 @@ func importFromClaude(root string, src config.Sources) error {
 }
 
 // mirrorClaudeMainFile mirrors <root>/CLAUDE.md to
-// <root>/.agnostic-ai/AGNOSTIC_AI.md.
-func mirrorClaudeMainFile(root string) error {
+// <root>/.agnostic-ai/AGNOSTIC_AI.md. Returns (true, nil) when the
+// mirror actually wrote so callers can suppress a misleading summary
+// line on a CLAUDE.md-less project.
+func mirrorClaudeMainFile(root string) (bool, error) {
 	return mirrorMainFile(root, claudeMainFile)
 }
 
 // mirrorMainFile copies <root>/<srcName> byte-for-byte to
-// <root>/.agnostic-ai/AGNOSTIC_AI.md. No-op when the source is absent.
-// Each importer calls this with the target's own top-level
-// instructions filename so the project keeps a CLI-agnostic copy
-// under the managed directory. Later imports overwrite earlier
+// <root>/.agnostic-ai/AGNOSTIC_AI.md. Returns (false, nil) when the
+// source is absent so the caller can skip its "seeded from <src>"
+// summary line. Each importer calls this with the target's own
+// top-level instructions filename so the project keeps a CLI-agnostic
+// copy under the managed directory. Later imports overwrite earlier
 // mirrors (last-import wins).
-func mirrorMainFile(root, srcName string) error {
+func mirrorMainFile(root, srcName string) (bool, error) {
 	src := filepath.Join(root, srcName)
 	dst := filepath.Join(root, agnosticMainFile)
-	if err := copyFileIfExists(src, dst); err != nil {
-		return fmt.Errorf("mirror %s: %w", srcName, err)
+	wrote, err := copyFileIfExists(src, dst)
+	if err != nil {
+		return false, fmt.Errorf("mirror %s: %w", srcName, err)
 	}
-	return nil
+	return wrote, nil
 }
 
-// copyFileIfExists copies src to dst byte-for-byte. Returns nil when
-// src is absent; surfaces every other read/write error.
-func copyFileIfExists(src, dst string) error {
+// copyFileIfExists copies src to dst byte-for-byte. Returns (false,
+// nil) when src is absent so the caller can distinguish a real copy
+// from a no-op; surfaces every other read/write error.
+func copyFileIfExists(src, dst string) (bool, error) {
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
-		return nil
+		return false, nil
 	}
 	if err != nil {
-		return fmt.Errorf("read %s: %w", src, err)
+		return false, fmt.Errorf("read %s: %w", src, err)
 	}
 	if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
 	if err := importWriteFile(dst, data, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", dst, err)
+		return false, fmt.Errorf("write %s: %w", dst, err)
 	}
-	return nil
+	return true, nil
 }
 
 // copyMarkdownDir copies every top-level *.md file from srcDir into

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -49,6 +49,9 @@ func importFromClaude(root string, src config.Sources) error {
 	if c.hooks, err = importClaudeHooks(root, filepath.Join(root, src.Hooks)); err != nil {
 		return err
 	}
+	if err := captureHookScripts(root, "claude"); err != nil {
+		return err
+	}
 	if c.mcps, err = importClaudeMCP(root, filepath.Join(root, src.MCPs)); err != nil {
 		return err
 	}

--- a/internal/cli/import_claude_hooks.go
+++ b/internal/cli/import_claude_hooks.go
@@ -13,8 +13,10 @@ import (
 )
 
 type claudeHookCommand struct {
-	Type    string `json:"type"`
-	Command string `json:"command"`
+	Type          string `json:"type"`
+	Command       string `json:"command"`
+	Timeout       int    `json:"timeout,omitempty"`
+	StatusMessage string `json:"statusMessage,omitempty"`
 }
 
 type claudeHookGroup struct {
@@ -60,9 +62,18 @@ func importClaudeHooks(root, dstDir string) (int, error) {
 	for _, event := range events {
 		for _, g := range s.Hooks[event] {
 			cmds := make([]string, 0, len(g.Hooks))
+			timeout := 0
+			statusMessage := ""
 			for _, h := range g.Hooks {
-				if h.Command != "" {
-					cmds = append(cmds, h.Command)
+				if h.Command == "" {
+					continue
+				}
+				cmds = append(cmds, h.Command)
+				if h.Timeout != 0 && timeout == 0 {
+					timeout = h.Timeout
+				}
+				if h.StatusMessage != "" && statusMessage == "" {
+					statusMessage = h.StatusMessage
 				}
 			}
 			if len(cmds) == 0 {
@@ -78,6 +89,12 @@ func importClaudeHooks(root, dstDir string) (int, error) {
 				doc["command"] = cmds[0]
 			} else {
 				doc["command"] = cmds
+			}
+			if timeout != 0 {
+				doc["timeout"] = timeout
+			}
+			if statusMessage != "" {
+				doc["statusMessage"] = statusMessage
 			}
 			raw, err := yaml.Marshal(doc)
 			if err != nil {

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -400,6 +401,31 @@ func TestImportFromClaude_PreservesHookTimeoutAndStatusMessage(t *testing.T) {
 // `.agnostic-ai/scripts/claude/` so a gitignored .claude/ tree can be
 // reconstructed by the next `sync`. Executable bit must survive the
 // copy.
+// The claude importer previously claimed "AGNOSTIC_AI.md seeded from
+// CLAUDE.md" even when the project had no root CLAUDE.md (the common
+// case when claude rules live entirely in `.claude/`). Verify the line
+// only prints when the mirror actually wrote.
+func TestImportFromClaude_SkipsMainFileSummaryWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	// No root CLAUDE.md, but settings.json forces import to run.
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), `{"includeCoAuthoredBy": false}`)
+
+	var buf bytes.Buffer
+	prev := logOut
+	logOut = &buf
+	defer func() { logOut = prev }()
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "AGNOSTIC_AI.md seeded from CLAUDE.md") {
+		t.Errorf("summary should not claim AGNOSTIC_AI.md was seeded when CLAUDE.md is absent:\n%s", buf.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".agnostic-ai", "AGNOSTIC_AI.md")); !os.IsNotExist(err) {
+		t.Errorf("expected no AGNOSTIC_AI.md when no source existed, err=%v", err)
+	}
+}
+
 func TestImportFromClaude_CapturesHookScriptBodies(t *testing.T) {
 	dir := t.TempDir()
 	body := "#!/usr/bin/env bash\necho protect\n"

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -364,6 +364,38 @@ func TestImportFromClaude_MultipleHookCommandsPerGroup(t *testing.T) {
 	}
 }
 
+// timeout and statusMessage are first-class Claude hook fields that
+// must round-trip through the spec, not be silently dropped during
+// import. Spec is the source of truth; on next sync the emit side
+// re-populates the fields from these Meta keys.
+func TestImportFromClaude_PreservesHookTimeoutAndStatusMessage(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "hooks": {
+    "PostToolUse": [
+      {"matcher": "Edit|Write", "hooks": [
+        {"type": "command", "command": "fmt", "timeout": 30, "statusMessage": "Formatting"},
+        {"type": "command", "command": "lint", "timeout": 30, "statusMessage": "Formatting"}
+      ]}
+    ]
+  }
+}`
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), settings)
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	path := findOneHookFile(t, filepath.Join(dir, "hooks"), "posttooluse")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"timeout: 30", "statusMessage: Formatting"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("expected %q in %s", want, data)
+		}
+	}
+}
+
 func TestImportFromClaude_WritesSettingsOverlay(t *testing.T) {
 	dir := t.TempDir()
 	settings := `{

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -396,6 +396,39 @@ func TestImportFromClaude_PreservesHookTimeoutAndStatusMessage(t *testing.T) {
 	}
 }
 
+// Hook script bodies under `.claude/hooks/` are captured into
+// `.agnostic-ai/scripts/claude/` so a gitignored .claude/ tree can be
+// reconstructed by the next `sync`. Executable bit must survive the
+// copy.
+func TestImportFromClaude_CapturesHookScriptBodies(t *testing.T) {
+	dir := t.TempDir()
+	body := "#!/usr/bin/env bash\necho protect\n"
+	if err := os.MkdirAll(filepath.Join(dir, ".claude", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".claude", "hooks", "protect-files.sh"), []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, ".agnostic-ai", "scripts", "claude", "protect-files.sh")
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("expected stashed script body: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("body mismatch: %q vs %q", got, body)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Errorf("expected executable bit preserved, got %v", info.Mode().Perm())
+	}
+}
+
 func TestImportFromClaude_WritesSettingsOverlay(t *testing.T) {
 	dir := t.TempDir()
 	settings := `{

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -36,6 +36,9 @@ func importFromCodex(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
+	if err := captureHookScripts(root, "codex"); err != nil {
+		return err
+	}
 	commands, err := importCodexCommands(root, filepath.Join(root, src.Commands))
 	if err != nil {
 		return err

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -272,6 +272,17 @@ func dedupSlug(used map[string]int, slug string) string {
 }
 
 func writeCodexRule(dstDir, name, description, globs, body string) error {
+	path := filepath.Join(dstDir, name+".md")
+
+	// A claude-imported rule already at this slug owns the canonical
+	// content; emit a one-line skip notice and keep the existing spec
+	// rather than blindly overwriting it with the AGENTS.md slice. The
+	// user can merge by hand if codex's body has unique content.
+	if existing, err := os.ReadFile(path); err == nil && len(existing) > 0 {
+		summaryf("  ! skipped %s — already exists (likely from a prior import); review codex AGENTS.md for unique content to merge by hand\n", path)
+		return nil
+	}
+
 	var fm strings.Builder
 	fm.WriteString("---\nname: " + name + "\n")
 	if description != "" {
@@ -284,7 +295,6 @@ func writeCodexRule(dstDir, name, description, globs, body string) error {
 	fm.WriteString(strings.TrimRight(body, "\n"))
 	fm.WriteString("\n")
 
-	path := filepath.Join(dstDir, name+".md")
 	if err := importWriteFile(path, []byte(fm.String()), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -47,7 +47,7 @@ func importFromCodex(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, "AGENTS.md"); err != nil {
+	if _, err := mirrorMainFile(root, "AGENTS.md"); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks, %d mcps, %d commands\n",

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -51,21 +51,40 @@ func importCodexAgents(root, dstDir string) (int, error) {
 			if err != nil {
 				return count, err
 			}
-			name := strings.TrimSuffix(e.Name(), ".toml")
+			tomlName := strings.TrimSuffix(e.Name(), ".toml")
 			if n, _ := doc["name"].(string); n != "" {
-				name = n
+				tomlName = n
 			}
-			if seen[name] {
+			// Canonicalise filename to dash-case so claude-imported
+			// `changelog-keeper.md` and codex-imported
+			// `changelog_keeper` resolve to the same spec on disk.
+			// The original underscore form is preserved verbatim in
+			// the frontmatter's `name:` field so codex emit keeps the
+			// TOML `name = "changelog_keeper"` value Codex expects.
+			canonical := canonicalSpecSlug(tomlName)
+			if seen[canonical] {
 				continue
 			}
-			seen[name] = true
-			if err := writeCodexAgentSpec(dstDir, name, doc); err != nil {
+			seen[canonical] = true
+
+			wrote, err := mergeOrWriteCodexAgentSpec(dstDir, canonical, tomlName, doc)
+			if err != nil {
 				return count, err
 			}
-			count++
+			if wrote {
+				count++
+			}
 		}
 	}
 	return count, nil
+}
+
+// canonicalSpecSlug returns name with `_` rewritten to `-` and the
+// result lowercased. Used to dedupe filenames between tools that pick
+// different separator conventions (claude uses dashes, codex uses
+// underscores).
+func canonicalSpecSlug(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "_", "-"))
 }
 
 func readCodexAgentTOML(path string) (map[string]any, error) {
@@ -87,14 +106,50 @@ var codexAgentTopLevel = map[string]bool{
 	"developer_instructions": true,
 }
 
-// writeCodexAgentSpec renders a codex agent TOML as an agnostic-ai agent
-// spec (.md with frontmatter + body). Known top-level keys map directly;
-// every other key lands under `x-codex` so the emitter round-trips them.
-func writeCodexAgentSpec(dstDir, name string, doc map[string]any) error {
+// mergeOrWriteCodexAgentSpec writes a codex agent spec at
+// `<dstDir>/<canonical>.md`. When a claude-imported file already lives
+// at that path the codex-specific keys (`x-codex.*` and any missing
+// top-level fields) are layered into it without overwriting the body or
+// the existing `name:` slug. Returns (wrote, err) where `wrote` is true
+// for both fresh writes and merges so the caller still counts the spec.
+//
+// Filename canonicalisation collapses claude's dashed convention and
+// codex's underscored convention onto the same on-disk file so a
+// project that imports both tools no longer carries duplicate specs
+// (changelog-keeper.md + changelog_keeper.md). When the codex `name`
+// differs from the canonical slug it lands under `x-codex.name` so the
+// codex emitter still produces TOML with the runtime-expected
+// underscored identifier.
+func mergeOrWriteCodexAgentSpec(dstDir, canonical, codexName string, doc map[string]any) (bool, error) {
+	path := filepath.Join(dstDir, canonical+".md")
+	existing, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return true, writeCodexAgentSpec(path, canonical, codexName, doc)
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	merged, err := mergeCodexAgentIntoExisting(string(existing), codexName, doc)
+	if err != nil {
+		return false, err
+	}
+	if err := importWriteFile(path, []byte(merged), 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// writeCodexAgentSpec renders a codex agent TOML as a fresh
+// agnostic-ai spec under path. Known top-level keys map directly into
+// the frontmatter; every other key lands under `x-codex`. `name:` uses
+// the canonical (dash) slug so the on-disk filename and frontmatter
+// stay aligned; when the codex runtime name differs it is preserved
+// under `x-codex.name`.
+func writeCodexAgentSpec(path, canonical, codexName string, doc map[string]any) error {
 	body, _ := doc["developer_instructions"].(string)
 	body = strings.TrimRight(body, "\n")
 
-	fm := map[string]any{"name": name}
+	fm := map[string]any{"name": canonical}
 	if d, _ := doc["description"].(string); d != "" {
 		fm["description"] = d
 	}
@@ -108,21 +163,95 @@ func writeCodexAgentSpec(dstDir, name string, doc map[string]any) error {
 		}
 		xcodex[key] = val
 	}
+	if codexName != "" && codexName != canonical {
+		xcodex["name"] = codexName
+	}
 	if len(xcodex) > 0 {
 		fm["x-codex"] = xcodex
 	}
 
 	raw, err := yaml.Marshal(fm)
 	if err != nil {
-		return fmt.Errorf("marshal %s: %w", name, err)
+		return fmt.Errorf("marshal %s: %w", canonical, err)
 	}
 	out := "---\n" + string(raw) + "---\n\n" + body + "\n"
 
-	path := filepath.Join(dstDir, name+".md")
 	if err := importWriteFile(path, []byte(out), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
+}
+
+// mergeCodexAgentIntoExisting parses an already-imported agent spec
+// (claude origin) and layers codex-specific frontmatter on top without
+// disturbing the body or existing top-level keys. Only the keys the
+// codex TOML actually provides get written, so claude's richer body
+// + description survive even when both tools defined the agent.
+func mergeCodexAgentIntoExisting(existing, codexName string, doc map[string]any) (string, error) {
+	front, body, ok := splitCodexAgentFrontmatter(existing)
+	if !ok {
+		return existing, nil
+	}
+	fm := map[string]any{}
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return "", fmt.Errorf("parse existing frontmatter: %w", err)
+	}
+	if _, has := fm["description"]; !has {
+		if d, _ := doc["description"].(string); d != "" {
+			fm["description"] = d
+		}
+	}
+	if _, has := fm["model"]; !has {
+		if m, _ := doc["model"].(string); m != "" {
+			fm["model"] = m
+		}
+	}
+	xcodex, _ := fm["x-codex"].(map[string]any)
+	if xcodex == nil {
+		xcodex = map[string]any{}
+	}
+	for key, val := range doc {
+		if codexAgentTopLevel[key] {
+			continue
+		}
+		if _, present := xcodex[key]; !present {
+			xcodex[key] = val
+		}
+	}
+	if codexName != "" {
+		if canonical, _ := fm["name"].(string); codexName != canonical {
+			if _, present := xcodex["name"]; !present {
+				xcodex["name"] = codexName
+			}
+		}
+	}
+	if len(xcodex) > 0 {
+		fm["x-codex"] = xcodex
+	}
+	raw, err := yaml.Marshal(fm)
+	if err != nil {
+		return "", fmt.Errorf("re-marshal frontmatter: %w", err)
+	}
+	return "---\n" + string(raw) + "---\n\n" + body, nil
+}
+
+// splitCodexAgentFrontmatter returns the YAML between the first two `---`
+// delimiters and the markdown body following them. Returns (_, _,
+// false) when the input does not open with a frontmatter block.
+func splitCodexAgentFrontmatter(doc string) (string, string, bool) {
+	if !strings.HasPrefix(doc, "---\n") {
+		return "", "", false
+	}
+	rest := doc[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", "", false
+	}
+	front := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = strings.TrimPrefix(body, "\n")
+	body = strings.TrimPrefix(body, "\n")
+	return front, body, true
 }
 
 // importCodexSkills walks `<root>/.agents/skills/<name>/` and mirrors

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -19,6 +20,7 @@ import (
 var codexAgentDirs = []string{".agents/agents", ".codex/agents"}
 
 const (
+	codexDir        = ".codex"
 	codexSkillsDir  = ".agents/skills"
 	codexConfigTOML = ".codex/config.toml"
 )
@@ -165,8 +167,10 @@ type codexConfigDoc struct {
 }
 
 type codexHookEntry struct {
-	Matcher string `toml:"matcher"`
-	Command string `toml:"command"`
+	Matcher       string `toml:"matcher"`
+	Command       string `toml:"command"`
+	Timeout       int    `toml:"timeout"`
+	StatusMessage string `toml:"statusMessage"`
 }
 
 type codexMCPEntry struct {
@@ -178,68 +182,187 @@ type codexMCPEntry struct {
 	HTTPHeaders       map[string]string `toml:"http_headers"`
 }
 
-// importCodexConfig reads `<root>/.codex/config.toml` and writes one
-// yaml per `[[hooks.<event>]]` entry to hooksDst and one yaml per
-// `[mcp_servers.<name>]` table to mcpsDst. Returns (hooks, mcps).
+// importCodexConfig reads `<root>/.codex/config.toml` plus the
+// standalone `<root>/.codex/hooks.json` (if present) and writes one
+// yaml per discovered hook to hooksDst and one yaml per `[mcp_servers.<name>]`
+// table to mcpsDst. Hooks declared in both files are deduped by
+// (event, matcher, command); the hooks.json variant wins because it
+// can carry timeout + statusMessage.
+//
+// Returns (hooks, mcps).
 func importCodexConfig(root, hooksDst, mcpsDst string) (int, int, error) {
-	path := filepath.Join(root, codexConfigTOML)
-	data, err := os.ReadFile(path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return 0, 0, nil
-	}
+	hooksByKey, mcpServers, err := readCodexConfigTOML(root)
 	if err != nil {
-		return 0, 0, fmt.Errorf("read %s: %w", path, err)
+		return 0, 0, err
 	}
-	var doc codexConfigDoc
-	if _, err := toml.Decode(string(data), &doc); err != nil {
-		return 0, 0, fmt.Errorf("parse %s: %w", path, err)
+	if err := mergeCodexHooksJSON(root, hooksByKey); err != nil {
+		return 0, 0, err
 	}
 
-	hooks, err := writeCodexHooks(doc.Hooks, hooksDst)
+	hooks, err := writeCodexHooksFromMap(hooksByKey, hooksDst)
 	if err != nil {
 		return hooks, 0, err
 	}
-	mcps, err := writeCodexMCPs(doc.MCPServers, mcpsDst)
+	mcps, err := writeCodexMCPs(mcpServers, mcpsDst)
 	if err != nil {
 		return hooks, mcps, err
 	}
 	return hooks, mcps, nil
 }
 
-func writeCodexHooks(byEvent map[string][]codexHookEntry, dstDir string) (int, error) {
-	events := make([]string, 0, len(byEvent))
-	for e := range byEvent {
-		events = append(events, e)
-	}
-	sort.Strings(events)
+// codexHookKey identifies a hook for dedupe across sources. Hooks with
+// the same (event, matcher, command) are considered the same entry.
+type codexHookKey struct {
+	event, matcher, command string
+}
 
-	count := 0
-	for _, event := range events {
-		for _, h := range byEvent[event] {
+// codexHookSlot is the merged hook representation built up by reading
+// every codex hook source. The order field preserves discovery order
+// so emitted spec files stay byte-stable across re-imports.
+type codexHookSlot struct {
+	order         int
+	entry         codexHookEntry
+	event         string
+	fromHooksJSON bool
+}
+
+// readCodexConfigTOML reads `.codex/config.toml` and returns a
+// dedupe-keyed map of hooks plus the MCP servers section. The dedupe key
+// uses (event, matcher, command) so the standalone hooks.json layer can
+// overwrite TOML-defined entries that carry less information.
+func readCodexConfigTOML(root string) (map[codexHookKey]*codexHookSlot, map[string]codexMCPEntry, error) {
+	hooks := map[codexHookKey]*codexHookSlot{}
+	path := filepath.Join(root, codexConfigTOML)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return hooks, nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var doc codexConfigDoc
+	if _, err := toml.Decode(string(data), &doc); err != nil {
+		return nil, nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, event := range sortedMapKeys(doc.Hooks) {
+		for _, h := range doc.Hooks[event] {
 			if h.Command == "" {
 				continue
 			}
-			name := hookSpecName(event, h.Matcher, []string{h.Command})
-			doc := map[string]any{
-				"name":    name,
-				"event":   event,
-				"command": h.Command,
+			k := codexHookKey{event: event, matcher: h.Matcher, command: h.Command}
+			if _, exists := hooks[k]; exists {
+				continue
 			}
-			if h.Matcher != "" {
-				doc["matcher"] = h.Matcher
-			}
-			raw, err := yaml.Marshal(doc)
-			if err != nil {
-				return count, fmt.Errorf("marshal hook %s: %w", name, err)
-			}
-			path := filepath.Join(dstDir, name+".yaml")
-			if err := importWriteFile(path, raw, 0o644); err != nil {
-				return count, fmt.Errorf("write %s: %w", path, err)
-			}
-			count++
+			hooks[k] = &codexHookSlot{order: len(hooks), entry: h, event: event}
 		}
 	}
+	return hooks, doc.MCPServers, nil
+}
+
+// mergeCodexHooksJSON layers `.codex/hooks.json` over the config.toml
+// dedupe map. When the same (event, matcher, command) appears in both,
+// the JSON entry wins so timeout + statusMessage propagate even when
+// the TOML copy carried only matcher + command.
+func mergeCodexHooksJSON(root string, hooks map[codexHookKey]*codexHookSlot) error {
+	path := filepath.Join(root, codexDir, "hooks.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	var s claudeSettings // identical shape: hooks[<event>][n].{matcher, hooks[m].{...}}
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, event := range sortedMapKeys(s.Hooks) {
+		for _, g := range s.Hooks[event] {
+			for _, h := range g.Hooks {
+				if h.Command == "" {
+					continue
+				}
+				k := codexHookKey{event: event, matcher: g.Matcher, command: h.Command}
+				slot, exists := hooks[k]
+				entry := codexHookEntry{
+					Matcher:       g.Matcher,
+					Command:       h.Command,
+					Timeout:       h.Timeout,
+					StatusMessage: h.StatusMessage,
+				}
+				if !exists {
+					hooks[k] = &codexHookSlot{
+						order:         len(hooks),
+						entry:         entry,
+						event:         event,
+						fromHooksJSON: true,
+					}
+					continue
+				}
+				slot.entry = entry
+				slot.fromHooksJSON = true
+			}
+		}
+	}
+	return nil
+}
+
+// writeCodexHooksFromMap emits one yaml per discovered hook. Hooks are
+// written in (event, order) order so a re-import produces byte-stable
+// output regardless of which source file changed.
+func writeCodexHooksFromMap(hooks map[codexHookKey]*codexHookSlot, dstDir string) (int, error) {
+	slots := make([]*codexHookSlot, 0, len(hooks))
+	for _, slot := range hooks {
+		slots = append(slots, slot)
+	}
+	sort.SliceStable(slots, func(i, j int) bool {
+		if slots[i].event != slots[j].event {
+			return slots[i].event < slots[j].event
+		}
+		return slots[i].order < slots[j].order
+	})
+
+	count := 0
+	for _, slot := range slots {
+		h := slot.entry
+		name := hookSpecName(slot.event, h.Matcher, []string{h.Command})
+		doc := map[string]any{
+			"name":    name,
+			"event":   slot.event,
+			"command": h.Command,
+		}
+		if h.Matcher != "" {
+			doc["matcher"] = h.Matcher
+		}
+		if h.Timeout != 0 {
+			doc["timeout"] = h.Timeout
+		}
+		if h.StatusMessage != "" {
+			doc["statusMessage"] = h.StatusMessage
+		}
+		raw, err := yaml.Marshal(doc)
+		if err != nil {
+			return count, fmt.Errorf("marshal hook %s: %w", name, err)
+		}
+		path := filepath.Join(dstDir, name+".yaml")
+		if err := importWriteFile(path, raw, 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", path, err)
+		}
+		count++
+	}
 	return count, nil
+}
+
+// sortedMapKeys returns a copy of map[string]V's keys sorted for
+// deterministic iteration. Local to the codex importer to avoid
+// colliding with the validate.go variant that takes a set.
+func sortedMapKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func writeCodexMCPs(servers map[string]codexMCPEntry, dstDir string) (int, error) {

--- a/internal/cli/import_codex_overlay.go
+++ b/internal/cli/import_codex_overlay.go
@@ -79,7 +79,7 @@ func importCodexConfigOverlay(root string) (bool, error) {
 
 	// Text-level strip preserves multi-line string literals, comments,
 	// blank lines, and key ordering that a decode/encode round-trip
-	// would otherwise normalise away. Falling back to encoding via the
+	// would otherwise normalize away. Falling back to encoding via the
 	// TOML library only happens when the text strip cannot produce a
 	// valid overlay (e.g. malformed input the parser still accepted).
 	filtered := stripCodexSpecManagedSections(string(data))
@@ -108,12 +108,13 @@ func importCodexConfigOverlay(root string) (bool, error) {
 // `[mcp_servers.<name>]` table from raw TOML while leaving every other
 // byte intact. This preserves multi-line string literals, comments, and
 // the author's original key ordering — qualities the BurntSushi encoder
-// normalises away on a decode/encode round-trip.
+// normalizes away on a decode/encode round-trip.
 //
 // A section runs from its `[…]` header line up to (but not including)
 // the next header line or end-of-file. Lines inside a multi-line string
-// (`"""…"""` or `'''…'''`) are never treated as section headers, so a
-// `[bracketed]` example inside a docstring will not split the value.
+// (triple-double or triple-single-quote literals) are never treated as
+// section headers, so a `[bracketed]` example inside a docstring will
+// not split the value.
 func stripCodexSpecManagedSections(raw string) string {
 	var out strings.Builder
 	out.Grow(len(raw))
@@ -122,7 +123,7 @@ func stripCodexSpecManagedSections(raw string) string {
 	skipping := false
 	inMultiline := ""
 	for i, line := range lines {
-		// Track whether we're inside a `"""…"""` or `'''…'''` block.
+		// Track whether we're inside a triple-quoted block.
 		// Section-header detection must not fire on lines that are
 		// part of a string value.
 		if inMultiline != "" {
@@ -151,11 +152,11 @@ func stripCodexSpecManagedSections(raw string) string {
 	return collapseBlankLineRuns(out.String())
 }
 
-// openMultilineDelimiter returns `"""` or `'''` when line opens a
-// multi-line string that does not close on the same line; otherwise it
-// returns the empty string. The check is deliberately simple: TOML
-// multi-line strings rarely appear in the codex overlay (the only common
-// case is `developer_instructions = """…"""`).
+// openMultilineDelimiter returns the triple-quote delimiter that opens
+// line when it does not close on the same line; otherwise it returns
+// the empty string. The check is deliberately simple: TOML multi-line
+// strings rarely appear in the codex overlay (the only common case is
+// developer_instructions).
 func openMultilineDelimiter(line string) string {
 	for _, delim := range []string{`"""`, `'''`} {
 		first := strings.Index(line, delim)

--- a/internal/cli/import_codex_overlay.go
+++ b/internal/cli/import_codex_overlay.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -62,6 +63,10 @@ func importCodexConfigOverlay(root string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("read %s: %w", src, err)
 	}
+
+	// Validate that the input is parseable as TOML before trying to strip
+	// the spec-managed sections; surfacing a parse error here points the
+	// user at the real config.toml rather than the filtered overlay.
 	doc := map[string]any{}
 	if _, err := toml.Decode(string(data), &doc); err != nil {
 		return false, fmt.Errorf("parse %s: %w", src, err)
@@ -71,16 +76,146 @@ func importCodexConfigOverlay(root string) (bool, error) {
 	if len(doc) == 0 {
 		return false, nil
 	}
-	var buf bytes.Buffer
-	if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
-		return false, fmt.Errorf("encode overlay: %w", err)
+
+	// Text-level strip preserves multi-line string literals, comments,
+	// blank lines, and key ordering that a decode/encode round-trip
+	// would otherwise normalise away. Falling back to encoding via the
+	// TOML library only happens when the text strip cannot produce a
+	// valid overlay (e.g. malformed input the parser still accepted).
+	filtered := stripCodexSpecManagedSections(string(data))
+	if filtered = strings.TrimSpace(filtered); filtered != "" {
+		filtered += "\n"
 	}
+	if filtered == "" {
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+			return false, fmt.Errorf("encode overlay: %w", err)
+		}
+		filtered = buf.String()
+	}
+
 	dst := codexOverlayPath(root)
 	if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
-	if err := importWriteFile(dst, buf.Bytes(), 0o644); err != nil {
+	if err := importWriteFile(dst, []byte(filtered), 0o644); err != nil {
 		return false, fmt.Errorf("write %s: %w", dst, err)
 	}
 	return true, nil
+}
+
+// stripCodexSpecManagedSections removes every `[[hooks.<event>]]` and
+// `[mcp_servers.<name>]` table from raw TOML while leaving every other
+// byte intact. This preserves multi-line string literals, comments, and
+// the author's original key ordering — qualities the BurntSushi encoder
+// normalises away on a decode/encode round-trip.
+//
+// A section runs from its `[…]` header line up to (but not including)
+// the next header line or end-of-file. Lines inside a multi-line string
+// (`"""…"""` or `'''…'''`) are never treated as section headers, so a
+// `[bracketed]` example inside a docstring will not split the value.
+func stripCodexSpecManagedSections(raw string) string {
+	var out strings.Builder
+	out.Grow(len(raw))
+
+	lines := strings.Split(raw, "\n")
+	skipping := false
+	inMultiline := ""
+	for i, line := range lines {
+		// Track whether we're inside a `"""…"""` or `'''…'''` block.
+		// Section-header detection must not fire on lines that are
+		// part of a string value.
+		if inMultiline != "" {
+			if strings.Contains(line, inMultiline) {
+				inMultiline = ""
+			}
+		} else {
+			inMultiline = openMultilineDelimiter(line)
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if inMultiline == "" && isCodexSectionHeader(trimmed) {
+			skipping = isManagedSectionHeader(trimmed)
+			if skipping {
+				continue
+			}
+		}
+		if skipping {
+			continue
+		}
+		out.WriteString(line)
+		if i < len(lines)-1 {
+			out.WriteByte('\n')
+		}
+	}
+	return collapseBlankLineRuns(out.String())
+}
+
+// openMultilineDelimiter returns `"""` or `'''` when line opens a
+// multi-line string that does not close on the same line; otherwise it
+// returns the empty string. The check is deliberately simple: TOML
+// multi-line strings rarely appear in the codex overlay (the only common
+// case is `developer_instructions = """…"""`).
+func openMultilineDelimiter(line string) string {
+	for _, delim := range []string{`"""`, `'''`} {
+		first := strings.Index(line, delim)
+		if first < 0 {
+			continue
+		}
+		last := strings.LastIndex(line, delim)
+		if last == first {
+			return delim
+		}
+	}
+	return ""
+}
+
+// isCodexSectionHeader reports whether a trimmed line opens a new TOML
+// section (either a regular `[name]` table or an `[[name]]` array of
+// tables). Multi-line strings are out-of-scope because they live inside
+// a value, not at column zero after a trim.
+func isCodexSectionHeader(trimmed string) bool {
+	if !strings.HasPrefix(trimmed, "[") {
+		return false
+	}
+	return strings.HasSuffix(trimmed, "]")
+}
+
+// isManagedSectionHeader reports whether a section header opens a
+// spec-managed table that the overlay should drop. The patterns mirror
+// the keys agnostic-ai owns: hooks (lifecycle hooks) and mcp_servers
+// (MCP server registrations).
+func isManagedSectionHeader(trimmed string) bool {
+	switch {
+	case strings.HasPrefix(trimmed, "[[hooks."),
+		strings.HasPrefix(trimmed, "[[hooks]]"),
+		strings.HasPrefix(trimmed, "[hooks."),
+		trimmed == "[hooks]",
+		strings.HasPrefix(trimmed, "[mcp_servers."),
+		trimmed == "[mcp_servers]":
+		return true
+	}
+	return false
+}
+
+// collapseBlankLineRuns collapses runs of two or more blank lines down
+// to a single blank line so the overlay file stays compact after
+// stripping managed sections.
+func collapseBlankLineRuns(s string) string {
+	var out strings.Builder
+	out.Grow(len(s))
+	blank := 0
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) == "" {
+			blank++
+			if blank > 1 {
+				continue
+			}
+		} else {
+			blank = 0
+		}
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	return strings.TrimRight(out.String(), "\n")
 }

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -422,6 +422,93 @@ command = "lint"
 	}
 }
 
+// Some Codex installs keep hooks in a standalone .codex/hooks.json
+// alongside config.toml. The schema matches Claude's settings.json hook
+// block: hooks[<event>][n].{matcher, hooks[m].{type, command, timeout,
+// statusMessage}}. Import should pick up that file, preserve timeout
+// and statusMessage, and dedupe against any duplicate entries in
+// config.toml.
+func TestImportFromCodex_HooksFromHooksJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex/hooks.json"), `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|apply_patch|Edit|Write",
+        "hooks": [
+          {"type": "command", "command": ".codex/hooks/protect-files.sh", "timeout": 5, "statusMessage": "Checking protected files"}
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          {"type": "command", "command": ".codex/hooks/format-php.sh", "timeout": 30}
+        ]
+      }
+    ]
+  }
+}`)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	pre := findOneHookFile(t, filepath.Join(dir, "hooks"), "pretooluse")
+	preData, _ := os.ReadFile(pre)
+	for _, want := range []string{
+		"matcher: Bash|apply_patch|Edit|Write",
+		"command: .codex/hooks/protect-files.sh",
+		"timeout: 5",
+		"statusMessage: Checking protected files",
+	} {
+		if !strings.Contains(string(preData), want) {
+			t.Errorf("expected %q in PreToolUse spec:\n%s", want, preData)
+		}
+	}
+	post := findOneHookFile(t, filepath.Join(dir, "hooks"), "posttooluse")
+	postData, _ := os.ReadFile(post)
+	for _, want := range []string{
+		"matcher: apply_patch|Edit|Write",
+		"command: .codex/hooks/format-php.sh",
+		"timeout: 30",
+	} {
+		if !strings.Contains(string(postData), want) {
+			t.Errorf("expected %q in PostToolUse spec:\n%s", want, postData)
+		}
+	}
+}
+
+// When both hooks.json and config.toml carry the same event/matcher/command,
+// keep one spec and prefer hooks.json (it can carry timeout + statusMessage).
+func TestImportFromCodex_HooksDedupHooksJsonOverConfigToml(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex/hooks.json"), `{
+  "hooks": {
+    "PostToolUse": [
+      {"matcher": "Edit", "hooks": [{"type": "command", "command": "fmt", "timeout": 30}]}
+    ]
+  }
+}`)
+	writeFile(t, filepath.Join(dir, ".codex/config.toml"), `[[hooks.PostToolUse]]
+matcher = "Edit"
+command = "fmt"
+`)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "hooks", "posttooluse-*.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one PostToolUse spec after dedupe, got %d: %v", len(matches), matches)
+	}
+	data, _ := os.ReadFile(matches[0])
+	if !strings.Contains(string(data), "timeout: 30") {
+		t.Errorf("dedupe should keep hooks.json variant carrying timeout:\n%s", data)
+	}
+}
+
 func TestImportFromCodex_SkipsAgentsAndSkillsWrappers(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "AGENTS.md"), `# AGENTS.md

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -616,6 +616,46 @@ command = "gofmt"
 	}
 }
 
+// TOML multi-line string literals (developer_instructions, prompt
+// templates, ...) must round-trip through the overlay as-is. The
+// BurntSushi encoder would otherwise collapse them to single-line
+// `"...\n..."` form and the user's hand-formatted instructions would
+// disappear on the next sync.
+func TestImportFromCodex_PreservesMultiLineStringLiteral(t *testing.T) {
+	dir := t.TempDir()
+	original := `commit_attribution = ""
+model = "gpt-5"
+
+developer_instructions = """
+This is the project repository. Treat AGENTS.md as the source of truth.
+
+Multi-line instruction.
+"""
+
+[features]
+codex_hooks = true
+`
+	writeFile(t, filepath.Join(dir, ".codex/config.toml"), original)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	overlay, err := os.ReadFile(filepath.Join(dir, ".agnostic-ai/overlays/codex.config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(overlay), `developer_instructions = """`) {
+		t.Errorf("overlay collapsed multi-line literal:\n%s", overlay)
+	}
+	if strings.Contains(string(overlay), `\n`) {
+		t.Errorf("overlay should not carry escaped newlines:\n%s", overlay)
+	}
+	for _, want := range []string{"This is the project repository.", "Multi-line instruction."} {
+		if !strings.Contains(string(overlay), want) {
+			t.Errorf("overlay missing original line %q:\n%s", want, overlay)
+		}
+	}
+}
+
 func TestImportFromCodex_NoOverlayWhenOnlyManagedKeys(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".codex/config.toml"), `[mcp_servers.fs]

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -511,6 +511,74 @@ command = "fmt"
 
 // Hook script bodies under `.codex/hooks/` capture into
 // `.agnostic-ai/scripts/codex/` for reconstruction on next sync.
+// Codex agent TOML files conventionally use underscored names
+// (\`name = "changelog_keeper"\`). Claude convention is dashed
+// (\`changelog-keeper.md\`). When both tools define the same agent the
+// importer must collapse them onto a single canonical dashed filename
+// so the project does not carry duplicate specs.
+func TestImportFromCodex_AgentNameDashUnderscoreCollisionDedupes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate prior claude import: agent already at dashed filename.
+	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	claudeBody := "---\nname: changelog-keeper\ndescription: Claude version\n---\n\nClaude-authored agent body.\n"
+	writeFile(t, filepath.Join(dir, "agents", "changelog-keeper.md"), claudeBody)
+
+	// Now run codex import with a TOML file using the underscore variant.
+	writeFile(t, filepath.Join(dir, ".agents/agents/changelog-keeper.toml"), `name = "changelog_keeper"
+description = "Codex version"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Codex hint.
+"""
+`)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "agents", "changelog*.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected one merged spec, got %d: %v", len(matches), matches)
+	}
+	merged, _ := os.ReadFile(matches[0])
+	if !strings.Contains(string(merged), "name: changelog-keeper") {
+		t.Errorf("merged spec should keep canonical dashed name:\n%s", merged)
+	}
+	if !strings.Contains(string(merged), "Claude-authored agent body.") {
+		t.Errorf("merged spec should retain claude body:\n%s", merged)
+	}
+	if !strings.Contains(string(merged), "name: changelog_keeper") {
+		t.Errorf("codex underscore identifier should land under x-codex.name:\n%s", merged)
+	}
+	if !strings.Contains(string(merged), "model_reasoning_effort: medium") {
+		t.Errorf("merged spec should pick up codex-specific x-codex keys:\n%s", merged)
+	}
+}
+
+// A codex-only project (no prior claude import) still benefits from
+// canonical dashed filenames so a later claude pass does not create
+// the duplicate.
+func TestImportFromCodex_AgentFilenameCanonicalisedToDashes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".agents/agents/foo.toml"), `name = "foo_bar"
+description = "x"
+developer_instructions = """body"""
+`)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "agents", "foo-bar.md")); err != nil {
+		t.Errorf("expected dashed filename, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "agents", "foo_bar.md")); err == nil {
+		t.Errorf("expected no underscored duplicate spec")
+	}
+}
+
 func TestImportFromCodex_CapturesHookScriptBodies(t *testing.T) {
 	dir := t.TempDir()
 	body := "#!/usr/bin/env bash\necho codex hook\n"

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -509,6 +509,30 @@ command = "fmt"
 	}
 }
 
+// Hook script bodies under `.codex/hooks/` capture into
+// `.agnostic-ai/scripts/codex/` for reconstruction on next sync.
+func TestImportFromCodex_CapturesHookScriptBodies(t *testing.T) {
+	dir := t.TempDir()
+	body := "#!/usr/bin/env bash\necho codex hook\n"
+	if err := os.MkdirAll(filepath.Join(dir, ".codex", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".codex", "hooks", "format-php.sh"), []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, ".agnostic-ai", "scripts", "codex", "format-php.sh")
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("expected stashed script body: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("body mismatch: %q vs %q", got, body)
+	}
+}
+
 func TestImportFromCodex_SkipsAgentsAndSkillsWrappers(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "AGENTS.md"), `# AGENTS.md

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -579,6 +579,38 @@ developer_instructions = """body"""
 	}
 }
 
+// AGENTS.md sharding splits the doc into one rule per H2 section. When
+// a claude-imported rule already lives at the canonical filename the
+// codex importer must skip (not overwrite) so claude's curated rule
+// survives. A warning makes the dedupe visible.
+func TestImportFromCodex_SkipsExistingRuleFromPriorImport(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate a prior claude import that wrote .agnostic-ai/rules/php.md.
+	if err := os.MkdirAll(filepath.Join(dir, "rules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	claudeBody := "---\nname: php\ndescription: Claude PHP rule\n---\n\nClaude PHP body.\n"
+	writeFile(t, filepath.Join(dir, "rules", "php.md"), claudeBody)
+
+	// Now an AGENTS.md authored under codex provides a `## PHP` section.
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "## PHP\n\nCodex PHP body.\n")
+
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "rules", "php.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "Claude PHP body.") {
+		t.Errorf("expected claude body preserved, got:\n%s", got)
+	}
+	if strings.Contains(string(got), "Codex PHP body.") {
+		t.Errorf("codex body should not overwrite claude rule:\n%s", got)
+	}
+}
+
 func TestImportFromCodex_CapturesHookScriptBodies(t *testing.T) {
 	dir := t.TempDir()
 	body := "#!/usr/bin/env bash\necho codex hook\n"

--- a/internal/cli/import_copilot.go
+++ b/internal/cli/import_copilot.go
@@ -45,7 +45,7 @@ func importFromCopilot(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, copilotMainFile); err != nil {
+	if _, err := mirrorMainFile(root, copilotMainFile); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d skills, %d mcps\n",

--- a/internal/cli/import_gemini.go
+++ b/internal/cli/import_gemini.go
@@ -44,7 +44,7 @@ func importFromGemini(root string, src config.Sources) error {
 	if err := captureHookScripts(root, "gemini"); err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, geminiMainFile); err != nil {
+	if _, err := mirrorMainFile(root, geminiMainFile); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps, %d hooks\n", rules, agents, mcps, hooks)

--- a/internal/cli/import_gemini.go
+++ b/internal/cli/import_gemini.go
@@ -41,6 +41,9 @@ func importFromGemini(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
+	if err := captureHookScripts(root, "gemini"); err != nil {
+		return err
+	}
 	if err := mirrorMainFile(root, geminiMainFile); err != nil {
 		return err
 	}

--- a/internal/cli/import_hook_scripts.go
+++ b/internal/cli/import_hook_scripts.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// agnosticScriptsDir is the project-relative root for stashed hook
+// script bodies. Mirrors the constant in the emit package so import
+// and sync agree on where the bodies live.
+const agnosticScriptsDir = ".agnostic-ai/scripts"
+
+// captureHookScripts copies every regular file under `<root>/.<tool>/hooks/`
+// into `<root>/.agnostic-ai/scripts/<tool>/`, preserving the file mode so
+// executable scripts stay executable. A no-op when the source directory
+// is missing — projects that author hook commands inline (e.g. `gofmt`)
+// have nothing to stash.
+//
+// Per-tool subdirectories let cross-tool emit fall back to the spec
+// origin's body when the target has no variant of its own. Unified
+// scripts can be promoted to `.agnostic-ai/scripts/<basename>` by hand
+// later; this helper never collapses tools to keep import lossless.
+func captureHookScripts(root, tool string) error {
+	srcDir := filepath.Join(root, "."+tool, "hooks")
+	dstDir := filepath.Join(root, agnosticScriptsDir, tool)
+	return copyHookScriptsTree(srcDir, dstDir)
+}
+
+func copyHookScriptsTree(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s: %w", srcDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		src := filepath.Join(srcDir, e.Name())
+		info, err := e.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", src, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		body, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		if err := importMkdirAll(dstDir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dstDir, err)
+		}
+		dst := filepath.Join(dstDir, e.Name())
+		if err := importWriteFile(dst, body, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
+	}
+	return nil
+}

--- a/internal/cli/import_opencode.go
+++ b/internal/cli/import_opencode.go
@@ -35,7 +35,7 @@ func importFromOpencode(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, opencodeMainFile); err != nil {
+	if _, err := mirrorMainFile(root, opencodeMainFile); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)

--- a/internal/cli/import_warp.go
+++ b/internal/cli/import_warp.go
@@ -39,7 +39,7 @@ func importFromWarp(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, warpMainFile); err != nil {
+	if _, err := mirrorMainFile(root, warpMainFile); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d agents, %d mcps\n", rules, agents, mcps)

--- a/internal/cli/import_zed.go
+++ b/internal/cli/import_zed.go
@@ -40,7 +40,7 @@ func importFromZed(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	if err := mirrorMainFile(root, zedMainFile); err != nil {
+	if _, err := mirrorMainFile(root, zedMainFile); err != nil {
 		return err
 	}
 	summaryf("imported %d rules, %d hooks, %d mcps\n", rules, hooks, mcps)


### PR DESCRIPTION
## Summary

Round-trip pass driven by a Phel-lang pilot import/sync that surfaced ten correctness bugs. Each bug has a regression test; full suite is 830 passing.

The recurring shape: import captured fewer fields than emit demanded, so the first `sync` after `import` quietly corrupted user config (lost timeouts, dropped commands, collapsed multi-line literals, scattered duplicate specs across dash/underscore conventions). Project that tried to gitignore `.<tool>/` also lost its hook script bodies because they live outside the spec tree.

## Bugs fixed

| # | Commit | Issue |
|---|--------|-------|
| A | [`0b77c14`](../commit/0b77c14) | codex emit dropped `command` for multi-command arrays; one matcher block, no command |
| B | [`55d32c1`](../commit/55d32c1) | codex import only read `.codex/config.toml`; `.codex/hooks.json` ignored, matcher entries lost |
| C | [`00d5615`](../commit/00d5615) | sibling-tool hook path prefix not rewritten on cross-tool emit |
| D | [`aa2e19a`](../commit/aa2e19a) | claude `timeout` + `statusMessage` round-trip silently dropped |
| E | [`f044cbb`](../commit/f044cbb) | TOML `"""..."""` collapsed to escaped single-line in overlay capture |
| F | [`48e3026`](../commit/48e3026) | claude `changelog-keeper.md` + codex `changelog_keeper.md` left as duplicate specs |
| G | [`d40cae2`](../commit/d40cae2) | hook script bodies under `.<tool>/hooks/*` not captured anywhere — gitignoring `.<tool>/` lost them |
| H | [`2e2a2d4`](../commit/2e2a2d4) | claude import claimed `AGNOSTIC_AI.md seeded from CLAUDE.md` even when CLAUDE.md absent |
| I | [`dd266a5`](../commit/dd266a5) | sync silently overwrote hand-authored entry-point files |
| J | [`b41aa01`](../commit/b41aa01) | codex AGENTS.md shred overwrote pre-existing rule files from prior import |

## New surface

- `emit.RewriteHookPath(cmd, target)` — normalises sibling-tool hook prefixes
- `emit.MaterializeHookScript(cmd, target, sourceTool, dryRun)` — copies stashed bodies into `.<target>/hooks/`
- `.agnostic-ai/scripts/{<tool>/<basename>, <basename>}` — new shared home for hook script bodies. Lookup precedence: target-specific → source-tool variant → unified.
- `mergeOrWriteCodexAgentSpec` + `canonicalSpecSlug` — collapse dash/underscore variants onto one spec; codex emits the underscore form via `x-codex.name` override.

## Re-pilot results (Phel-lang)

- `import claude` → 6 rules, 9 agents, 15 skills, 3 hooks, no spurious AGNOSTIC_AI.md log
- `import codex` → 10 rules, 5 agents, **2 hooks** (was 0), `developer_instructions = """…"""` preserved verbatim
- `sync` → 320 files / 13 targets in 31ms, warns before clobbering hand-authored AGENTS.md
- `sync --check` → exit 0, byte-stable

## Test plan

- [x] `go test ./...` — 830 passing across 28 packages
- [x] `go build ./...` clean
- [x] End-to-end pilot: `init` + `import claude` + `import codex` + `sync` + `sync --check` against a 200-spec real project (Phel-lang)
- [x] Hook script bodies survive a `rm -rf .claude/ .codex/ .gemini/` followed by `sync`
- [x] Multi-command hooks emit one TOML block per command
- [x] Cross-tool import dedupe collapses dash/underscore agent variants