### PR TITLE
fix(import): preserve tool-helper files across import → sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ### Fixed
 - `RewriteHookPath` rewrites every `.<sibling>/hooks/` occurrence in a hook command, not just bare-prefix and quoted forms. Hooks authored with shell expansions like `"$(git rev-parse --show-toplevel)/.codex/hooks/x.sh"` now sync cleanly to sibling targets. Pair with `target:` frontmatter (#249) for hooks that must stay scoped to one tool. Closes #250.
 - `agnostic-ai import codex` now captures `.codex/rules/default.rules` into `.agnostic-ai/overlays/codex.exec-policies.yaml`. The codex emitter auto-loads that overlay when no `outputs.codex.exec-policies` inline list and no explicit `exec-policies-file` is set, so a round-trip from a hand-authored Skylark policy file no longer silently drops the rules. Closes #265.
+- `agnostic-ai import claude/codex` captures helper files (`CLAUDE.md`, `README.md`, `statusline.sh`, codex `README.md`) into `.agnostic-ai/overlays/<tool>/<basename>` with file mode preserved. Each adapter restores them on `sync` so a wipe of `.<tool>/` between import and sync no longer drops project memory, operator docs, or executables the agent references. Closes #267.
 
 ### Removed
 

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -110,6 +110,10 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 
+	if err := emit.RestoreHelperFiles(target, dryRun); err != nil {
+		return err
+	}
+
 	return emit.WriteMCPFile(b.MCPs, emit.MCPSchemaServersMap, emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)
 }
 

--- a/internal/adapters/codex/codex.go
+++ b/internal/adapters/codex/codex.go
@@ -122,7 +122,10 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emitExecPolicies(cfg, dryRun); err != nil {
 		return err
 	}
-	return materializeHookScripts(hooks, dryRun)
+	if err := materializeHookScripts(hooks, dryRun); err != nil {
+		return err
+	}
+	return emit.RestoreHelperFiles(target, dryRun)
 }
 
 // materializeHookScripts copies each hook's stashed script body from

