### PR TITLE
fix(codex): render exec-policy justification + match as inline kwargs

### DIFF
--- a/internal/adapters/codex/exec_policies.go
+++ b/internal/adapters/codex/exec_policies.go
@@ -106,33 +106,36 @@ func validateExecPolicy(p config.CodexExecPolicy, index int) error {
 }
 
 // renderExecPoliciesSkylark turns the policy list into the Codex CLI's
-// `prefix_rule(...)` DSL. Each policy renders as one block. Justification
-// appears as a leading `# ...` comment; example matches go below the
-// rule as commented examples for human readers.
+// `prefix_rule(...)` DSL. Each policy renders as one block with all
+// optional fields (`justification`, `match`) as inline kwargs — the form
+// the codex docs show and the form `agnostic-ai import codex` captures
+// from hand-authored files, so import → sync stays byte-stable.
+//
+// Multi-line justification strings collapse to a single line in the
+// emit because the inline kwarg form takes one double-quoted Skylark
+// string; embedded newlines are not preserved (use the YAML overlay if
+// you need a multi-paragraph justification).
 func renderExecPoliciesSkylark(policies []config.CodexExecPolicy) string {
 	var b strings.Builder
 	for i, p := range policies {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		if p.Justification != "" {
-			for _, line := range strings.Split(strings.TrimSpace(p.Justification), "\n") {
-				b.WriteString("# ")
-				b.WriteString(line)
-				b.WriteByte('\n')
-			}
-		}
 		b.WriteString("prefix_rule(\n")
 		b.WriteString("    pattern = ")
 		writeStringList(&b, p.Pattern)
 		b.WriteString(",\n")
-		b.WriteString(fmt.Sprintf("    decision = %q,\n", p.Decision))
-		b.WriteString(")\n")
-		for _, m := range p.Match {
-			b.WriteString("# match: ")
-			b.WriteString(m)
-			b.WriteByte('\n')
+		fmt.Fprintf(&b, "    decision = %q,\n", p.Decision)
+		if p.Justification != "" {
+			justification := strings.ReplaceAll(strings.TrimSpace(p.Justification), "\n", " ")
+			fmt.Fprintf(&b, "    justification = %q,\n", justification)
 		}
+		if len(p.Match) > 0 {
+			b.WriteString("    match = ")
+			writeStringList(&b, p.Match)
+			b.WriteString(",\n")
+		}
+		b.WriteString(")\n")
 	}
 	return b.String()
 }

--- a/internal/adapters/codex/exec_policies_test.go
+++ b/internal/adapters/codex/exec_policies_test.go
@@ -38,13 +38,13 @@ func TestEmit_ExecPolicies_WritesSkylarkDSL(t *testing.T) {
 	}
 	out := string(got)
 	for _, want := range []string{
-		"# Composer scripts are project entrypoints.",
 		`pattern = ["composer", "test"]`,
 		`decision = "allow"`,
-		"# match: composer test",
-		"# Never remove the filesystem root.",
+		`justification = "Composer scripts are project entrypoints."`,
+		`match = ["composer test", "composer test -- --filter Foo"]`,
 		`pattern = ["rm", "-rf", "/"]`,
 		`decision = "forbidden"`,
+		`justification = "Never remove the filesystem root."`,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("default.rules missing %q in:\n%s", want, out)


### PR DESCRIPTION
## Summary

- Codex exec-policy renderer emitted `justification` as a leading `# ...` comment and `match` as trailing `# match:` lines.
- Codex CLI accepts both forms, but hand-authored projects use the inline kwargs form (the form `agnostic-ai import codex` captures via #279).
- Switch the default renderer to inline kwargs so import → sync round-trips byte-stable.

Closes #280

## Test plan

- [x] Updated `TestEmit_ExecPolicies_WritesSkylarkDSL` for the new shape
- [x] `go test ./...` → 891 passed
- [x] Verified against phel-lang PR #2085 ground truth: import codex → sync produces structurally equivalent `default.rules`