### PR TITLE
fix(hooks): rewrite sibling hook prefixes inside shell expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - `agnostic-ai import <tool>` auto-sets `target: <tool>` on imported hooks (codex/claude/gemini). Codex-specific shell-wrapped hook scripts no longer leak into claude `settings.json` on cross-tool sync. Remove the field by hand if you want a hook to flow to every target.
 
 ### Fixed
+- `RewriteHookPath` rewrites every `.<sibling>/hooks/` occurrence in a hook command, not just bare-prefix and quoted forms. Hooks authored with shell expansions like `"$(git rev-parse --show-toplevel)/.codex/hooks/x.sh"` now sync cleanly to sibling targets. Pair with `target:` frontmatter (#249) for hooks that must stay scoped to one tool. Closes #250.
 
 ### Removed
 

--- a/internal/adapters/internal/emit/hook_path.go
+++ b/internal/adapters/internal/emit/hook_path.go
@@ -28,22 +28,26 @@ var hookSiblingPrefixes = []string{
 	".gemini/hooks/",
 }
 
-// RewriteHookPath returns cmd with a recognized sibling-tool hook
-// directory prefix replaced by `.<target>/hooks/`. When cmd does not
-// start with any recognized prefix it is returned unchanged so non-hook
-// commands stay verbatim.
+// RewriteHookPath returns cmd with every recognized sibling-tool hook
+// directory substring replaced by `.<target>/hooks/`. Scans the whole
+// command so paths wrapped in shell expansions (`"$(git rev-parse
+// --show-toplevel)/.codex/hooks/x.sh"`), absolute paths, or quoted
+// strings all rewrite. Same-target substrings stay put (no-op).
+//
+// Substring match has a small false-positive risk if the literal text
+// `.codex/hooks/` appears in a hook command for non-path reasons; the
+// substring is specific enough that this is acceptable, and the user
+// can pin a hook to one tool with the `target:` frontmatter field.
 func RewriteHookPath(cmd, target string) string {
 	if cmd == "" || target == "" {
 		return cmd
 	}
+	replacement := "." + target + "/hooks/"
 	for _, prefix := range hookSiblingPrefixes {
-		if strings.HasPrefix(cmd, prefix) {
-			return "." + target + "/hooks/" + cmd[len(prefix):]
+		if prefix == replacement {
+			continue
 		}
-		quoted := `"` + prefix
-		if strings.HasPrefix(cmd, quoted) {
-			return `"` + "." + target + "/hooks/" + cmd[len(quoted):]
-		}
+		cmd = strings.ReplaceAll(cmd, prefix, replacement)
 	}
 	return cmd
 }

--- a/internal/adapters/internal/emit/hook_path_test.go
+++ b/internal/adapters/internal/emit/hook_path_test.go
@@ -48,6 +48,30 @@ func TestRewriteHookPath_TranslatesSiblingPrefix(t *testing.T) {
 			target: "codex",
 			want:   "",
 		},
+		{
+			name:   "shell-expanded path rewrites embedded prefix",
+			cmd:    `"$(git rev-parse --show-toplevel)/.codex/hooks/protect-files.sh"`,
+			target: "claude",
+			want:   `"$(git rev-parse --show-toplevel)/.claude/hooks/protect-files.sh"`,
+		},
+		{
+			name:   "absolute path with embedded sibling prefix rewrites",
+			cmd:    "/usr/local/bin/runner /tmp/.gemini/hooks/run.sh",
+			target: "claude",
+			want:   "/usr/local/bin/runner /tmp/.claude/hooks/run.sh",
+		},
+		{
+			name:   "multiple sibling prefixes in one command all rewrite",
+			cmd:    ".codex/hooks/pre.sh && .gemini/hooks/post.sh",
+			target: "claude",
+			want:   ".claude/hooks/pre.sh && .claude/hooks/post.sh",
+		},
+		{
+			name:   "same-target shell expansion is a no-op",
+			cmd:    `"$(pwd)/.claude/hooks/x.sh"`,
+			target: "claude",
+			want:   `"$(pwd)/.claude/hooks/x.sh"`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `RewriteHookPath` now scans the entire command and replaces every `.<sibling>/hooks/` occurrence with `.<target>/hooks/`. Previously only bare-prefix and quoted-prefix forms matched.
- Fixes the case where a codex hook authored as `"$(git rev-parse --show-toplevel)/.codex/hooks/x.sh"` sync'd to claude with the codex path still embedded inside the shell expression.

## Implementation

- `internal/adapters/internal/emit/hook_path.go`: replaced the two `strings.HasPrefix` branches with a `strings.ReplaceAll` loop over `hookSiblingPrefixes`. Skip the no-op same-target prefix.
- 4 new test cases: shell-expanded path, absolute path with embedded prefix, multiple prefixes in one command, same-target no-op.

## Trade-off

Substring match has a small false-positive risk if the literal `.<tool>/hooks/` substring appears in a hook command for non-path reasons (e.g. an `echo` literal). Pair with `target:` frontmatter (#249) for hooks that must stay scoped to one tool.

## Refactor pass

Single-file change. Re-reviewed the diff for naming/style; replacement is shorter than the original two-branch implementation, no extra abstraction needed. No further cleanup.

## Test plan
- [x] `go test ./...` (851 passing across 28 packages)
- [x] New regression tests cover shell-expansion + multi-occurrence + same-target no-op

Closes #250