--- a/internal/adapters/internal/emit/helper_files.go
+++ b/internal/adapters/internal/emit/helper_files.go
@@ -1,0 +1,71 @@
+// Package emit helper_files restores tool-native helper files captured
+// at import time so a fresh sync rebuilds a self-contained `.<tool>/`
+// tree without re-running import.
+//
+// Captured layout (set by `agnostic-ai import <tool>`):
+//
+//	.agnostic-ai/overlays/<tool>/<basename>
+//
+// Restored layout (set by each adapter's Emit()):
+//
+//	.<tool>/<basename>
+//
+// File mode is preserved so an executable helper (e.g. statusline.sh)
+// stays executable on restore.
+package emit
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// agnosticOverlayDir is the project-relative root for captured tool-native
+// files outside the spec dirs. Mirrors the constant in the cli package
+// so emit and import agree.
+const agnosticOverlayDir = ".agnostic-ai/overlays"
+
+// RestoreHelperFiles copies every `.agnostic-ai/overlays/<tool>/*` file
+// back to `.<tool>/<basename>` with its mode bits preserved. No-op when
+// the overlay tree is missing or empty — projects that did not capture
+// any helpers have nothing to restore.
+func RestoreHelperFiles(tool string, dryRun bool) error {
+	srcDir := filepath.Join(agnosticOverlayDir, tool)
+	entries, err := os.ReadDir(srcDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s: %w", srcDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == "" {
+			continue
+		}
+		src := filepath.Join(srcDir, e.Name())
+		info, err := e.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", src, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		body, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		dst := filepath.Join("."+tool, e.Name())
+		if dryRun {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+		}
+		if err := os.WriteFile(dst, body, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
+	}
+	return nil
+}

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -52,6 +52,10 @@ func importFromClaude(root string, src config.Sources) error {
 	if err := captureHookScripts(root, "claude"); err != nil {
 		return err
 	}
+	helpers, err := captureHelperFiles(root, "claude")
+	if err != nil {
+		return err
+	}
 	if c.mcps, err = importClaudeMCP(root, filepath.Join(root, src.MCPs)); err != nil {
 		return err
 	}
@@ -75,6 +79,10 @@ func importFromClaude(root string, src config.Sources) error {
 	if overlaySeeded {
 		summaryf("  → %s seeded from %s/settings.json (carries non-hook settings across re-syncs)\n",
 			claudeOverlayRelPath(), claudeDir)
+	}
+	for _, h := range helpers {
+		summaryf("  → %s seeded from %s/%s\n",
+			filepath.Join(agnosticOverlayDir, "claude", h), claudeDir, h)
 	}
 	printImportNextSteps(root, "claude")
 	return nil

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -76,6 +76,10 @@ func importFromCodexWithOpts(root string, src config.Sources, opts importCodexOp
 	if err != nil {
 		return err
 	}
+	helpers, err := captureHelperFiles(root, "codex")
+	if err != nil {
+		return err
+	}
 	if _, err := mirrorMainFile(root, "AGENTS.md"); err != nil {
 		return err
 	}
@@ -88,6 +92,10 @@ func importFromCodexWithOpts(root string, src config.Sources, opts importCodexOp
 	if execPoliciesSeeded {
 		summaryf("  → %s seeded from %s (sync re-emits prefix_rule entries)\n",
 			filepath.Join(agnosticOverlayDir, codexExecPoliciesOverlayFile), codexExecPoliciesFile)
+	}
+	for _, h := range helpers {
+		summaryf("  → %s seeded from .codex/%s\n",
+			filepath.Join(agnosticOverlayDir, "codex", h), h)
 	}
 	printImportNextSteps(root, "codex")
 	return nil

--- a/internal/cli/import_helper_files.go
+++ b/internal/cli/import_helper_files.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// helperFile names one tool-native file that lives outside the
+// per-kind spec dirs (agents, skills, rules, hooks, mcps, commands)
+// but must survive a `import` → `sync` round-trip. Examples: Claude's
+// `CLAUDE.md` (project memory), operator `README.md` files,
+// `statusline.sh` invoked from `settings.json` statusLine.command.
+//
+// Each helper is captured at import to
+// `.agnostic-ai/overlays/<tool>/<basename>` (file mode preserved so an
+// executable script stays executable) and restored at sync to
+// `.<tool>/<basename>`.
+type helperFile struct {
+	tool, basename string
+}
+
+// helperFilesByTool lists every helper file each importer captures.
+// Keep the list small: the goal is to preserve functional files the
+// agent actually reads or executes, not every stray doc that happens
+// to live under `.<tool>/`.
+var helperFilesByTool = map[string][]helperFile{
+	"claude": {
+		{tool: "claude", basename: "CLAUDE.md"},
+		{tool: "claude", basename: "README.md"},
+		{tool: "claude", basename: "statusline.sh"},
+	},
+	"codex": {
+		{tool: "codex", basename: "README.md"},
+	},
+}
+
+// helperOverlayPath returns the captured overlay path for a helper.
+func helperOverlayPath(root, tool, basename string) string {
+	return filepath.Join(root, agnosticOverlayDir, tool, basename)
+}
+
+// captureHelperFiles copies the tool-native helper files declared in
+// helperFilesByTool into the overlay tree, preserving file mode. A no-op
+// per file when the source is missing — most projects do not ship every
+// helper. Returns the basenames that were actually captured so the
+// import summary can surface them.
+func captureHelperFiles(root, tool string) ([]string, error) {
+	var captured []string
+	for _, h := range helperFilesByTool[tool] {
+		src := filepath.Join(root, "."+h.tool, h.basename)
+		info, err := os.Stat(src)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return captured, fmt.Errorf("stat %s: %w", src, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		body, err := os.ReadFile(src)
+		if err != nil {
+			return captured, fmt.Errorf("read %s: %w", src, err)
+		}
+		dst := helperOverlayPath(root, h.tool, h.basename)
+		if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return captured, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+		}
+		if err := importWriteFile(dst, body, info.Mode().Perm()); err != nil {
+			return captured, fmt.Errorf("write %s: %w", dst, err)
+		}
+		captured = append(captured, h.basename)
+	}
+	return captured, nil
+}

--- a/internal/cli/import_helper_files_test.go
+++ b/internal/cli/import_helper_files_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCaptureHelperFiles_Claude(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude/CLAUDE.md"), "project memory body\n")
+	writeFile(t, filepath.Join(dir, ".claude/README.md"), "operator docs\n")
+	scriptPath := filepath.Join(dir, ".claude/statusline.sh")
+	writeFile(t, scriptPath, "#!/bin/sh\necho prompt\n")
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	captured, err := captureHelperFiles(dir, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(captured) != 3 {
+		t.Errorf("expected 3 captured, got %v", captured)
+	}
+
+	for _, name := range []string{"CLAUDE.md", "README.md", "statusline.sh"} {
+		path := filepath.Join(dir, ".agnostic-ai/overlays/claude", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("missing overlay %s: %v", name, err)
+		}
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, ".agnostic-ai/overlays/claude/statusline.sh"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("captured statusline.sh lost exec bit: mode=%v", info.Mode().Perm())
+		}
+	}
+}
+
+// Missing helpers are silent — most projects do not ship every helper.
+func TestCaptureHelperFiles_NoHelpers(t *testing.T) {
+	dir := t.TempDir()
+	captured, err := captureHelperFiles(dir, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(captured) != 0 {
+		t.Errorf("expected empty list, got %v", captured)
+	}
+}
+
+// importFromClaude → claude adapter Emit round-trips the helpers
+// without losing CLAUDE.md, README.md, statusline.sh (and its exec bit).
+func TestImportClaudeThenSync_HelperFilesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude/CLAUDE.md"), "memory body\n")
+	writeFile(t, filepath.Join(dir, ".claude/README.md"), "docs\n")
+	scriptPath := filepath.Join(dir, ".claude/statusline.sh")
+	writeFile(t, scriptPath, "#!/bin/sh\necho hi\n")
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "# Project\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wipe the native dir to prove the round-trip rebuilds from overlay.
+	if err := os.RemoveAll(filepath.Join(dir, ".claude")); err != nil {
+		t.Fatal(err)
+	}
+	// Recreate empty .claude/ so sync writes into a fresh tree without
+	// hitting the agnostic-managed entrypoint overwrite warning.
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeMinimalConfig(t, dir, ".agnostic-ai")
+	prevDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevDir) })
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	silence(t)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []struct {
+		name string
+		body string
+	}{
+		{"CLAUDE.md", "memory body\n"},
+		{"README.md", "docs\n"},
+		{"statusline.sh", "#!/bin/sh\necho hi\n"},
+	} {
+		got, err := os.ReadFile(filepath.Join(dir, ".claude", want.name))
+		if err != nil {
+			t.Errorf("restored %s missing: %v", want.name, err)
+			continue
+		}
+		if string(got) != want.body {
+			t.Errorf("%s body drift: got %q want %q", want.name, got, want.body)
+		}
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, ".claude/statusline.sh"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("restored statusline.sh lost exec bit: mode=%v", info.Mode().Perm())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `agnostic-ai import claude/codex` captures helper files into `.agnostic-ai/overlays/<tool>/<basename>` with file mode preserved.
- Adapter `Emit` restores them on sync via new `emit.RestoreHelperFiles(tool, dryRun)`.
- Files covered today: claude `CLAUDE.md` + `README.md` + `statusline.sh`, codex `README.md`. List is small + explicit.

## Why

After `import` → `sync` round-trip these files vanished:

- `.claude/CLAUDE.md` — project memory Claude reads at session start.
- `.claude/statusline.sh` — referenced by `settings.json` `statusLine.command`.
- `.claude/README.md`, `.codex/README.md` — operator docs.

statusline.sh going missing is the worst: settings.json still references it but the script is gone. Agent breaks on startup.

## Implementation

- `internal/cli/import_helper_files.go` (new): `captureHelperFiles(root, tool)` + `helperFilesByTool` registry. File mode preserved so an executable script stays executable.
- `internal/adapters/internal/emit/helper_files.go` (new): `RestoreHelperFiles(tool, dryRun)` copies overlay → `.<tool>/<basename>`.
- `internal/cli/import_claude.go` + `import_codex.go`: wired into the importers; summary prints one line per captured helper.
- `internal/adapters/claude/claude.go` + `codex/codex.go`: `Emit` calls `emit.RestoreHelperFiles(target, dryRun)` after the hook-script materializer.
- 3 new tests: unit capture, no-helpers no-op, full round-trip (wipe `.claude/`, re-sync, assert content + exec bit).

## Refactor pass

Reviewed touched files. No duplication, no dead branches, no speculative abstractions. The helper list is intentionally hard-coded — these are functional files agents read, not arbitrary user content; expanding into a generic copy-everything pattern would invite surprise.

## Test plan
- [x] `go test ./...` (876 passing across 28 packages)
- [x] `./agnostic-ai sync --check` (exit 0)

Closes #267