### PR TITLE
feat(doctor): warn on divergent hook script bodies across tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ### Added
 - `import.codex.shred` config knob. Set to `false` to keep each `AGENTS.md` as a single rule spec instead of sharding it by `##` heading. Default `true` preserves existing behavior. Closes #248.
 - Hook frontmatter accepts `target: <name>` or `targets: [a, b]` to scope a hook to specific CLIs. Empty/omitted keeps legacy "emit everywhere" behavior. Closes #249.
+- `agnostic-ai doctor` flags divergent hook script bodies under `.agnostic-ai/scripts/<tool>/<basename>`. When the same basename exists for two or more tools with different SHA-256 bodies, doctor lists the per-tool sizes/hashes and suggests consolidating to `.agnostic-ai/scripts/<basename>`. Not auto-fixable. Closes #251.
 
 ### Changed
 - `agnostic-ai import <tool>` auto-sets `target: <tool>` on imported hooks (codex/claude/gemini). Codex-specific shell-wrapped hook scripts no longer leak into claude `settings.json` on cross-tool sync. Remove the field by hand if you want a hook to flow to every target.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -394,6 +394,15 @@ hint. HTTP/SSE servers (no command, only `url:`) skip the check. The
 report is advisory: a missing binary is an environment problem, not a
 spec problem, so it does not change doctor's exit code.
 
+After the MCP block, doctor walks `.agnostic-ai/scripts/<tool>/` per
+tool and groups files by basename. When the same basename exists under
+two or more tools with different SHA-256 bodies it prints one finding
+per divergent script (sizes + truncated hashes per variant) and the
+suggested consolidation path `.agnostic-ai/scripts/<basename>`.
+Divergence registers as drift and contributes to a non-zero exit
+because it usually represents an unnoticed import diff between tools.
+Not auto-fixable: choosing which body wins requires human judgement.
+
 ## status
 
 Show project configuration and current sync state. Exits 0 even when drift is

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -242,6 +242,13 @@ func newDoctorCmd() *cobra.Command {
 			// 5. MCP resolution
 			reportMCPCommandResolution(cmd)
 
+			// 5b. Hook script body divergence across per-tool stashes.
+			scriptDrift, err := reportDivergentHookScripts(cmd, ".")
+			if err != nil {
+				return err
+			}
+			hasDrift = hasDrift || scriptDrift
+
 			// 6. Next step
 			doctorNextStep(cmd, hasDrift, true)
 

--- a/internal/cli/doctor_hook_scripts.go
+++ b/internal/cli/doctor_hook_scripts.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// hookScriptVariant records one body of a same-named hook script captured
+// for a specific source tool under `.agnostic-ai/scripts/<tool>/<basename>`.
+type hookScriptVariant struct {
+	tool string
+	path string
+	size int64
+	sha  string
+}
+
+// reportDivergentHookScripts walks `.agnostic-ai/scripts/<tool>/` and
+// flags any basename that exists under two or more tools with different
+// SHA-256 bodies. Same-content duplicates are silent. Drift is not
+// auto-fixable; reconciliation needs human judgement about which body
+// wins.
+func reportDivergentHookScripts(cmd *cobra.Command, root string) (bool, error) {
+	cmd.Println()
+	cmd.Println("Hook script divergence:")
+
+	scriptsRoot := filepath.Join(root, agnosticScriptsDir)
+	variants, err := collectHookScriptVariants(scriptsRoot)
+	if err != nil {
+		return false, err
+	}
+	if len(variants) == 0 {
+		cmd.Println("  (no per-tool hook scripts captured)")
+		return false, nil
+	}
+
+	diverged := false
+	basenames := make([]string, 0, len(variants))
+	for b := range variants {
+		basenames = append(basenames, b)
+	}
+	sort.Strings(basenames)
+	for _, basename := range basenames {
+		vs := variants[basename]
+		if len(vs) < 2 || allSameHash(vs) {
+			continue
+		}
+		diverged = true
+		tools := make([]string, len(vs))
+		for i, v := range vs {
+			tools[i] = v.tool
+		}
+		cmd.Printf("  ✗ divergent hook script: scripts/{%s}/%s\n",
+			joinSorted(tools), basename)
+		for _, v := range vs {
+			cmd.Printf("      %-7s variant: %d bytes  sha256: %s\n",
+				v.tool, v.size, v.sha[:12])
+		}
+		cmd.Println("      consolidate by moving the agreed body to")
+		cmd.Printf("      %s/%s and deleting the per-tool copies,\n",
+			agnosticScriptsDir, basename)
+		cmd.Println("      or document the intentional divergence in a sibling note.")
+	}
+	if !diverged {
+		cmd.Println("  ✓ no divergent hook scripts")
+	}
+	return diverged, nil
+}
+
+// collectHookScriptVariants returns basename → variants list for every
+// per-tool hook script captured under root. Returns an empty map (no
+// error) when root does not exist.
+func collectHookScriptVariants(root string) (map[string][]hookScriptVariant, error) {
+	out := map[string][]hookScriptVariant{}
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return out, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", root, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		toolDir := filepath.Join(root, e.Name())
+		files, err := os.ReadDir(toolDir)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", toolDir, err)
+		}
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			path := filepath.Join(toolDir, f.Name())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("read %s: %w", path, err)
+			}
+			sum := sha256.Sum256(data)
+			info, err := f.Info()
+			if err != nil {
+				return nil, fmt.Errorf("stat %s: %w", path, err)
+			}
+			out[f.Name()] = append(out[f.Name()], hookScriptVariant{
+				tool: e.Name(),
+				path: path,
+				size: info.Size(),
+				sha:  hex.EncodeToString(sum[:]),
+			})
+		}
+	}
+	// Sort each variant slice by tool for stable output.
+	for k := range out {
+		sort.Slice(out[k], func(i, j int) bool { return out[k][i].tool < out[k][j].tool })
+	}
+	return out, nil
+}
+
+// allSameHash reports whether every variant has the same body sha.
+func allSameHash(vs []hookScriptVariant) bool {
+	for i := 1; i < len(vs); i++ {
+		if vs[i].sha != vs[0].sha {
+			return false
+		}
+	}
+	return true
+}
+
+// joinSorted returns the tool names comma-joined in alphabetical order,
+// used inside the `scripts/{<tools>}/<basename>` finding line.
+func joinSorted(tools []string) string {
+	cp := append([]string(nil), tools...)
+	sort.Strings(cp)
+	return strings.Join(cp, ",")
+}

