### PR TITLE
feat(hooks): add target: scoping to prevent cross-tool leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 - `import.codex.shred` config knob. Set to `false` to keep each `AGENTS.md` as a single rule spec instead of sharding it by `##` heading. Default `true` preserves existing behavior. Closes #248.
+- Hook frontmatter accepts `target: <name>` or `targets: [a, b]` to scope a hook to specific CLIs. Empty/omitted keeps legacy "emit everywhere" behavior. Closes #249.
 
 ### Changed
+- `agnostic-ai import <tool>` auto-sets `target: <tool>` on imported hooks (codex/claude/gemini). Codex-specific shell-wrapped hook scripts no longer leak into claude `settings.json` on cross-tool sync. Remove the field by hand if you want a hook to flow to every target.
 
 ### Fixed
 

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -154,6 +154,19 @@ command: "npx prettier --write \"$CLAUDE_FILE_PATHS\""
 | `event` | yes | none | Hook event. See list below. |
 | `matcher` | no | empty | Regex on tool name (or other event-specific selector). |
 | `command` | yes | none | Shell command to run when triggered. |
+| `target` | no | empty | Single target name. Emits only there. Use to scope a hook to one tool. |
+| `targets` | no | empty | List of target names. Emits only to those. Use when a hook makes sense for two tools but not all. |
+
+When neither `target` nor `targets` is set the hook emits to every target that supports hooks (legacy behavior). `target` and `targets` are mutually informative; `target` takes precedence when both appear.
+
+```yaml
+event: PostToolUse
+matcher: apply_patch|Edit|Write
+command: "$(git rev-parse --show-toplevel)/.codex/hooks/format-php.sh"
+target: codex   # shell-expanded codex path; do not leak to other tools
+```
+
+Hooks imported from a tool-native source auto-set `target` to that tool (codex import → `target: codex`, claude import → `target: claude`, gemini import → `target: gemini`). Remove the field by hand if you want the hook to flow everywhere.
 
 ### Supported events (Claude Code)
 

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -101,11 +101,12 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 
-	if err := writeSettings(b.Hooks, dir, cfg, dryRun); err != nil {
+	hooks := b.HooksFor(target)
+	if err := writeSettings(hooks, dir, cfg, dryRun); err != nil {
 		return err
 	}
 
-	if err := materializeHookScripts(b.Hooks, dryRun); err != nil {
+	if err := materializeHookScripts(hooks, dryRun); err != nil {
 		return err
 	}
 

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -394,6 +394,42 @@ func TestEmit_WritesHookSettings(t *testing.T) {
 	}
 }
 
+// A hook scoped to a different target must not surface in claude's
+// settings.json, even though claude supports the kind. Two-hook bundle:
+// one scoped to codex, one un-scoped; only the un-scoped hook lands.
+func TestEmit_HookTargetScopingFiltersOtherTargets(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindHook, Name: "codex-only",
+			Meta: map[string]any{
+				"event": "PostToolUse", "matcher": "Edit",
+				"command": "echo codex", "target": "codex",
+			},
+		},
+		{
+			Kind: spec.KindHook, Name: "everywhere",
+			Meta: map[string]any{
+				"event": "PostToolUse", "matcher": "Edit",
+				"command": "echo all",
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, ".claude/settings.json"))
+	out := string(raw)
+	if !strings.Contains(out, "echo all") {
+		t.Errorf("expected un-scoped hook in claude settings:\n%s", out)
+	}
+	if strings.Contains(out, "echo codex") {
+		t.Errorf("codex-scoped hook should not land in claude settings:\n%s", out)
+	}
+}
+
 // Per-hook timeout (seconds) and statusMessage are first-class Claude
 // schema fields. When the spec carries them via Meta they must propagate
 // to every emitted `hooks[].{...}` object so behavior survives a

--- a/internal/adapters/codex/codex.go
+++ b/internal/adapters/codex/codex.go
@@ -115,7 +115,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emitConfigTOML(b, cfg, dryRun); err != nil {
 		return err
 	}
-	return materializeHookScripts(b.Hooks, dryRun)
+	return materializeHookScripts(b.HooksFor(target), dryRun)
 }
 
 // materializeHookScripts copies each hook's stashed script body from
@@ -177,7 +177,7 @@ func emitConfigTOML(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err != nil {
 		return err
 	}
-	body := renderConfigTOML(b.Hooks, b.MCPs, codexCfg, overlay, overlayKeys)
+	body := renderConfigTOML(b.HooksFor(target), b.MCPs, codexCfg, overlay, overlayKeys)
 	if body == "" {
 		return nil
 	}

--- a/internal/adapters/codex/config_toml_test.go
+++ b/internal/adapters/codex/config_toml_test.go
@@ -113,6 +113,39 @@ func TestEmit_Hook_GroupsByEvent(t *testing.T) {
 	}
 }
 
