### PR TITLE
fix(codex): preserve hook matcher token order from spec

### DIFF
--- a/internal/adapters/codex/hooks_json.go
+++ b/internal/adapters/codex/hooks_json.go
@@ -118,11 +118,16 @@ func buildHooksJSON(hooks []spec.Entry) *hooksDoc {
 	groupOrder := []matcherCmdKey{}
 	for _, k := range keyOrder {
 		a := byKey[k]
-		joined := joinMatcherSegments(a.matcherOrder)
-		gk := matcherCmdKey{event: k.event, matcher: joined}
+		// Dedupe groups by the canonical (sorted) matcher key so two
+		// specs with `Edit|Write` and `Write|Edit` collapse together,
+		// but emit the segments in author-supplied order so a hand-
+		// authored matcher round-trips byte-stable.
+		dedupeKey := joinMatcherSegments(a.matcherOrder)
+		display := strings.Join(a.matcherOrder, "|")
+		gk := matcherCmdKey{event: k.event, matcher: dedupeKey}
 		g, ok := groups[gk]
 		if !ok {
-			g = &matcherGroup{Matcher: joined}
+			g = &matcherGroup{Matcher: display}
 			groups[gk] = g
 			groupOrder = append(groupOrder, gk)
 		}

--- a/internal/adapters/codex/hooks_json_test.go
+++ b/internal/adapters/codex/hooks_json_test.go
@@ -152,6 +152,31 @@ func TestEmit_HooksJSON_HooksMoveOutOfConfigToml(t *testing.T) {
 	}
 }
 
+// Regression for #266: matcher pipe-segment order is preserved as
+// authored, not alphabetized. `Bash|apply_patch|Edit|Write` (the form
+// shipped by codex out of the box) must round-trip byte-stable.
+func TestEmit_HooksJSON_PreservesMatcherTokenOrder(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindHook, Name: "h",
+			Meta: map[string]any{
+				"event":   "PreToolUse",
+				"matcher": "Bash|apply_patch|Edit|Write",
+				"command": "echo go",
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, ".codex/hooks.json"))
+	if !strings.Contains(string(raw), `"matcher": "Bash|apply_patch|Edit|Write"`) {
+		t.Errorf("expected matcher order preserved, got:\n%s", raw)
+	}
+}
+
 // outputs.codex.hooks-file relocates the emitted file.
 func TestEmit_HooksJSON_HonorsHooksFileOverride(t *testing.T) {
 	dir := testutil.TempCwd(t)


### PR DESCRIPTION
## Summary

- Hook matcher pipe-segments were alphabetized at emit time, so `Bash|apply_patch|Edit|Write` came out as `Bash|Edit|Write|apply_patch`.
- Keep the sorted form as the dedupe group key, but emit the segments in author-supplied order so the round-trip stays byte-stable.

Closes #266

## Test plan

- [x] New `TestEmit_HooksJSON_PreservesMatcherTokenOrder`
- [x] Existing union/dedupe tests still pass (`go test ./...` → 866 passed)
- [x] Verified against phel-lang PR #2085 ground truth: `.codex/hooks.json` matcher field byte-identical after import → sync