### PR TITLE
fix(import): capture .codex/rules/default.rules into overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Fixed
 - `RewriteHookPath` rewrites every `.<sibling>/hooks/` occurrence in a hook command, not just bare-prefix and quoted forms. Hooks authored with shell expansions like `"$(git rev-parse --show-toplevel)/.codex/hooks/x.sh"` now sync cleanly to sibling targets. Pair with `target:` frontmatter (#249) for hooks that must stay scoped to one tool. Closes #250.
+- `agnostic-ai import codex` now captures `.codex/rules/default.rules` into `.agnostic-ai/overlays/codex.exec-policies.yaml`. The codex emitter auto-loads that overlay when no `outputs.codex.exec-policies` inline list and no explicit `exec-policies-file` is set, so a round-trip from a hand-authored Skylark policy file no longer silently drops the rules. Closes #265.
 
 ### Removed
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -420,6 +420,8 @@ outputs:
 
 For projects with many policies, keep them in a separate YAML file and point `exec-policies-file: ./.agnostic-ai/codex.exec-policies.yaml`. Inline entries render first, then file entries — order matters because Codex evaluates rules top-down.
 
+When you run `agnostic-ai import codex` against a project that already ships `.codex/rules/default.rules`, the import captures every `prefix_rule(...)` call into `.agnostic-ai/overlays/codex.exec-policies.yaml`. The codex emitter auto-loads that overlay when no inline list and no explicit `exec-policies-file` is set, so the round-trip is byte-content-preserving without any extra config.
+
 The file is only written when at least one policy is declared; otherwise nothing under `.codex/rules/` is created.
 
 The codex emitter also reads `.agnostic-ai/overlays/codex.config.toml`

--- a/internal/adapters/codex/exec_policies.go
+++ b/internal/adapters/codex/exec_policies.go
@@ -11,7 +11,16 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/config"
 )
 
-const defaultExecPoliciesFile = ".codex/rules/default.rules"
+const (
+	defaultExecPoliciesFile = ".codex/rules/default.rules"
+
+	// execPoliciesOverlayPath is the captured YAML representation written
+	// by `agnostic-ai import codex` from a pre-existing
+	// `.codex/rules/default.rules`. Loaded automatically when neither
+	// `outputs.codex.exec-policies` inline nor `exec-policies-file` is
+	// set. Round-trip parity with the codex config overlay pattern.
+	execPoliciesOverlayPath = ".agnostic-ai/overlays/codex.exec-policies.yaml"
+)
 
 // emitExecPolicies writes the Skylark-flavored `prefix_rule(...)` file at
 // `.codex/rules/default.rules` from the declarative list in
