### PR TITLE
feat(import): add import.codex.shred knob for monolithic AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ## [Unreleased]
 
 ### Added
+- `import.codex.shred` config knob. Set to `false` to keep each `AGENTS.md` as a single rule spec instead of sharding it by `##` heading. Default `true` preserves existing behavior. Closes #248.
 
 ### Changed
 

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -196,6 +196,9 @@
         },
         "sync": {
           "$ref": "#/$defs/SyncConfig"
+        },
+        "import": {
+          "$ref": "#/$defs/ImportConfig"
         }
       },
       "additionalProperties": false,
@@ -211,6 +214,24 @@
         },
         "path": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ImportCodex": {
+      "properties": {
+        "shred": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ImportConfig": {
+      "properties": {
+        "codex": {
+          "$ref": "#/$defs/ImportCodex"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -248,6 +248,26 @@ sync:
   collision-policy: prefer-spec   # CI-safe: skip collision check
 ```
 
+## `import`
+
+Per-source knobs for the `import` command. Empty blocks fall back to per-source defaults.
+
+### `import.codex.shred`
+
+Controls how `agnostic-ai import codex` treats `AGENTS.md`.
+
+| Value | Behavior |
+|-------|----------|
+| `true` | Split each `AGENTS.md` into one rule spec per `##` heading. Default. |
+| `false` | Keep each `AGENTS.md` as a single rule spec (full body verbatim). Use when codex `AGENTS.md` duplicates policy already authored as standalone rules and you want it as a reference doc, not a source of new rule files. |
+
+```yaml
+# In agnostic-ai.yaml
+import:
+  codex:
+    shred: false   # one rule per AGENTS.md, no H2 sharding
+```
+
 ## `on-unsupported`
 
 | Value | Behavior |

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -73,9 +73,9 @@ func newImportCmd() *cobra.Command {
 				defer reportImportDryRun()
 			}
 			if len(args) == 1 {
-				return runImport(".", args[0], cfg.Sources)
+				return runImport(".", args[0], cfg)
 			}
-			return runImportMany(".", args, cfg.Sources)
+			return runImportMany(".", args, cfg)
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report which spec files would be written without touching disk.")
@@ -83,14 +83,15 @@ func newImportCmd() *cobra.Command {
 }
 
 // runImport dispatches to the per-source importer.
-func runImport(root, source string, src config.Sources) error {
+func runImport(root, source string, cfg *config.Config) error {
+	src := cfg.Sources
 	switch source {
 	case "all":
-		return importAll(root, src)
+		return importAll(root, cfg)
 	case "claude":
 		return importFromClaude(root, src)
 	case "codex":
-		return importFromCodex(root, src)
+		return importFromCodexWithOpts(root, src, importCodexOpts{Shred: cfg.Import.Codex.Shred})
 	case "cursor":
 		return importFromCursor(root, src)
 	case "aider":
@@ -119,7 +120,7 @@ func runImport(root, source string, src config.Sources) error {
 // AGNOSTIC_AI.md` ends up mirroring the last source's top-level
 // instructions file (last-wins). Sources are validated up-front so a
 // typo on arg N fails before any writes happen.
-func runImportMany(root string, sources []string, src config.Sources) error {
+func runImportMany(root string, sources []string, cfg *config.Config) error {
 	for _, s := range sources {
 		if s == "all" {
 			return errs.Coded(errs.CodeImportFileUnknown,
@@ -133,7 +134,7 @@ func runImportMany(root string, sources []string, src config.Sources) error {
 	var failed []string
 	for _, s := range sources {
 		_, _ = fmt.Fprintf(os.Stdout, "→ importing from %s\n", s)
-		if err := runImport(root, s, src); err != nil {
+		if err := runImport(root, s, cfg); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "! %s: %v\n", s, err)
 			failed = append(failed, s)
 		}
@@ -156,7 +157,7 @@ func isKnownImportSource(source string) bool {
 }
 
 // importAll detects every AI CLI present in root and imports from each.
-func importAll(root string, src config.Sources) error {
+func importAll(root string, cfg *config.Config) error {
 	detected := detectExistingTargets(root)
 	if len(detected) == 0 {
 		fmt.Println("no known AI CLI configs detected")
@@ -165,7 +166,7 @@ func importAll(root string, src config.Sources) error {
 	var errs []string
 	for _, t := range detected {
 		_, _ = fmt.Fprintf(os.Stdout, "→ importing from %s\n", t)
-		if err := runImport(root, t, src); err != nil {
+		if err := runImport(root, t, cfg); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "! %s: %v\n", t, err)
 			errs = append(errs, t)
 		}

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -12,15 +12,39 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/config"
 )
 
+// importCodexOpts toggles non-default import behavior. Zero value keeps
+// the historical defaults (AGENTS.md shredded into one rule per H2).
+type importCodexOpts struct {
+	// Shred controls whether AGENTS.md is split into one rule per H2
+	// section (true, default) or kept as a single rule per file (false).
+	// Nil means default (true). Use false when codex AGENTS.md is a
+	// reference doc rather than a source of new policy.
+	Shred *bool
+}
+
+// shredEnabled reports whether H2 sharding is on (default true).
+func (o importCodexOpts) shredEnabled() bool {
+	if o.Shred == nil {
+		return true
+	}
+	return *o.Shred
+}
+
 // importFromCodex reads existing Codex config (AGENTS.md hierarchy,
 // `.agents/agents/*.toml`, `.agents/skills/<name>/SKILL.md`, and
 // `.codex/config.toml`) under root and writes specs into the configured
 // source directories.
 func importFromCodex(root string, src config.Sources) error {
+	return importFromCodexWithOpts(root, src, importCodexOpts{})
+}
+
+// importFromCodexWithOpts is importFromCodex with explicit per-run opts.
+// The CLI entry point fills opts from `import.codex.*` config keys.
+func importFromCodexWithOpts(root string, src config.Sources, opts importCodexOpts) error {
 	if err := mkdirAllSources(root, src.Rules, src.Agents, src.Skills, src.Hooks, src.MCPs, src.Commands); err != nil {
 		return err
 	}
-	rules, err := importCodexRules(root, filepath.Join(root, src.Rules), src)
+	rules, err := importCodexRules(root, filepath.Join(root, src.Rules), src, opts)
 	if err != nil {
 		return err
 	}
@@ -79,7 +103,9 @@ var codexSkipHeadings = map[string]bool{
 // importCodexRules walks the project tree for AGENTS.md files and writes
 // one rule per ## section found into dstDir. Rules from <dir>/AGENTS.md
 // inherit "globs: <dir>/**". Slug collisions across files are deduplicated.
-func importCodexRules(root, dstDir string, src config.Sources) (int, error) {
+// When opts.Shred is false, each AGENTS.md becomes a single rule whose body
+// is the file verbatim, skipping the H2 split.
+func importCodexRules(root, dstDir string, src config.Sources, opts importCodexOpts) (int, error) {
 	files, err := findCodexFiles(root, src)
 	if err != nil {
 		return 0, err
@@ -94,6 +120,18 @@ func importCodexRules(root, dstDir string, src config.Sources) (int, error) {
 		data, err := os.ReadFile(f.path)
 		if err != nil {
 			return count, fmt.Errorf("read %s: %w", f.path, err)
+		}
+		if !opts.shredEnabled() {
+			body := strings.TrimSpace(string(data))
+			if body == "" {
+				continue
+			}
+			name := dedupSlug(used, projectSlug(root))
+			if err := writeCodexRule(dstDir, name, "", f.globs, body); err != nil {
+				return count, err
+			}
+			count++
+			continue
 		}
 		sections := codexSectionsFrom(string(data))
 		if len(sections) == 0 {

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -816,3 +816,105 @@ func TestImportCmd_CodexRoutes(t *testing.T) {
 		t.Error("expected .agnostic-ai/rules/routed.md after import codex")
 	}
 }
+
+// When import.codex.shred is false the importer keeps each AGENTS.md as a
+// single rule spec instead of splitting it by H2 heading. The body lands
+// verbatim under one rule named after the project (root) or scoped slug
+// (nested), so codex AGENTS.md acts as a reference doc rather than a source
+// of new policy.
+func TestImportFromCodex_ShredFalseKeepsAgentsMdAsSingleRule(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), `# Project
+
+Top-level intro.
+
+## go-style
+
+gofmt clean.
+
+## commits
+
+Conventional Commits.
+`)
+	shred := false
+	if err := importFromCodexWithOpts(dir, rootSources(), importCodexOpts{Shred: &shred}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, "rules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 rule, got %d: %v", len(entries), names(entries))
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "rules", entries[0].Name()))
+	out := string(data)
+	for _, want := range []string{
+		"## go-style",
+		"gofmt clean.",
+		"## commits",
+		"Conventional Commits.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("monolithic rule missing %q in:\n%s", want, out)
+		}
+	}
+	for _, never := range []string{"go-style.md", "commits.md"} {
+		if _, err := os.Stat(filepath.Join(dir, "rules", never)); err == nil {
+			t.Errorf("expected no shard %s when shred=false", never)
+		}
+	}
+}
+
+// Nested AGENTS.md files still produce one rule each (carrying the
+// inferred globs) when shred is false.
+func TestImportFromCodex_ShredFalseNestedKeepsOneRulePerFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "## root\n\nroot body.\n")
+	writeFile(t, filepath.Join(dir, "src", "AGENTS.md"), "## srca\n\nsrc body.\n")
+
+	shred := false
+	if err := importFromCodexWithOpts(dir, rootSources(), importCodexOpts{Shred: &shred}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, "rules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 rule files (one per AGENTS.md), got %d: %v", len(entries), names(entries))
+	}
+	var sawGlobs bool
+	for _, e := range entries {
+		data, _ := os.ReadFile(filepath.Join(dir, "rules", e.Name()))
+		if strings.Contains(string(data), "globs: src/**") {
+			sawGlobs = true
+		}
+	}
+	if !sawGlobs {
+		t.Error("nested AGENTS.md should carry globs: src/** in monolithic rule")
+	}
+}
+
+// Default behavior (Shred nil) still shards by H2. Regression guard.
+func TestImportFromCodex_ShredDefaultStillShards(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "## one\n\nbody one.\n\n## two\n\nbody two.\n")
+
+	if err := importFromCodexWithOpts(dir, rootSources(), importCodexOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"one.md", "two.md"} {
+		if _, err := os.Stat(filepath.Join(dir, "rules", want)); err != nil {
+			t.Errorf("expected shard %s under default behavior: %v", want, err)
+		}
+	}
+}
+
+func names(entries []os.DirEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Name()
+	}
+	return out
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -113,7 +113,7 @@ func newInitCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("load config after init: %w", err)
 			}
-			return runImport(".", fromCLI, cfg.Sources)
+			return runImport(".", fromCLI, cfg)
 		},
 	}
 	cmd.Flags().BoolVar(&demo, "demo", false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,22 @@ type Config struct {
 	OnUnsupported string            `yaml:"on-unsupported,omitempty" json:"on-unsupported,omitempty"`
 	Gitignore     Gitignore         `yaml:"gitignore,omitempty"      json:"gitignore,omitempty"`
 	Sync          SyncConfig        `yaml:"sync,omitempty"           json:"sync,omitempty"`
+	Import        ImportConfig      `yaml:"import,omitempty"         json:"import,omitempty"`
+}
+
+// ImportConfig holds per-source knobs for the `import` command. Empty
+// values fall back to per-source defaults documented under each substruct.
+type ImportConfig struct {
+	Codex ImportCodex `yaml:"codex,omitempty" json:"codex,omitempty"`
+}
+
+// ImportCodex tunes `agnostic-ai import codex`.
+type ImportCodex struct {
+	// Shred toggles AGENTS.md H2 sharding. Nil or true keeps the default
+	// behavior (one rule spec per ## heading). False keeps each AGENTS.md
+	// as a single rule spec, useful when codex AGENTS.md duplicates policy
+	// already authored as standalone rules.
+	Shred *bool `yaml:"shred,omitempty" json:"shred,omitempty"`
 }
 
 // SyncConfig holds declarative knobs for the sync command. Settings here


### PR DESCRIPTION
## Summary

- Add `import.codex.shred` config knob. When `false`, `agnostic-ai import codex` keeps each `AGENTS.md` as a single rule spec instead of sharding it by `##` heading.
- Default stays `true` (current shard-by-H2 behavior).
- Use case: codex `AGENTS.md` overlaps with policy already authored as standalone rules. Sharding produced duplicate semantically-overlapping rule files (16 specs where 6 sources of truth would do). The knob makes codex `AGENTS.md` a reference doc rather than a source of new policy.

## Implementation

- `internal/config/config.go`: new `Import` field, `ImportConfig` + `ImportCodex` types.
- `internal/cli/import_codex.go`: split `importFromCodex` into a wrapper + `importFromCodexWithOpts(root, src, opts)`. Existing tests keep the original signature.
- `internal/cli/import.go`: `runImport*` and `importAll` switched from `config.Sources` → `*config.Config` to thread the new opts through. Codex case fills `importCodexOpts.Shred` from `cfg.Import.Codex.Shred`.
- Schema regenerated via `go run ./cmd/schemagen`.

## Refactor pass

Re-reviewed every touched file. No duplication, dead branches, or speculative abstractions introduced. The monolithic-write block in `importCodexRules` mirrors the existing no-section fallback; extracting a helper for two near-identical 6-line blocks would obscure rather than clarify.

## Test plan
- [x] `go test ./...` (833 passing across 28 packages)
- [x] `./agnostic-ai sync --check` (exit 0)
- [x] `go run ./cmd/schemagen` regenerates `docs/schemas/config.schema.json` with the new `import.codex.shred` field

Closes #248