--- a/internal/cli/doctor_hook_scripts_test.go
+++ b/internal/cli/doctor_hook_scripts_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestReportDivergentHookScripts_FlagsDifferentBodies(t *testing.T) {
+	root := t.TempDir()
+	mustWriteHookScript(t, root, "claude", "protect-files.sh", "echo claude\n")
+	mustWriteHookScript(t, root, "codex", "protect-files.sh", "echo codex (different)\n")
+
+	cmd := newSilentCobra()
+	drift, err := reportDivergentHookScripts(cmd, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !drift {
+		t.Error("expected drift=true for divergent bodies")
+	}
+	out := cmd.OutOrStderr().(*bytes.Buffer).String()
+	for _, want := range []string{
+		"✗ divergent hook script: scripts/{claude,codex}/protect-files.sh",
+		"claude  variant:",
+		"codex   variant:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("doctor output missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestReportDivergentHookScripts_SilentOnIdenticalBodies(t *testing.T) {
+	root := t.TempDir()
+	body := "echo same\n"
+	mustWriteHookScript(t, root, "claude", "protect-files.sh", body)
+	mustWriteHookScript(t, root, "codex", "protect-files.sh", body)
+
+	cmd := newSilentCobra()
+	drift, err := reportDivergentHookScripts(cmd, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drift {
+		t.Error("expected drift=false for identical bodies")
+	}
+	out := cmd.OutOrStderr().(*bytes.Buffer).String()
+	if !strings.Contains(out, "✓ no divergent hook scripts") {
+		t.Errorf("expected clean line, got:\n%s", out)
+	}
+}
+
+func TestReportDivergentHookScripts_NoScriptsDir(t *testing.T) {
+	root := t.TempDir()
+
+	cmd := newSilentCobra()
+	drift, err := reportDivergentHookScripts(cmd, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drift {
+		t.Error("expected drift=false when .agnostic-ai/scripts/ is absent")
+	}
+	out := cmd.OutOrStderr().(*bytes.Buffer).String()
+	if !strings.Contains(out, "(no per-tool hook scripts captured)") {
+		t.Errorf("expected empty-stash notice, got:\n%s", out)
+	}
+}
+
+// A script appearing under only one tool is not divergence — silent.
+func TestReportDivergentHookScripts_SingleToolNotFlagged(t *testing.T) {
+	root := t.TempDir()
+	mustWriteHookScript(t, root, "codex", "lone.sh", "echo lone\n")
+
+	cmd := newSilentCobra()
+	drift, err := reportDivergentHookScripts(cmd, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drift {
+		t.Error("single-tool script should not register as divergence")
+	}
+}
+
+func mustWriteHookScript(t *testing.T, root, tool, basename, body string) {
+	t.Helper()
+	dir := filepath.Join(root, agnosticScriptsDir, tool)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, basename), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newSilentCobra() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetOut(&bytes.Buffer{})
+	c.SetErr(&bytes.Buffer{})
+	return c
+}


### PR DESCRIPTION
## Summary

- `agnostic-ai doctor` now walks `.agnostic-ai/scripts/<tool>/<basename>` and flags any basename appearing under two or more tools with different SHA-256 bodies.
- Each finding prints per-tool size + truncated hash and suggests consolidating to `.agnostic-ai/scripts/<basename>`.
- Divergence registers as drift and contributes to a non-zero `doctor` exit.

## Why

When a repo imports both Claude and Codex into a single project, the two tools may ship different implementations of a same-named script (Phel-lang shipped `.claude/hooks/protect-files.sh` at 395B and `.codex/hooks/protect-files.sh` at 1.5K). Today the stash silently keeps both and each tool gets a different body on sync; the maintainer rarely notices.

## Implementation

- New `internal/cli/doctor_hook_scripts.go`: `reportDivergentHookScripts` + `collectHookScriptVariants`.
- Hooked into `newDoctorCmd` between MCP resolution and "Next step" sections. `hasDrift = hasDrift || scriptDrift` so divergence flips the exit code.
- 4 unit tests cover: different bodies → flagged, identical bodies → silent, no scripts dir → silent, single tool → silent.

## Not auto-fixable

`--fix` is intentionally not wired up. Picking which body wins requires human judgement — could be the older import got out of date, could be intentional tool-specific divergence.

## Refactor pass

Re-reviewed the new file. Collapsed a 9-line hand-rolled comma join into `strings.Join(sort.Strings(...))`. No further cleanup needed.

## Test plan
- [x] `go test ./...` (855 passing across 28 packages)
- [x] `./agnostic-ai sync --check` (exit 0)
- [x] New unit tests cover divergence + clean + empty + single-tool cases

Closes #251