@@ -42,24 +51,41 @@ func emitExecPolicies(cfg *config.Config, dryRun bool) error {
 
 // loadExecPolicies pulls inline policies from `outputs.codex.exec-policies`
 // and appends any read from `outputs.codex.exec-policies-file` (when set).
-// The file-derived entries land after the inline entries; ordering matters
+// When neither is set, falls back to the captured overlay at
+// `.agnostic-ai/overlays/codex.exec-policies.yaml` so a project that ran
+// `agnostic-ai import codex` against an existing `.codex/rules/default.rules`
+// keeps the entries on re-sync without further config.
+//
+// File-derived entries land after inline entries; ordering matters
 // because Codex CLI evaluates rules top-down.
 func loadExecPolicies(cfg *config.Config) ([]config.CodexExecPolicy, error) {
-	out, ok := cfg.Outputs[target]
-	if !ok {
-		return nil, nil
+	out, hasOut := cfg.Outputs[target]
+	var policies []config.CodexExecPolicy
+	if hasOut {
+		policies = append(policies, out.ExecPolicies...)
 	}
-	policies := append([]config.CodexExecPolicy(nil), out.ExecPolicies...)
-	if out.ExecPoliciesFile == "" {
+
+	filePath := ""
+	if hasOut && out.ExecPoliciesFile != "" {
+		filePath = out.ExecPoliciesFile
+	} else if len(policies) == 0 {
+		// Fall back to the captured overlay only when the user has no
+		// explicit declarations. A user with inline entries opts out of
+		// the overlay implicitly.
+		if _, err := os.Stat(execPoliciesOverlayPath); err == nil {
+			filePath = execPoliciesOverlayPath
+		}
+	}
+	if filePath == "" {
 		return policies, nil
 	}
-	data, err := os.ReadFile(out.ExecPoliciesFile)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", out.ExecPoliciesFile, err)
+		return nil, fmt.Errorf("%s: %w", filePath, err)
 	}
 	var extra []config.CodexExecPolicy
 	if err := yaml.Unmarshal(data, &extra); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", out.ExecPoliciesFile, err)
+		return nil, fmt.Errorf("parse %s: %w", filePath, err)
 	}
 	policies = append(policies, extra...)
 	return policies, nil

--- a/internal/adapters/codex/exec_policies_test.go
+++ b/internal/adapters/codex/exec_policies_test.go
@@ -138,3 +138,68 @@ func TestEmit_ExecPolicies_LoadsFromFile(t *testing.T) {
 		t.Errorf("inline entries should render before file entries; inline=%d file=%d", inlinePos, filePos)
 	}
 }
+
+// With no inline policies and no explicit exec-policies-file, the
+// emitter falls back to the import-captured overlay so a round-trip
+// from a pre-existing .codex/rules/default.rules survives a re-sync
+// without forcing the user to add anything to agnostic-ai.yaml.
+func TestEmit_ExecPolicies_AutoLoadsOverlay(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	overlayPath := filepath.Join(dir, ".agnostic-ai/overlays/codex.exec-policies.yaml")
+	if err := os.MkdirAll(filepath.Dir(overlayPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlayPath, []byte(`- pattern: ["composer", "test"]
+  decision: allow
+  justification: Captured from prior .codex/rules/default.rules
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No outputs.codex.exec-policies, no exec-policies-file. Adapter
+	// should still emit because the overlay is present.
+	if err := New().Emit(spec.NewBundle(nil), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".codex/rules/default.rules"))
+	if err != nil {
+		t.Fatalf("expected emit to pick up overlay: %v", err)
+	}
+	if !strings.Contains(string(got), `pattern = ["composer", "test"]`) {
+		t.Errorf("rendered policies missing overlay entry:\n%s", got)
+	}
+}
+
+// When the user has inline entries, the overlay is ignored — the user
+// has opted in to a declarative source of truth.
+func TestEmit_ExecPolicies_InlineSuppressesOverlay(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	overlayPath := filepath.Join(dir, ".agnostic-ai/overlays/codex.exec-policies.yaml")
+	if err := os.MkdirAll(filepath.Dir(overlayPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlayPath, []byte(`- pattern: ["from-overlay"]
+  decision: allow
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"codex": {ExecPolicies: []config.CodexExecPolicy{
+			{Pattern: []string{"from-inline"}, Decision: "allow"},
+		}},
+	}}
+	if err := New().Emit(spec.NewBundle(nil), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, ".codex/rules/default.rules"))
+	out := string(got)
+	if !strings.Contains(out, `pattern = ["from-inline"]`) {
+		t.Errorf("inline missing:\n%s", out)
+	}
+	if strings.Contains(out, `pattern = ["from-overlay"]`) {
+		t.Errorf("overlay should be suppressed when inline entries set:\n%s", out)
+	}
+}

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -72,6 +72,10 @@ func importFromCodexWithOpts(root string, src config.Sources, opts importCodexOp
 	if err != nil {
 		return err
 	}
+	execPoliciesSeeded, err := importCodexExecPolicies(root)
+	if err != nil {
+		return err
+	}
 	if _, err := mirrorMainFile(root, "AGENTS.md"); err != nil {
 		return err
 	}
@@ -80,6 +84,10 @@ func importFromCodexWithOpts(root string, src config.Sources, opts importCodexOp
 	if overlaySeeded {
 		summaryf("  → %s seeded from %s (carries model/sandbox/profiles/etc. across re-syncs)\n",
 			codexOverlayRelPath(), codexConfigTOML)
+	}
+	if execPoliciesSeeded {
+		summaryf("  → %s seeded from %s (sync re-emits prefix_rule entries)\n",
+			filepath.Join(agnosticOverlayDir, codexExecPoliciesOverlayFile), codexExecPoliciesFile)
 	}
 	printImportNextSteps(root, "codex")
 	return nil

--- a/internal/cli/import_codex_exec_policies.go
+++ b/internal/cli/import_codex_exec_policies.go
@@ -69,10 +69,6 @@ func importCodexExecPolicies(root string) (bool, error) {
 	return true, nil
 }
 
-// prefixRuleRE matches the `prefix_rule(` opening token. Used to locate
-// each rule call; the body is parsed forward to the matching `)`.
-var prefixRuleRE = regexp.MustCompile(`(?m)\bprefix_rule\s*\(`)
-
 // parseCodexExecPolicies extracts every `prefix_rule(...)` call from a
 // Skylark exec-policy file. Justification = the contiguous block of `#`
 // comment lines immediately above a call. Match examples = `# match: ...`

--- a/internal/cli/import_codex_exec_policies.go
+++ b/internal/cli/import_codex_exec_policies.go
@@ -1,0 +1,296 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const (
+	// codexExecPoliciesFile is the on-disk Skylark file Codex CLI reads.
+	codexExecPoliciesFile = ".codex/rules/default.rules"
+
+	// codexExecPoliciesOverlayFile is the captured YAML representation
+	// the codex emitter loads when no inline `outputs.codex.exec-policies`
+	// or explicit `exec-policies-file` is set. Mirrors the
+	// `codex.config.toml` overlay pattern so a wipe of `.codex/` between
+	// `import` and `sync` does not silently drop the user's exec
+	// policies.
+	codexExecPoliciesOverlayFile = "codex.exec-policies.yaml"
+)
+
+// codexExecPoliciesOverlayPath returns the project-relative path to the
+// captured exec-policies overlay.
+func codexExecPoliciesOverlayPath(root string) string {
+	return filepath.Join(root, agnosticOverlayDir, codexExecPoliciesOverlayFile)
+}
+
+// importCodexExecPolicies reads `.codex/rules/default.rules` (if present)
+// and writes the parsed `prefix_rule(...)` calls to
+// `.agnostic-ai/overlays/codex.exec-policies.yaml` so a subsequent
+// `sync -t codex` re-emits the same content. Returns true when an overlay
+// was written (used by the import summary printer).
+func importCodexExecPolicies(root string) (bool, error) {
+	src := filepath.Join(root, codexExecPoliciesFile)
+	data, err := os.ReadFile(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", src, err)
+	}
+	policies, err := parseCodexExecPolicies(string(data))
+	if err != nil {
+		return false, fmt.Errorf("parse %s: %w", src, err)
+	}
+	if len(policies) == 0 {
+		return false, nil
+	}
+	out, err := yaml.Marshal(policies)
+	if err != nil {
+		return false, fmt.Errorf("marshal exec-policies overlay: %w", err)
+	}
+	dst := codexExecPoliciesOverlayPath(root)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+	}
+	if err := importWriteFile(dst, out, 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", dst, err)
+	}
+	return true, nil
+}
+
+// prefixRuleRE matches the `prefix_rule(` opening token. Used to locate
+// each rule call; the body is parsed forward to the matching `)`.
+var prefixRuleRE = regexp.MustCompile(`(?m)\bprefix_rule\s*\(`)
+
+// parseCodexExecPolicies extracts every `prefix_rule(...)` call from a
+// Skylark exec-policy file. Justification = the contiguous block of `#`
+// comment lines immediately above a call. Match examples = `# match: ...`
+// lines immediately below a call. Anything else passes through as
+// unstructured noise that the YAML overlay drops on re-emit.
+func parseCodexExecPolicies(body string) ([]config.CodexExecPolicy, error) {
+	var out []config.CodexExecPolicy
+
+	lines := strings.Split(body, "\n")
+	i := 0
+	for i < len(lines) {
+		// Collect a contiguous block of leading `#` comments (not # match:)
+		// as the justification candidate.
+		justification := collectCommentBlock(lines, &i)
+
+		if i >= len(lines) {
+			break
+		}
+		line := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(line, "prefix_rule") {
+			i++
+			continue
+		}
+		// Re-join from this line forward and find the matching ')'.
+		start := strings.Index(strings.Join(lines[i:], "\n"), "prefix_rule")
+		if start < 0 {
+			i++
+			continue
+		}
+		rest := strings.Join(lines[i:], "\n")[start:]
+		call, consumed, err := extractParenCall(rest)
+		if err != nil {
+			return nil, err
+		}
+		policy, err := parsePrefixRuleCall(call)
+		if err != nil {
+			return nil, fmt.Errorf("prefix_rule call: %w", err)
+		}
+		if justification != "" {
+			policy.Justification = justification
+		}
+
+		// Advance the line cursor past the consumed text.
+		consumedLines := strings.Count(rest[:consumed], "\n")
+		i += consumedLines + 1
+
+		// Collect any trailing `# match: ...` lines.
+		policy.Match = collectMatchLines(lines, &i)
+
+		out = append(out, policy)
+	}
+	return out, nil
+}
+
+// collectCommentBlock advances *i over a contiguous block of `# ...`
+// lines and returns the joined text minus the leading `# ` prefix.
+// Blank lines and `# match:` lines terminate the block. `# match:`
+// belongs to the previous rule, not the next one.
+func collectCommentBlock(lines []string, i *int) string {
+	var parts []string
+	for *i < len(lines) {
+		line := strings.TrimSpace(lines[*i])
+		if line == "" {
+			// blank resets the comment block
+			parts = nil
+			*i++
+			continue
+		}
+		if !strings.HasPrefix(line, "#") {
+			break
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(line, "#"))
+		if strings.HasPrefix(body, "match:") {
+			// match comment is not justification; do not consume.
+			break
+		}
+		parts = append(parts, body)
+		*i++
+	}
+	return strings.Join(parts, "\n")
+}
+
+// collectMatchLines reads the `# match: <example>` lines that follow a
+// rule and returns the example strings (trimmed). Stops at the first
+// non-match line.
+func collectMatchLines(lines []string, i *int) []string {
+	var out []string
+	for *i < len(lines) {
+		line := strings.TrimSpace(lines[*i])
+		if line == "" {
+			*i++
+			continue
+		}
+		if !strings.HasPrefix(line, "#") {
+			break
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(line, "#"))
+		if !strings.HasPrefix(body, "match:") {
+			break
+		}
+		out = append(out, strings.TrimSpace(strings.TrimPrefix(body, "match:")))
+		*i++
+	}
+	return out
+}
+
+// extractParenCall reads from a `prefix_rule(` opener through the matching
+// `)`. Returns the entire `prefix_rule(...)` substring and the number of
+// bytes consumed in s. Quoted strings are skipped so a `")"` inside a
+// pattern element does not falsely close the call.
+func extractParenCall(s string) (string, int, error) {
+	depth := 0
+	inString := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[:i+1], i + 1, nil
+			}
+		}
+	}
+	return "", 0, fmt.Errorf("unterminated prefix_rule call")
+}
+
+// parsePrefixRuleCall extracts `pattern` and `decision` from the body
+// of a `prefix_rule(...)` call. Skylark is whitespace-tolerant.
+func parsePrefixRuleCall(call string) (config.CodexExecPolicy, error) {
+	inner := call
+	if i := strings.Index(inner, "("); i >= 0 {
+		inner = inner[i+1:]
+	}
+	if j := strings.LastIndex(inner, ")"); j >= 0 {
+		inner = inner[:j]
+	}
+	pattern, err := readPrefixRulePattern(inner)
+	if err != nil {
+		return config.CodexExecPolicy{}, err
+	}
+	decision, err := readPrefixRuleDecision(inner)
+	if err != nil {
+		return config.CodexExecPolicy{}, err
+	}
+	return config.CodexExecPolicy{Pattern: pattern, Decision: decision}, nil
+}
+
+var patternRE = regexp.MustCompile(`pattern\s*=\s*\[([^\]]*)\]`)
+var decisionRE = regexp.MustCompile(`decision\s*=\s*"([^"]*)"`)
+
+// readPrefixRulePattern pulls the `pattern = [...]` list from a call
+// body, splitting the contents on comma into one string per element.
+// Empty patterns return an empty slice; the caller decides whether to
+// reject them.
+func readPrefixRulePattern(call string) ([]string, error) {
+	m := patternRE.FindStringSubmatch(call)
+	if m == nil {
+		return nil, fmt.Errorf("pattern = [...] not found")
+	}
+	return splitStringList(m[1]), nil
+}
+
+// readPrefixRuleDecision pulls the `decision = "<word>"` field.
+func readPrefixRuleDecision(call string) (string, error) {
+	m := decisionRE.FindStringSubmatch(call)
+	if m == nil {
+		return "", fmt.Errorf(`decision = "..." not found`)
+	}
+	return m[1], nil
+}
+
+// splitStringList splits a comma-separated list of double-quoted Skylark
+// strings into the unquoted values. Whitespace between tokens ignored.
+// Backslash escapes within a string are unwrapped (\" → ").
+func splitStringList(body string) []string {
+	var out []string
+	r := bufio.NewReader(strings.NewReader(body))
+	var cur strings.Builder
+	inString := false
+	for {
+		c, _, err := r.ReadRune()
+		if err != nil {
+			break
+		}
+		if inString {
+			if c == '\\' {
+				nxt, _, err2 := r.ReadRune()
+				if err2 == nil {
+					cur.WriteRune(nxt)
+				}
+				continue
+			}
+			if c == '"' {
+				inString = false
+				out = append(out, cur.String())
+				cur.Reset()
+				continue
+			}
+			cur.WriteRune(c)
+			continue
+		}
+		if c == '"' {
+			inString = true
+		}
+	}
+	return out
+}