+// Hooks scoped to another target via `target:` must be skipped entirely
+// from .codex/config.toml so a claude-only hook does not leak into codex.
+func TestEmit_Hook_TargetScopingFiltersOtherTargets(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindHook, Name: "claude-only",
+			Meta: map[string]any{
+				"event": "PostToolUse", "matcher": "Edit",
+				"command": "echo claude", "target": "claude",
+			},
+		},
+		{
+			Kind: spec.KindHook, Name: "codex-rule",
+			Meta: map[string]any{
+				"event": "PostToolUse", "matcher": "Edit",
+				"command": "echo codex", "target": "codex",
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/config.toml"))
+	if !strings.Contains(got, `command = "echo codex"`) {
+		t.Errorf("codex-scoped hook missing in codex config.toml:\n%s", got)
+	}
+	if strings.Contains(got, `command = "echo claude"`) {
+		t.Errorf("claude-scoped hook must not leak into codex config.toml:\n%s", got)
+	}
+}
+
 // A hook spec carrying a command array emits one [[hooks.<event>]] block per command.
 // Same matcher + event share the array; codex's TOML schema has a single command field.
 func TestEmit_Hook_CommandArrayExpandsToMultipleBlocks(t *testing.T) {

--- a/internal/adapters/external/external.go
+++ b/internal/adapters/external/external.go
@@ -165,7 +165,7 @@ func buildInput(target string, b spec.Bundle, cfg *config.Config, dryRun bool) I
 	in.Specs.Agents = entriesToWire(b.Agents)
 	in.Specs.Skills = entriesToWire(b.Skills)
 	in.Specs.Rules = entriesToWire(b.Rules)
-	in.Specs.Hooks = entriesToWire(b.Hooks)
+	in.Specs.Hooks = entriesToWire(b.HooksFor(target))
 	in.Specs.MCPs = entriesToWire(b.MCPs)
 	return in
 }

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -67,7 +67,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emitSettings(b, emit.OutputMCPFile(cfg, target, defaultSettingsFile), dryRun); err != nil {
 		return err
 	}
-	return materializeHookScripts(b.Hooks, dryRun)
+	return materializeHookScripts(b.HooksFor(target), dryRun)
 }
 
 // materializeHookScripts copies each hook's stashed script body from
