### PR TITLE
feat(codex): render .codex/rules/default.rules from exec-policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - `import.codex.shred` config knob. Set to `false` to keep each `AGENTS.md` as a single rule spec instead of sharding it by `##` heading. Default `true` preserves existing behavior. Closes #248.
 - Hook frontmatter accepts `target: <name>` or `targets: [a, b]` to scope a hook to specific CLIs. Empty/omitted keeps legacy "emit everywhere" behavior. Closes #249.
 - `agnostic-ai doctor` flags divergent hook script bodies under `.agnostic-ai/scripts/<tool>/<basename>`. When the same basename exists for two or more tools with different SHA-256 bodies, doctor lists the per-tool sizes/hashes and suggests consolidating to `.agnostic-ai/scripts/<basename>`. Not auto-fixable. Closes #251.
+- `outputs.codex.exec-policies` (inline list) and `outputs.codex.exec-policies-file` (external YAML) render Codex CLI's Skylark `prefix_rule(...)` exec-policy DSL into `.codex/rules/default.rules`. Each entry declares `pattern`, `decision` (`allow`/`forbidden`/`ask`), optional `justification`, and optional `match` examples. No file is written when no policies are declared. Closes #254.
 
 ### Changed
 - `agnostic-ai import <tool>` auto-sets `target: <tool>` on imported hooks (codex/claude/gemini). Codex-specific shell-wrapped hook scripts no longer leak into claude `settings.json` on cross-tool sync. Remove the field by hand if you want a hook to flow to every target.

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -123,6 +123,34 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "CodexExecPolicy": {
+      "properties": {
+        "pattern": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "decision": {
+          "type": "string"
+        },
+        "justification": {
+          "type": "string"
+        },
+        "match": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "pattern",
+        "decision"
+      ]
+    },
     "CodexModelProvider": {
       "properties": {
         "name": {
@@ -301,6 +329,15 @@
         },
         "config": {
           "$ref": "#/$defs/CodexConfig"
+        },
+        "exec-policies": {
+          "items": {
+            "$ref": "#/$defs/CodexExecPolicy"
+          },
+          "type": "array"
+        },
+        "exec-policies-file": {
+          "type": "string"
         },
         "collision-policy": {
           "type": "string"

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -83,6 +83,12 @@ outputs:
     #                            # claude's .claude/skills/ tree directly.
     commands-dir: .codex/prompts # default. One .md per command (slash prompt).
     mcp-file: .codex/config.toml # default. Holds both [[hooks.<event>]] and [mcp_servers.<name>].
+    # exec-policies:              # opt-in. Renders .codex/rules/default.rules.
+    #   - pattern: ["composer", "test"]
+    #     decision: allow          # allow | forbidden | ask
+    #     justification: Run tests
+    #     match: ["composer test"]
+    # exec-policies-file: ./agnostic-ai/codex.exec-policies.yaml  # alt: external YAML list
   gemini:
     commands-dir: .gemini/commands   # default. One .toml per agent (and per skill when opted in).
     emit-skills-as-commands: false   # default
@@ -386,6 +392,34 @@ outputs:
 | `notify` | string array | External program Codex invokes on session events. First element is the executable; rest are arguments. |
 | `profiles` | map | Named `[profiles.<name>]` blocks. Each entry overrides top-level fields when Codex runs with `--profile <name>`. Supported keys: `model`, `sandbox`, `approval-policy`, `model-reasoning-effort`, `model-reasoning-summary`, `model-provider`. |
 | `model-providers` | map | Named `[model_providers.<id>]` blocks declaring backends Codex can call. Supported keys: `name`, `base-url`, `wire-api`, `api-key-env`, `env-key`. Reference an `id` from `profiles.<name>.model-provider`. |
+
+### Codex exec-policies
+
+`outputs.codex.exec-policies` (list) or `outputs.codex.exec-policies-file` (path to a YAML list) declares Codex CLI's Skylark-flavored exec-policy DSL, rendered into `.codex/rules/default.rules` on sync. Each entry allow- or forbid-lists a shell command prefix.
+
+```yaml
+outputs:
+  codex:
+    exec-policies:
+      - pattern: ["composer", "test"]
+        decision: allow           # allow | forbidden | ask
+        justification: Composer scripts are project entrypoints.
+        match: ["composer test", "composer test -- --filter Foo"]
+      - pattern: ["rm", "-rf", "/"]
+        decision: forbidden
+        justification: Never remove the filesystem root.
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `pattern` | yes | Shell command prefix tokens (`["composer", "test"]`). Becomes the `prefix_rule(pattern = [...])` argument. |
+| `decision` | yes | One of `allow`, `forbidden`, `ask`. |
+| `justification` | no | Free-form comment emitted above the rule as a `#` line. |
+| `match` | no | Example matches rendered as commented `# match: ...` lines below the rule. Documentation only; Codex CLI ignores them. |
+
+For projects with many policies, keep them in a separate YAML file and point `exec-policies-file: ./.agnostic-ai/codex.exec-policies.yaml`. Inline entries render first, then file entries — order matters because Codex evaluates rules top-down.
+
+The file is only written when at least one policy is declared; otherwise nothing under `.codex/rules/` is created.
 
 The codex emitter also reads `.agnostic-ai/overlays/codex.config.toml`
 (captured by `agnostic-ai import codex`) and prepends its body before

--- a/internal/adapters/codex/codex.go
+++ b/internal/adapters/codex/codex.go
@@ -115,6 +115,9 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emitConfigTOML(b, cfg, dryRun); err != nil {
 		return err
 	}
+	if err := emitExecPolicies(cfg, dryRun); err != nil {
+		return err
+	}
 	return materializeHookScripts(b.HooksFor(target), dryRun)
 }
 

--- a/internal/adapters/codex/exec_policies.go
+++ b/internal/adapters/codex/exec_policies.go
@@ -1,0 +1,130 @@
+package codex
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const defaultExecPoliciesFile = ".codex/rules/default.rules"
+
+// emitExecPolicies writes the Skylark-flavored `prefix_rule(...)` file at
+// `.codex/rules/default.rules` from the declarative list in
+// `outputs.codex.exec-policies` (inline) or `outputs.codex.exec-policies-file`
+// (path to a YAML list). The file is the exec-policy DSL Codex CLI reads to
+// allow- or forbid-list shell command prefixes for repo automation.
+//
+// No-op when neither field is set so users who do not opt in get no
+// surprise file under `.codex/rules/`.
+func emitExecPolicies(cfg *config.Config, dryRun bool) error {
+	policies, err := loadExecPolicies(cfg)
+	if err != nil {
+		return err
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+	for i, p := range policies {
+		if err := validateExecPolicy(p, i); err != nil {
+			return err
+		}
+	}
+	body := renderExecPoliciesSkylark(policies)
+	// Skylark uses `#` line comments — same as YAML — so reuse the YAML
+	// header so the provenance banner sits inside a comment block.
+	return emit.WriteFile(defaultExecPoliciesFile, emit.WithHeader(body, emit.FormatYAML), dryRun)
+}
+
+// loadExecPolicies pulls inline policies from `outputs.codex.exec-policies`
+// and appends any read from `outputs.codex.exec-policies-file` (when set).
+// The file-derived entries land after the inline entries; ordering matters
+// because Codex CLI evaluates rules top-down.
+func loadExecPolicies(cfg *config.Config) ([]config.CodexExecPolicy, error) {
+	out, ok := cfg.Outputs[target]
+	if !ok {
+		return nil, nil
+	}
+	policies := append([]config.CodexExecPolicy(nil), out.ExecPolicies...)
+	if out.ExecPoliciesFile == "" {
+		return policies, nil
+	}
+	data, err := os.ReadFile(out.ExecPoliciesFile)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", out.ExecPoliciesFile, err)
+	}
+	var extra []config.CodexExecPolicy
+	if err := yaml.Unmarshal(data, &extra); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", out.ExecPoliciesFile, err)
+	}
+	policies = append(policies, extra...)
+	return policies, nil
+}
+
+// validateExecPolicy enforces the minimal schema. Index is included in
+// the error so users with a long list can find the offender.
+func validateExecPolicy(p config.CodexExecPolicy, index int) error {
+	if len(p.Pattern) == 0 {
+		return fmt.Errorf("exec-policies[%d]: pattern must not be empty", index)
+	}
+	switch p.Decision {
+	case "allow", "forbidden", "ask":
+	default:
+		return fmt.Errorf("exec-policies[%d]: decision must be allow|forbidden|ask, got %q", index, p.Decision)
+	}
+	return nil
+}
+
+// renderExecPoliciesSkylark turns the policy list into the Codex CLI's
+// `prefix_rule(...)` DSL. Each policy renders as one block. Justification
+// appears as a leading `# ...` comment; example matches go below the
+// rule as commented examples for human readers.
+func renderExecPoliciesSkylark(policies []config.CodexExecPolicy) string {
+	var b strings.Builder
+	for i, p := range policies {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if p.Justification != "" {
+			for _, line := range strings.Split(strings.TrimSpace(p.Justification), "\n") {
+				b.WriteString("# ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+		}
+		b.WriteString("prefix_rule(\n")
+		b.WriteString("    pattern = ")
+		writeStringList(&b, p.Pattern)
+		b.WriteString(",\n")
+		b.WriteString(fmt.Sprintf("    decision = %q,\n", p.Decision))
+		b.WriteString(")\n")
+		for _, m := range p.Match {
+			b.WriteString("# match: ")
+			b.WriteString(m)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// writeStringList writes a Python/Skylark string list literal:
+// `["a", "b", "c"]`. Empty list is `[]`.
+func writeStringList(b *strings.Builder, xs []string) {
+	if len(xs) == 0 {
+		b.WriteString("[]")
+		return
+	}
+	b.WriteByte('[')
+	for i, s := range xs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(b, "%q", s)
+	}
+	b.WriteByte(']')
+}
+

--- a/internal/adapters/codex/exec_policies.go
+++ b/internal/adapters/codex/exec_policies.go
@@ -127,4 +127,3 @@ func writeStringList(b *strings.Builder, xs []string) {
 	}
 	b.WriteByte(']')
 }
-

--- a/internal/adapters/codex/exec_policies_test.go
+++ b/internal/adapters/codex/exec_policies_test.go
@@ -1,0 +1,140 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func TestEmit_ExecPolicies_WritesSkylarkDSL(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"codex": {ExecPolicies: []config.CodexExecPolicy{
+			{
+				Pattern:       []string{"composer", "test"},
+				Decision:      "allow",
+				Justification: "Composer scripts are project entrypoints.",
+				Match:         []string{"composer test", "composer test -- --filter Foo"},
+			},
+			{
+				Pattern:       []string{"rm", "-rf", "/"},
+				Decision:      "forbidden",
+				Justification: "Never remove the filesystem root.",
+			},
+		}},
+	}}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".codex/rules/default.rules"))
+	if err != nil {
+		t.Fatalf("expected .codex/rules/default.rules: %v", err)
+	}
+	out := string(got)
+	for _, want := range []string{
+		"# Composer scripts are project entrypoints.",
+		`pattern = ["composer", "test"]`,
+		`decision = "allow"`,
+		"# match: composer test",
+		"# Never remove the filesystem root.",
+		`pattern = ["rm", "-rf", "/"]`,
+		`decision = "forbidden"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("default.rules missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// Empty / unset exec-policies must not create the file.
+func TestEmit_ExecPolicies_NoFileWhenUnset(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	if err := New().Emit(spec.NewBundle(nil), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".codex/rules/default.rules")); !os.IsNotExist(err) {
+		t.Errorf("expected no default.rules when exec-policies unset, got: %v", err)
+	}
+}
+
+// Empty pattern is a hard error so a typo does not silently emit a
+// no-op rule that would block real commands.
+func TestEmit_ExecPolicies_EmptyPatternErrors(t *testing.T) {
+	testutil.TempCwd(t)
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"codex": {ExecPolicies: []config.CodexExecPolicy{
+			{Pattern: nil, Decision: "allow"},
+		}},
+	}}
+	err := New().Emit(spec.NewBundle(nil), cfg, false)
+	if err == nil || !strings.Contains(err.Error(), "pattern must not be empty") {
+		t.Errorf("expected pattern-empty error, got: %v", err)
+	}
+}
+
+func TestEmit_ExecPolicies_BadDecisionErrors(t *testing.T) {
+	testutil.TempCwd(t)
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"codex": {ExecPolicies: []config.CodexExecPolicy{
+			{Pattern: []string{"x"}, Decision: "maybe"},
+		}},
+	}}
+	err := New().Emit(spec.NewBundle(nil), cfg, false)
+	if err == nil || !strings.Contains(err.Error(), "decision must be allow|forbidden|ask") {
+		t.Errorf("expected bad-decision error, got: %v", err)
+	}
+}
+
+// `exec-policies-file` lets a project keep many entries in a separate YAML
+// file instead of inlining them in agnostic-ai.yaml. Inline entries (when
+// present) come first; file entries append.
+func TestEmit_ExecPolicies_LoadsFromFile(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	policiesFile := filepath.Join(dir, "policies.yaml")
+	if err := os.WriteFile(policiesFile, []byte(`- pattern: ["composer", "fix"]
+  decision: allow
+  justification: Run formatters.
+- pattern: ["sudo"]
+  decision: forbidden
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"codex": {
+			ExecPolicies: []config.CodexExecPolicy{
+				{Pattern: []string{"composer", "test"}, Decision: "allow"},
+			},
+			ExecPoliciesFile: policiesFile,
+		},
+	}}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, ".codex/rules/default.rules"))
+	out := string(got)
+	for _, want := range []string{
+		`pattern = ["composer", "test"]`,
+		`pattern = ["composer", "fix"]`,
+		`pattern = ["sudo"]`,
+		`decision = "forbidden"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	// Inline entry must appear before file entries.
+	inlinePos := strings.Index(out, `pattern = ["composer", "test"]`)
+	filePos := strings.Index(out, `pattern = ["composer", "fix"]`)
+	if inlinePos == -1 || filePos == -1 || inlinePos > filePos {
+		t.Errorf("inline entries should render before file entries; inline=%d file=%d", inlinePos, filePos)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,23 @@ type Sources struct {
 	Commands string `yaml:"commands,omitempty" json:"commands,omitempty"`
 }
 
+// CodexExecPolicy describes one Skylark-flavored `prefix_rule(...)` entry
+// emitted into `.codex/rules/default.rules`. Codex CLI consumes that file
+// as an exec-policy DSL that allow- or forbid-lists shell command
+// prefixes; agnostic-ai users declare the data declaratively in
+// `agnostic-ai.yaml` and the codex adapter renders the file.
+type CodexExecPolicy struct {
+	// Pattern is the shell command prefix tokens, e.g. ["composer", "test"].
+	Pattern []string `yaml:"pattern"                 json:"pattern"`
+	// Decision is one of "allow", "forbidden", "ask".
+	Decision string `yaml:"decision"                json:"decision"`
+	// Justification is a free-form comment emitted alongside the rule.
+	Justification string `yaml:"justification,omitempty" json:"justification,omitempty"`
+	// Match enumerates example commands the rule applies to. Optional;
+	// when present they appear as a `# match:` comment block.
+	Match []string `yaml:"match,omitempty"         json:"match,omitempty"`
+}
+
 type Output struct {
 	Dir                  string          `yaml:"dir,omitempty"                      json:"dir,omitempty"`
 	File                 string          `yaml:"file,omitempty"                     json:"file,omitempty"`
@@ -105,11 +122,13 @@ type Output struct {
 	Model                string          `yaml:"model,omitempty"                    json:"model,omitempty"`
 	WeakModel            string          `yaml:"weak-model,omitempty"               json:"weak-model,omitempty"`
 	MCPDir               string          `yaml:"mcp-dir,omitempty"                  json:"mcp-dir,omitempty"`
-	EmitSkillsAsCommands bool            `yaml:"emit-skills-as-commands,omitempty"  json:"emit-skills-as-commands,omitempty"`
-	SharedSubagents      *bool           `yaml:"shared-subagents,omitempty"         json:"shared-subagents,omitempty"`
-	Settings             *ClaudeSettings `yaml:"settings,omitempty"                 json:"settings,omitempty"`
-	Config               *CodexConfig    `yaml:"config,omitempty"                   json:"config,omitempty"`
-	CollisionPolicy      string          `yaml:"collision-policy,omitempty"         json:"collision-policy,omitempty"`
+	EmitSkillsAsCommands bool              `yaml:"emit-skills-as-commands,omitempty"  json:"emit-skills-as-commands,omitempty"`
+	SharedSubagents      *bool             `yaml:"shared-subagents,omitempty"         json:"shared-subagents,omitempty"`
+	Settings             *ClaudeSettings   `yaml:"settings,omitempty"                 json:"settings,omitempty"`
+	Config               *CodexConfig      `yaml:"config,omitempty"                   json:"config,omitempty"`
+	ExecPolicies         []CodexExecPolicy `yaml:"exec-policies,omitempty"            json:"exec-policies,omitempty"`
+	ExecPoliciesFile     string            `yaml:"exec-policies-file,omitempty"       json:"exec-policies-file,omitempty"`
+	CollisionPolicy      string            `yaml:"collision-policy,omitempty"         json:"collision-policy,omitempty"`
 }
 
 // ClaudeSettings is the first-class representation of `.claude/settings.json`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,23 +105,23 @@ type CodexExecPolicy struct {
 }
 
 type Output struct {
-	Dir                  string          `yaml:"dir,omitempty"                      json:"dir,omitempty"`
-	File                 string          `yaml:"file,omitempty"                     json:"file,omitempty"`
-	RulesFile            string          `yaml:"rules-file,omitempty"               json:"rules-file,omitempty"`
-	RulesDir             string          `yaml:"rules-dir,omitempty"                json:"rules-dir,omitempty"`
-	MCPFile              string          `yaml:"mcp-file,omitempty"                 json:"mcp-file,omitempty"`
-	AgentsDir            string          `yaml:"agents-dir,omitempty"               json:"agents-dir,omitempty"`
-	SkillsDir            string          `yaml:"skills-dir,omitempty"               json:"skills-dir,omitempty"`
-	InstructionsDir      string          `yaml:"instructions-dir,omitempty"         json:"instructions-dir,omitempty"`
-	CommandsDir          string          `yaml:"commands-dir,omitempty"             json:"commands-dir,omitempty"`
-	ChatmodesDir         string          `yaml:"chatmodes-dir,omitempty"            json:"chatmodes-dir,omitempty"`
-	WorkflowsDir         string          `yaml:"workflows-dir,omitempty"            json:"workflows-dir,omitempty"`
-	AssistantsDir        string          `yaml:"assistants-dir,omitempty"           json:"assistants-dir,omitempty"`
-	TasksFile            string          `yaml:"tasks-file,omitempty"               json:"tasks-file,omitempty"`
-	ConfFile             string          `yaml:"conf-file,omitempty"                json:"conf-file,omitempty"`
-	Model                string          `yaml:"model,omitempty"                    json:"model,omitempty"`
-	WeakModel            string          `yaml:"weak-model,omitempty"               json:"weak-model,omitempty"`
-	MCPDir               string          `yaml:"mcp-dir,omitempty"                  json:"mcp-dir,omitempty"`
+	Dir                  string            `yaml:"dir,omitempty"                      json:"dir,omitempty"`
+	File                 string            `yaml:"file,omitempty"                     json:"file,omitempty"`
+	RulesFile            string            `yaml:"rules-file,omitempty"               json:"rules-file,omitempty"`
+	RulesDir             string            `yaml:"rules-dir,omitempty"                json:"rules-dir,omitempty"`
+	MCPFile              string            `yaml:"mcp-file,omitempty"                 json:"mcp-file,omitempty"`
+	AgentsDir            string            `yaml:"agents-dir,omitempty"               json:"agents-dir,omitempty"`
+	SkillsDir            string            `yaml:"skills-dir,omitempty"               json:"skills-dir,omitempty"`
+	InstructionsDir      string            `yaml:"instructions-dir,omitempty"         json:"instructions-dir,omitempty"`
+	CommandsDir          string            `yaml:"commands-dir,omitempty"             json:"commands-dir,omitempty"`
+	ChatmodesDir         string            `yaml:"chatmodes-dir,omitempty"            json:"chatmodes-dir,omitempty"`
+	WorkflowsDir         string            `yaml:"workflows-dir,omitempty"            json:"workflows-dir,omitempty"`
+	AssistantsDir        string            `yaml:"assistants-dir,omitempty"           json:"assistants-dir,omitempty"`
+	TasksFile            string            `yaml:"tasks-file,omitempty"               json:"tasks-file,omitempty"`
+	ConfFile             string            `yaml:"conf-file,omitempty"                json:"conf-file,omitempty"`
+	Model                string            `yaml:"model,omitempty"                    json:"model,omitempty"`
+	WeakModel            string            `yaml:"weak-model,omitempty"               json:"weak-model,omitempty"`
+	MCPDir               string            `yaml:"mcp-dir,omitempty"                  json:"mcp-dir,omitempty"`
 	EmitSkillsAsCommands bool              `yaml:"emit-skills-as-commands,omitempty"  json:"emit-skills-as-commands,omitempty"`
 	SharedSubagents      *bool             `yaml:"shared-subagents,omitempty"         json:"shared-subagents,omitempty"`
 	Settings             *ClaudeSettings   `yaml:"settings,omitempty"                 json:"settings,omitempty"`


### PR DESCRIPTION
## Summary

- New `outputs.codex.exec-policies` (inline list) and `outputs.codex.exec-policies-file` (external YAML) declarative knobs.
- Codex adapter renders them into `.codex/rules/default.rules` using Codex CLI's Skylark `prefix_rule(...)` DSL.
- No file written when no policies are declared.

## Why

Codex CLI reads `.codex/rules/default.rules` to allow- or forbid-list shell command prefixes for repo automation. Projects migrating to agnostic-ai lost their carefully scoped lists. This adds a first-class config knob so policies are declarative + version-controlled.

## Design choice

Issue offered two paths: (A) new top-level spec kind, (B) frontmatter on rule specs. I picked a third — a typed config field — because:

- Exec policies are codex-specific data, not portable across tools.
- A new spec kind would propagate "unsupported" warnings through every other adapter.
- Frontmatter-on-rules mixes prose policy with shell-allowlist DSL data.

The config-field approach keeps the DSL output isolated to codex with no cross-cutting changes.

## Schema

```yaml
outputs:
  codex:
    exec-policies:
      - pattern: ["composer", "test"]
        decision: allow             # allow | forbidden | ask
        justification: Composer scripts are project entrypoints.
        match: ["composer test", "composer test -- --filter Foo"]
      - pattern: ["rm", "-rf", "/"]
        decision: forbidden
        justification: Never remove the filesystem root.
```

For long lists keep the entries in a separate YAML file and point `exec-policies-file` at it; inline entries render first, file entries append (Codex evaluates rules top-down).

## Implementation

- `internal/config/config.go`: new `CodexExecPolicy` type; `Output` gains `ExecPolicies []CodexExecPolicy` and `ExecPoliciesFile string`.
- `internal/adapters/codex/exec_policies.go` (new): load, validate, render. Validation enforces non-empty pattern + valid decision; index in error message helps locate offender in long lists.
- `internal/adapters/codex/codex.go`: wired into `Emit` after `emitConfigTOML`.
- Skylark uses `#` line comments — same as YAML — so reuse `emit.FormatYAML` for the provenance header.
- Schema regenerated via `go run ./cmd/schemagen`.

## Refactor pass

Reviewed the new file. Dropped an unused `defaultExecPoliciesDir()` helper. Inlined a one-shot `path :=` local. No other cleanup.

## Test plan
- [x] `go test ./...` (860 passing across 28 packages)
- [x] `./agnostic-ai sync --check` (exit 0)
- [x] New unit tests: renders Skylark DSL correctly; no-op when unset; empty pattern errors; bad decision errors; loads from file in addition to inline; inline-before-file ordering

Closes #254