### PR TITLE
test: skip executable-bit asserts on Windows

### DIFF
--- a/internal/adapters/internal/emit/hook_scripts_test.go
+++ b/internal/adapters/internal/emit/hook_scripts_test.go
@@ -3,6 +3,7 @@ package emit
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -50,12 +51,14 @@ func TestMaterializeHookScript_CopiesSourceToolStashIntoTargetHooks(t *testing.T
 	if string(out) != string(body) {
 		t.Errorf("body mismatch: %q vs %q", out, body)
 	}
-	info, err := os.Stat(filepath.Join(dir, ".codex/hooks/protect-files.sh"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm()&0o100 == 0 {
-		t.Errorf("expected executable bit preserved, got %v", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, ".codex/hooks/protect-files.sh"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o100 == 0 {
+			t.Errorf("expected executable bit preserved, got %v", info.Mode().Perm())
+		}
 	}
 }
 

--- a/internal/cli/import_claude_test.go
+++ b/internal/cli/import_claude_test.go
@@ -446,12 +446,14 @@ func TestImportFromClaude_CapturesHookScriptBodies(t *testing.T) {
 	if string(got) != body {
 		t.Errorf("body mismatch: %q vs %q", got, body)
 	}
-	info, err := os.Stat(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm()&0o100 == 0 {
-		t.Errorf("expected executable bit preserved, got %v", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o100 == 0 {
+			t.Errorf("expected executable bit preserved, got %v", info.Mode().Perm())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Two new hook-script tests (added in #245) asserted the POSIX executable bit unconditionally after a file copy. NTFS does not carry the bit, so the windows-latest CI job failed on \`Mode().Perm()&0o100 == 0\` even though cross-platform behaviour was correct.

Guard the mode-bit asserts behind \`runtime.GOOS != \"windows\"\` — same pattern already used in \`claude_test.go\`, \`codex_test.go\`, and the skill-asset round-trip tests.

Blocks the v0.25.0 release: every CI job must be green before tagging.

## Test plan

- [x] \`go test ./...\` passes locally (830 tests)
- [x] Existing executable-bit guard pattern reused (\`runtime.GOOS != \"windows\"\`)
- [ ] windows-latest CI job goes green