@@ -95,7 +95,7 @@ func emitSettings(b spec.Bundle, path string, dryRun bool) error {
 	if servers := buildMCPServers(b.MCPs); len(servers) > 0 {
 		keys["mcpServers"] = servers
 	}
-	if hooks := buildHooks(b.Hooks); len(hooks) > 0 {
+	if hooks := buildHooks(b.HooksFor(target)); len(hooks) > 0 {
 		keys["hooks"] = hooks
 	}
 	if len(keys) == 0 {

--- a/internal/adapters/zed/zed.go
+++ b/internal/adapters/zed/zed.go
@@ -57,7 +57,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	}, dryRun); err != nil {
 		return err
 	}
-	if err := emitTasks(b.Hooks, emit.OutputTasksFile(cfg, target, ""), dryRun); err != nil {
+	if err := emitTasks(b.HooksFor(target), emit.OutputTasksFile(cfg, target, ""), dryRun); err != nil {
 		return err
 	}
 	return emitContextServers(b.MCPs, emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)

--- a/internal/cli/import_claude_hooks.go
+++ b/internal/cli/import_claude_hooks.go
@@ -84,6 +84,7 @@ func importClaudeHooks(root, dstDir string) (int, error) {
 				"name":    name,
 				"event":   event,
 				"matcher": g.Matcher,
+				"target":  "claude",
 			}
 			if len(cmds) == 1 {
 				doc["command"] = cmds[0]

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -459,6 +459,7 @@ func writeCodexHooksFromMap(hooks map[codexHookKey]*codexHookSlot, dstDir string
 			"name":    name,
 			"event":   slot.event,
 			"command": h.Command,
+			"target":  "codex",
 		}
 		if h.Matcher != "" {
 			doc["matcher"] = h.Matcher

--- a/internal/cli/import_gemini.go
+++ b/internal/cli/import_gemini.go
@@ -252,8 +252,9 @@ func writeGeminiHooks(hooks map[string]any, dstDir string) (int, error) {
 			}
 			name := hookSpecName(event, matcher, cmds)
 			doc := map[string]any{
-				"name":  name,
-				"event": event,
+				"name":   name,
+				"event":  event,
+				"target": "gemini",
 			}
 			if cmd != "" {
 				doc["command"] = cmd

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -81,6 +81,47 @@ func (e Entry) Description() string {
 	return d
 }
 
+// EmitsTo reports whether this entry should emit for the given target.
+//
+// Entries opt into per-target scoping via the `target` (string) or
+// `targets` (list of strings) frontmatter field. When neither is set the
+// entry emits everywhere a supporting adapter exists (legacy behavior).
+// When set, only adapters whose name appears in the list see the entry.
+//
+// Empty target string short-circuits to true so callers that do not pass
+// a target (tests, ad-hoc tooling) keep historical semantics.
+func (e Entry) EmitsTo(target string) bool {
+	if target == "" {
+		return true
+	}
+	if s, ok := e.Meta["target"].(string); ok && s != "" {
+		return s == target
+	}
+	switch v := e.Meta["targets"].(type) {
+	case []any:
+		if len(v) == 0 {
+			return true
+		}
+		for _, x := range v {
+			if s, ok := x.(string); ok && s == target {
+				return true
+			}
+		}
+		return false
+	case []string:
+		if len(v) == 0 {
+			return true
+		}
+		for _, s := range v {
+			if s == target {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
 // Globs returns the entry's globs frontmatter as a string, or "" if
 // missing or not a string.
 func (e Entry) Globs() string {
@@ -145,6 +186,22 @@ func (b Bundle) All() []Entry {
 	out = append(out, b.Hooks...)
 	out = append(out, b.MCPs...)
 	out = append(out, b.Commands...)
+	return out
+}
+
+// HooksFor returns the subset of b.Hooks that should emit for target,
+// per Entry.EmitsTo. Use this in adapter Emit() loops to honor hook
+// `target:` / `targets:` scoping. Empty target returns b.Hooks verbatim.
+func (b Bundle) HooksFor(target string) []Entry {
+	if target == "" {
+		return b.Hooks
+	}
+	out := make([]Entry, 0, len(b.Hooks))
+	for _, h := range b.Hooks {
+		if h.EmitsTo(target) {
+			out = append(out, h)
+		}
+	}
 	return out
 }
 

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -297,6 +297,60 @@ func TestLoadBundle_TagsLayerProject(t *testing.T) {
 	}
 }
 
+func TestEntry_EmitsTo(t *testing.T) {
+	cases := []struct {
+		name   string
+		meta   map[string]any
+		target string
+		want   bool
+	}{
+		{"no scoping → all targets", nil, "claude", true},
+		{"empty target → permissive", map[string]any{"target": "claude"}, "", true},
+		{"target match", map[string]any{"target": "claude"}, "claude", true},
+		{"target mismatch", map[string]any{"target": "codex"}, "claude", false},
+		{"targets list match", map[string]any{"targets": []any{"claude", "codex"}}, "codex", true},
+		{"targets list miss", map[string]any{"targets": []any{"claude"}}, "codex", false},
+		{"targets []string match", map[string]any{"targets": []string{"gemini"}}, "gemini", true},
+		{"targets []string miss", map[string]any{"targets": []string{"gemini"}}, "claude", false},
+		{"empty target string falls through to permissive", map[string]any{"target": ""}, "claude", true},
+		{"empty targets list permissive", map[string]any{"targets": []any{}}, "claude", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := Entry{Kind: KindHook, Meta: tc.meta}
+			if got := e.EmitsTo(tc.target); got != tc.want {
+				t.Errorf("EmitsTo(%q) = %v, want %v (meta=%v)", tc.target, got, tc.want, tc.meta)
+			}
+		})
+	}
+}
+
+func TestBundle_HooksFor(t *testing.T) {
+	all := Bundle{Hooks: []Entry{
+		{Kind: KindHook, Name: "a"},
+		{Kind: KindHook, Name: "b", Meta: map[string]any{"target": "claude"}},
+		{Kind: KindHook, Name: "c", Meta: map[string]any{"target": "codex"}},
+		{Kind: KindHook, Name: "d", Meta: map[string]any{"targets": []any{"claude", "gemini"}}},
+	}}
+	got := all.HooksFor("claude")
+	gotNames := make([]string, len(got))
+	for i, h := range got {
+		gotNames[i] = h.Name
+	}
+	want := []string{"a", "b", "d"}
+	if len(got) != len(want) {
+		t.Fatalf("HooksFor(claude) = %v, want %v", gotNames, want)
+	}
+	for i, n := range want {
+		if gotNames[i] != n {
+			t.Errorf("at %d: got %q, want %q", i, gotNames[i], n)
+		}
+	}
+	if untouched := all.HooksFor(""); len(untouched) != 4 {
+		t.Errorf("empty target should return all hooks, got %d", len(untouched))
+	}
+}
+
 func defaultsForTest() *config.Config {
 	return &config.Config{
 		Sources: config.Sources{

--- a/tests/integration/chain_roundtrip_test.go
+++ b/tests/integration/chain_roundtrip_test.go
@@ -107,6 +107,14 @@ func TestRoundTrip_ClaudeCodexClaude(t *testing.T) {
 // The codex overlay must carry every non-managed `.codex/config.toml`
 // key through the chain so the final config.toml still has the
 // user-authored `model`, `[profiles.*]`, `[history]` blocks.
+//
+// Hooks imported from codex are auto-tagged `target: codex` (per #249) so
+// they intentionally do NOT leak into claude on the intermediate sync.
+// That means after wiping specs and re-importing from claude, the hook
+// is no longer in the bundle; the round-trip preserves overlay + MCP
+// state but not the codex-scoped hook. To exercise hook round-trip the
+// other test (TestRoundTrip_ClaudeCodexClaude) covers the symmetric
+// claude-scoped path.
 func TestRoundTrip_CodexClaudeCodex(t *testing.T) {
 	dir := t.TempDir()
 	seedCodexNative(t, dir)
@@ -130,11 +138,26 @@ func TestRoundTrip_CodexClaudeCodex(t *testing.T) {
 	assertContains(t, filepath.Join(dir, ".codex/prompts/release.md"),
 		"release helper body")
 	assertContains(t, filepath.Join(dir, ".codex/config.toml"),
-		`[mcp_servers.fs]`, `command = "npx"`,
-		`[[hooks.PostToolUse]]`, `matcher = "Edit"`, `command = "echo edited"`)
+		`[mcp_servers.fs]`, `command = "npx"`)
 	// Overlay carries first-class codex config keys through the chain.
 	assertContains(t, filepath.Join(dir, ".codex/config.toml"),
 		`model = "gpt-5"`, `[profiles.work]`)
+	// Codex-scoped hook must not have leaked to claude during the
+	// intermediate sync, so it is gone after re-import from claude.
+	assertAbsent(t, filepath.Join(dir, ".codex/config.toml"),
+		`[[hooks.PostToolUse]]`)
+}
+
+// assertAbsent fails when path contains substr.
+func assertAbsent(t *testing.T, path, substr string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if strings.Contains(string(data), substr) {
+		t.Errorf("%s unexpectedly contains %q", path, substr)
+	}
 }
 
 func runCmd(t *testing.T, args ...string) {


### PR DESCRIPTION
## Summary

- Hook frontmatter accepts `target: <name>` or `targets: [a, b]`. Hook emits only to listed adapters. Empty/omitted = legacy emit-everywhere.
- Tool-native importers (codex/claude/gemini) auto-set `target: <tool>` on hooks they read so codex-specific shell-wrapped paths and claude-only `PreCompact`-style hooks stay scoped.
- Filtering applied in claude, codex, gemini, zed, and external adapters via `Bundle.HooksFor(target)`.

## Implementation

- `internal/spec/spec.go`: new `Entry.EmitsTo(target)` + `Bundle.HooksFor(target)`. Permissive on empty target string and on `target: \"\"` so callers without target pass-through stay correct.
- Adapters call `b.HooksFor(target)` at every hook-iteration site (`writeSettings`, `materializeHookScripts`, `buildHooks`, `emitTasks`, `renderConfigTOML`, `entriesToWire`).
- Importers inject `\"target\": \"<tool>\"` into the doc map before YAML-marshalling each hook spec.
- Updated `TestRoundTrip_CodexClaudeCodex` to assert the codex-scoped hook does NOT leak through claude — that was the bug the issue called out. Added an `assertAbsent` helper used by the new assertion.

## Behavior change

Previously, importing a hook from one tool and syncing to a sibling would emit that hook everywhere. After this PR, imported hooks are scoped to their source tool by default. Existing users who want a hook to flow to every target can strip the auto-set `target:` field from the imported spec.

## Refactor pass

Re-reviewed every touched file. Lifted the missing `b.Hooks` filter call into the `external` adapter so its forwarded bundle honors the same scoping as the in-tree adapters — committed separately as a `ref(...)`.

## Test plan
- [x] `go test ./...` (847 passing across 28 packages)
- [x] `./agnostic-ai sync --check` (exit 0)
- [x] New unit tests cover `EmitsTo` matrix + `HooksFor` filter
- [x] New adapter integration tests assert claude-scoped hook does not land in codex `config.toml`, and codex-scoped hook does not land in claude `settings.json`

Closes #249