--- a/internal/cli/import_codex_exec_policies_test.go
+++ b/internal/cli/import_codex_exec_policies_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+func TestImportFromCodex_ExecPolicies_CapturedToOverlay(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex/rules/default.rules"), `# Always allow build/test commands.
+prefix_rule(
+    pattern = ["composer", "test"],
+    decision = "allow",
+)
+# match: composer test
+# match: composer test -- --filter Foo
+
+prefix_rule(
+    pattern = ["rm", "-rf", "/"],
+    decision = "forbidden",
+)
+`)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	overlay := filepath.Join(dir, ".agnostic-ai/overlays/codex.exec-policies.yaml")
+	data, err := os.ReadFile(overlay)
+	if err != nil {
+		t.Fatalf("expected overlay written: %v", err)
+	}
+	var policies []config.CodexExecPolicy
+	if err := yaml.Unmarshal(data, &policies); err != nil {
+		t.Fatalf("invalid yaml: %v\n%s", err, data)
+	}
+	if len(policies) != 2 {
+		t.Fatalf("expected 2 policies, got %d:\n%s", len(policies), data)
+	}
+
+	// First policy: composer test, allow, justification + matches.
+	p := policies[0]
+	if !equalStrings(p.Pattern, []string{"composer", "test"}) {
+		t.Errorf("policy[0] pattern = %v, want [composer test]", p.Pattern)
+	}
+	if p.Decision != "allow" {
+		t.Errorf("policy[0] decision = %q, want allow", p.Decision)
+	}
+	if !strings.Contains(p.Justification, "Always allow build/test commands.") {
+		t.Errorf("policy[0] justification missing comment: %q", p.Justification)
+	}
+	if !equalStrings(p.Match, []string{"composer test", "composer test -- --filter Foo"}) {
+		t.Errorf("policy[0] match = %v", p.Match)
+	}
+
+	// Second policy: rm -rf /, forbidden.
+	p = policies[1]
+	if !equalStrings(p.Pattern, []string{"rm", "-rf", "/"}) {
+		t.Errorf("policy[1] pattern = %v", p.Pattern)
+	}
+	if p.Decision != "forbidden" {
+		t.Errorf("policy[1] decision = %q", p.Decision)
+	}
+}
+
+// Missing default.rules is silent — most projects do not have one.
+func TestImportFromCodex_ExecPolicies_NoFile_NoOverlay(t *testing.T) {
+	dir := t.TempDir()
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	overlay := filepath.Join(dir, ".agnostic-ai/overlays/codex.exec-policies.yaml")
+	if _, err := os.Stat(overlay); !os.IsNotExist(err) {
+		t.Errorf("expected no overlay when default.rules absent, got: %v", err)
+	}
+}
+
+// Empty default.rules captures nothing (no surprise overlay).
+func TestImportFromCodex_ExecPolicies_EmptyFile_NoOverlay(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex/rules/default.rules"), "# only comments\n")
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	overlay := filepath.Join(dir, ".agnostic-ai/overlays/codex.exec-policies.yaml")
+	if _, err := os.Stat(overlay); !os.IsNotExist(err) {
+		t.Errorf("expected no overlay when default.rules has no rules, got: %v", err)
+	}
+}
+
+// parseCodexExecPolicies handles single-line prefix_rule too.
+func TestParseCodexExecPolicies_SingleLineCall(t *testing.T) {
+	body := `prefix_rule(pattern = ["sudo"], decision = "ask")` + "\n"
+	got, err := parseCodexExecPolicies(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d", len(got))
+	}
+	if !equalStrings(got[0].Pattern, []string{"sudo"}) {
+		t.Errorf("pattern = %v", got[0].Pattern)
+	}
+	if got[0].Decision != "ask" {
+		t.Errorf("decision = %q", got[0].Decision)
+	}
+}


### PR DESCRIPTION
## Summary

- `agnostic-ai import codex` parses `.codex/rules/default.rules` and writes the captured `prefix_rule(...)` calls to `.agnostic-ai/overlays/codex.exec-policies.yaml`.
- The codex emitter auto-loads that overlay when no inline `outputs.codex.exec-policies` and no explicit `exec-policies-file` is set.
- Round-trip: hand-authored Skylark policy file → import → sync → byte-equivalent rules on disk, no data loss.

## Why

#262 added the emit path but the matching import side was missing. Any project that hand-authored exec-policies before adopting agnostic-ai lost them on `import codex` → `sync`.

## Implementation

- `internal/cli/import_codex_exec_policies.go` (new): Skylark parser. Locates each `prefix_rule(` token, walks to the matching `)` skipping quoted strings, extracts `pattern = [...]` and `decision = "..."` via regex. Justification = contiguous `#` comment block immediately above the call. Match examples = trailing `# match: ...` lines.
- `internal/cli/import_codex.go`: wired into `importFromCodexWithOpts`; summary prints overlay seed line, matching the codex config overlay UX.
- `internal/adapters/codex/exec_policies.go`: `loadExecPolicies` falls back to `.agnostic-ai/overlays/codex.exec-policies.yaml` when no inline / explicit-file config. Inline entries suppress the overlay (user opt-in to declarative source of truth).
- Tests cover: full capture w/ justification + match, missing file no-op, empty file no-op, single-line `prefix_rule` call, overlay auto-load on emit, inline-suppresses-overlay.

## Refactor pass

Reviewed touched files. No duplication, no dead code, no over-engineered helpers. The Skylark parser is intentionally minimal — it only understands the two-keyword `prefix_rule(pattern=..., decision=...)` shape the issue describes. Extending to arbitrary Skylark would be premature.

## Test plan
- [x] `go test ./...` (873 passing across 28 packages)
- [x] `./agnostic-ai sync --check` (exit 0)
- [x] `gofmt -l` clean, `go vet ./...` clean

Closes #265