### PR TITLE
feat(import): auto-set target on tool-only agents and skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - Codex hooks emit into `.codex/hooks.json` with matcher-aware dedupe and `timeout` + `statusMessage` support. Override via `outputs.codex.hooks-file`. Closes #255.
 - `target:` / `targets:` / `target-exclude:` / `targets-exclude:` frontmatter scoping applies to every spec kind (agents, skills, rules, commands, mcps), not just hooks. Closes #292.
 - Per-target body fences: wrap prose in `::target codex` / `::end` markers to emit that block only to the named target. Closes #293.
+- `import claude` / `import codex` auto-set `target: <tool>` on agents/skills present in only one tool's tree so first-time imports preserve tool-only intent without manual frontmatter edits. Closes #299.
 
 ### Changed
 - `import <tool>` auto-sets `target: <tool>` on imported hooks so codex-specific scripts no longer leak into claude `settings.json` on cross-tool sync.

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -209,6 +209,8 @@ target: codex   # shell-expanded codex path; do not leak to other tools
 
 Hooks imported from a tool-native source auto-set `target` to that tool (codex import → `target: codex`, claude import → `target: claude`, gemini import → `target: gemini`). Remove the field by hand if you want the hook to flow everywhere.
 
+`import claude` and `import codex` apply the same auto-scoping to agents and skills: when both `.claude/` and `.codex/` exist on disk but only one carries a given spec, the captured frontmatter gains `target: <tool>`. A spec present in both tools stays un-scoped (cross-emit). Pure single-tool projects also stay un-scoped so byte-identical round-trips still hold.
+
 ### Supported events (Claude Code)
 
 | Event | When it fires |

--- a/internal/cli/import_auto_target.go
+++ b/internal/cli/import_auto_target.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -116,11 +117,13 @@ func addTargetFrontmatter(body, target string) string {
 }
 
 // injectTargetInSkillMD rewrites SKILL.md at path to declare
-// `target: <name>`. No-op when the file is missing or already scoped.
+// `target: <name>`. No-op when the file already declares any target.
+// Callers invoke this immediately after a successful copy, so a missing
+// SKILL.md indicates a real I/O problem worth surfacing.
 func injectTargetInSkillMD(path, target string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil
+		return fmt.Errorf("read %s: %w", path, err)
 	}
 	out := addTargetFrontmatter(string(data), target)
 	if out == string(data) {

--- a/internal/cli/import_auto_target.go
+++ b/internal/cli/import_auto_target.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// codexTreeExists reports whether root carries any sign of a Codex
+// installation. A claude-only project must not gain `target: claude`
+// tags during import, since cross-emit would never have triggered
+// anyway.
+func codexTreeExists(root string) bool {
+	for _, d := range codexAgentDirs {
+		if dirExists(filepath.Join(root, d)) {
+			return true
+		}
+	}
+	for _, d := range codexSkillsDirs {
+		if dirExists(filepath.Join(root, d)) {
+			return true
+		}
+	}
+	return dirExists(filepath.Join(root, codexDir))
+}
+
+// claudeTreeExists is the symmetric check for `import codex`.
+func claudeTreeExists(root string) bool {
+	return dirExists(filepath.Join(root, claudeDir))
+}
+
+// codexHasAgent reports whether any codex agents directory contains a
+// TOML whose basename canonicalises to the same slug. Canonicalisation
+// folds dash/underscore variants (changelog-keeper vs changelog_keeper)
+// so the auto-target check matches the round-trip merge already done
+// for codex agent specs.
+func codexHasAgent(root, canonical string) bool {
+	for _, dir := range codexAgentDirs {
+		entries, err := os.ReadDir(filepath.Join(root, dir))
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+				continue
+			}
+			base := strings.TrimSuffix(e.Name(), ".toml")
+			if canonicalSpecSlug(base) == canonical {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// codexHasSkill reports whether `<root>/<codexSkillsDir>/<name>/SKILL.md`
+// exists under any known codex skills root.
+func codexHasSkill(root, name string) bool {
+	for _, dir := range codexSkillsDirs {
+		if _, err := os.Stat(filepath.Join(root, dir, name, "SKILL.md")); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// claudeHasAgent reports whether `<root>/.claude/agents/<canonical>.md`
+// exists (after canonicalising the on-disk filename).
+func claudeHasAgent(root, canonical string) bool {
+	dir := filepath.Join(root, claudeDir, "agents")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		base := strings.TrimSuffix(e.Name(), ".md")
+		if canonicalSpecSlug(base) == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+// claudeHasSkill reports whether `<root>/.claude/skills/<name>/SKILL.md`
+// exists.
+func claudeHasSkill(root, name string) bool {
+	_, err := os.Stat(filepath.Join(root, claudeDir, "skills", name, "SKILL.md"))
+	return err == nil
+}
+
+var targetKeyRE = regexp.MustCompile(`(?m)^target[\t ]*:`)
+
+// addTargetFrontmatter sets `target: <name>` in the leading YAML
+// frontmatter of body. If body already declares any `target:` key the
+// original is returned unchanged (idempotent). Bodies without
+// frontmatter get one synthesized.
+func addTargetFrontmatter(body, target string) string {
+	if !strings.HasPrefix(body, "---\n") {
+		return "---\ntarget: " + target + "\n---\n\n" + body
+	}
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return body
+	}
+	front := rest[:end]
+	afterMarker := rest[end+len("\n---"):]
+	if targetKeyRE.MatchString(front) {
+		return body
+	}
+	return "---\n" + front + "\ntarget: " + target + "\n---" + afterMarker
+}
+
+// injectTargetInSkillMD rewrites SKILL.md at path to declare
+// `target: <name>`. No-op when the file is missing or already scoped.
+func injectTargetInSkillMD(path, target string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	out := addTargetFrontmatter(string(data), target)
+	if out == string(data) {
+		return nil
+	}
+	return importWriteFile(path, []byte(out), 0o644)
+}

--- a/internal/cli/import_auto_target_test.go
+++ b/internal/cli/import_auto_target_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A claude-only project (no codex tree) must not gain a `target:` tag,
+// preserving byte-identical round-trip for single-tool repos.
+func TestImportFromClaude_NoCodexTree_NoTargetTag(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nname: explorer\nmodel: sonnet\n---\nbody\n"
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "explorer.md"), body)
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "explorer.md"))
+	if strings.Contains(got, "target:") {
+		t.Errorf("unexpected target tag in claude-only repo:\n%s", got)
+	}
+}
+
+// When the project has both tools but the codex side lacks a matching
+// agent, the claude-imported spec gains `target: claude` so sync no
+// longer cross-emits it.
+func TestImportFromClaude_CodexLacksAgent_AddsTargetClaude(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "explorer.md"),
+		"---\nname: explorer\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "phel.toml"),
+		"name = \"phel\"\ndeveloper_instructions = \"x\"\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "explorer.md"))
+	if !strings.Contains(got, "target: claude") {
+		t.Errorf("expected `target: claude` in scoped agent:\n%s", got)
+	}
+}
+
+// When codex carries a matching agent (under either canonical form) the
+// imported spec must stay un-scoped so cross-emit keeps working.
+func TestImportFromClaude_CodexHasAgent_NoTargetTag(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "changelog-keeper.md"),
+		"---\nname: changelog-keeper\n---\nbody\n")
+	// Codex stores the same agent under the underscore convention.
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "changelog_keeper.toml"),
+		"name = \"changelog_keeper\"\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "changelog-keeper.md"))
+	if strings.Contains(got, "target:") {
+		t.Errorf("did not expect target tag, both tools have spec:\n%s", got)
+	}
+}
+
+func TestImportFromClaude_CodexLacksSkill_AddsTargetClaude(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "validator", "SKILL.md"),
+		"---\nname: validator\n---\nbody\n")
+	// Force codex tree to exist via a sibling skill so the gate fires.
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "other", "SKILL.md"),
+		"---\nname: other\n---\nx\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "validator", "SKILL.md"))
+	if !strings.Contains(got, "target: claude") {
+		t.Errorf("expected `target: claude` in scoped skill:\n%s", got)
+	}
+}
+
+func TestImportFromClaude_CodexHasSkill_NoTargetTag(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "shared", "SKILL.md"),
+		"---\nname: shared\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "shared", "SKILL.md"),
+		"---\nname: shared\n---\nx\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "shared", "SKILL.md"))
+	if strings.Contains(got, "target:") {
+		t.Errorf("did not expect target tag in shared skill:\n%s", got)
+	}
+}
+
+func TestImportFromCodex_NoClaudeTree_NoTargetTag(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "phel.toml"),
+		"name = \"phel\"\ndeveloper_instructions = \"x\"\n")
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "phel.md"))
+	if strings.Contains(got, "target:") {
+		t.Errorf("unexpected target tag in codex-only repo:\n%s", got)
+	}
+}
+
+func TestImportFromCodex_ClaudeLacksAgent_AddsTargetCodex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "phel.toml"),
+		"name = \"phel\"\ndeveloper_instructions = \"x\"\n")
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "explorer.md"),
+		"---\nname: explorer\n---\nbody\n")
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "phel.md"))
+	if !strings.Contains(got, "target: codex") {
+		t.Errorf("expected `target: codex` in scoped agent:\n%s", got)
+	}
+}
+
+func TestImportFromCodex_ClaudeHasAgent_NoTargetTag(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "changelog_keeper.toml"),
+		"name = \"changelog_keeper\"\ndeveloper_instructions = \"x\"\n")
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "changelog-keeper.md"),
+		"---\nname: changelog-keeper\n---\nbody\n")
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "changelog-keeper.md"))
+	if strings.Contains(got, "target:") {
+		t.Errorf("did not expect target tag, both tools have spec:\n%s", got)
+	}
+}
+
+func TestImportFromCodex_ClaudeLacksSkill_AddsTargetCodex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "phel", "SKILL.md"),
+		"---\nname: phel\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "other", "SKILL.md"),
+		"---\nname: other\n---\nx\n")
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "phel", "SKILL.md"))
+	if !strings.Contains(got, "target: codex") {
+		t.Errorf("expected `target: codex` in scoped skill:\n%s", got)
+	}
+}
+
+func TestAddTargetFrontmatter_Idempotent(t *testing.T) {
+	body := "---\nname: x\ntarget: claude\n---\nbody\n"
+	got := addTargetFrontmatter(body, "claude")
+	if got != body {
+		t.Errorf("addTargetFrontmatter mutated already-scoped body:\n%s", got)
+	}
+}
+
+func TestAddTargetFrontmatter_AppendsToExistingFrontmatter(t *testing.T) {
+	body := "---\nname: x\n---\nbody\n"
+	got := addTargetFrontmatter(body, "claude")
+	want := "---\nname: x\ntarget: claude\n---\nbody\n"
+	if got != want {
+		t.Errorf("addTargetFrontmatter:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestAddTargetFrontmatter_NoFrontmatter_Synthesizes(t *testing.T) {
+	body := "bare body\n"
+	got := addTargetFrontmatter(body, "codex")
+	want := "---\ntarget: codex\n---\n\nbare body\n"
+	if got != want {
+		t.Errorf("addTargetFrontmatter:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/cli/import_claude_skills.go
+++ b/internal/cli/import_claude_skills.go
@@ -6,15 +6,51 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
 )
 
 // importClaudeAgents copies .claude/agents/*.md byte-for-byte to dstDir.
+// When the project also carries a Codex installation but the matching
+// codex agent is absent there, the captured spec gains `target: claude`
+// frontmatter so the next sync does not cross-emit a claude-only agent
+// into `.codex/`.
 func importClaudeAgents(root, dstDir string) (int, error) {
 	src := filepath.Join(root, claudeDir, "agents")
 	if !dirExists(src) {
 		return 0, nil
 	}
-	return copyMarkdownDir(src, dstDir)
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", src, err)
+	}
+	codexPresent := codexTreeExists(root)
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		srcPath := filepath.Join(src, e.Name())
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			return count, fmt.Errorf("read %s: %w", srcPath, err)
+		}
+		out := header.Strip(string(data))
+		name := strings.TrimSuffix(e.Name(), ".md")
+		if codexPresent && !codexHasAgent(root, canonicalSpecSlug(name)) {
+			out = addTargetFrontmatter(out, "claude")
+		}
+		dstPath := filepath.Join(dstDir, e.Name())
+		if err := importMkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+			return count, fmt.Errorf("mkdir %s: %w", filepath.Dir(dstPath), err)
+		}
+		if err := importWriteFile(dstPath, []byte(out), 0o644); err != nil {
+			return count, fmt.Errorf("write %s: %w", dstPath, err)
+		}
+		count++
+	}
+	return count, nil
 }
 
 // importClaudeSkills copies each `.claude/skills/<name>/` directory tree
@@ -22,7 +58,9 @@ func importClaudeAgents(root, dstDir string) (int, error) {
 // skill to be considered; once present, every sibling file (and nested
 // subdirectories such as `scripts/`, `assets/`, helper Python/JS
 // modules, fixtures, etc.) is mirrored verbatim so a roundtrip
-// preserves the full skill payload.
+// preserves the full skill payload. SKILL.md gains `target: claude`
+// frontmatter when the project has a codex tree but no matching codex
+// skill (auto-scoping per #299).
 func importClaudeSkills(root, dstDir string) (int, error) {
 	src := filepath.Join(root, claudeDir, "skills")
 	entries, err := os.ReadDir(src)
@@ -32,6 +70,7 @@ func importClaudeSkills(root, dstDir string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("read %s: %w", src, err)
 	}
+	codexPresent := codexTreeExists(root)
 	count := 0
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -46,6 +85,11 @@ func importClaudeSkills(root, dstDir string) (int, error) {
 		skillDst := filepath.Join(dstDir, e.Name())
 		if err := copyDirTree(skillSrc, skillDst); err != nil {
 			return count, fmt.Errorf("copy skill %s: %w", e.Name(), err)
+		}
+		if codexPresent && !codexHasSkill(root, e.Name()) {
+			if err := injectTargetInSkillMD(filepath.Join(skillDst, "SKILL.md"), "claude"); err != nil {
+				return count, fmt.Errorf("scope skill %s: %w", e.Name(), err)
+			}
 		}
 		count++
 	}

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -38,6 +38,7 @@ var codexSkillsDirs = []string{".codex/skills", ".agents/skills"}
 func importCodexAgents(root, dstDir string) (int, error) {
 	count := 0
 	seen := map[string]bool{}
+	claudePresent := claudeTreeExists(root)
 	for _, sub := range codexAgentDirs {
 		dir := filepath.Join(root, sub)
 		entries, err := os.ReadDir(dir)
@@ -72,7 +73,11 @@ func importCodexAgents(root, dstDir string) (int, error) {
 			}
 			seen[canonical] = true
 
-			wrote, err := mergeOrWriteCodexAgentSpec(dstDir, canonical, tomlName, doc)
+			scope := ""
+			if claudePresent && !claudeHasAgent(root, canonical) {
+				scope = "codex"
+			}
+			wrote, err := mergeOrWriteCodexAgentSpec(dstDir, canonical, tomlName, doc, scope)
 			if err != nil {
 				return count, err
 			}
@@ -125,11 +130,11 @@ var codexAgentTopLevel = map[string]bool{
 // differs from the canonical slug it lands under `x-codex.name` so the
 // codex emitter still produces TOML with the runtime-expected
 // underscored identifier.
-func mergeOrWriteCodexAgentSpec(dstDir, canonical, codexName string, doc map[string]any) (bool, error) {
+func mergeOrWriteCodexAgentSpec(dstDir, canonical, codexName string, doc map[string]any, scope string) (bool, error) {
 	path := filepath.Join(dstDir, canonical+".md")
 	existing, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return true, writeCodexAgentSpec(path, canonical, codexName, doc)
+		return true, writeCodexAgentSpec(path, canonical, codexName, doc, scope)
 	}
 	if err != nil {
 		return false, fmt.Errorf("read %s: %w", path, err)
@@ -150,7 +155,7 @@ func mergeOrWriteCodexAgentSpec(dstDir, canonical, codexName string, doc map[str
 // the canonical (dash) slug so the on-disk filename and frontmatter
 // stay aligned; when the codex runtime name differs it is preserved
 // under `x-codex.name`.
-func writeCodexAgentSpec(path, canonical, codexName string, doc map[string]any) error {
+func writeCodexAgentSpec(path, canonical, codexName string, doc map[string]any, scope string) error {
 	body, _ := doc["developer_instructions"].(string)
 	body = strings.TrimRight(body, "\n")
 
@@ -160,6 +165,9 @@ func writeCodexAgentSpec(path, canonical, codexName string, doc map[string]any) 
 	}
 	if m, _ := doc["model"].(string); m != "" {
 		fm["model"] = m
+	}
+	if scope != "" {
+		fm["target"] = scope
 	}
 	xcodex := map[string]any{}
 	for key, val := range doc {
@@ -249,6 +257,7 @@ var agentFrontmatterOrder = []string{
 	"name",
 	"description",
 	"model",
+	"target",
 	"allowed_tools",
 	"argument-hint",
 	"disable-model-invocation",
@@ -331,6 +340,7 @@ func splitCodexAgentFrontmatter(doc string) (string, string, bool) {
 func importCodexSkills(root, dstDir string) (int, error) {
 	count := 0
 	seen := map[string]bool{}
+	claudePresent := claudeTreeExists(root)
 	for _, sub := range codexSkillsDirs {
 		srcDir := filepath.Join(root, sub)
 		entries, err := os.ReadDir(srcDir)
@@ -355,12 +365,21 @@ func importCodexSkills(root, dstDir string) (int, error) {
 			}
 			seen[e.Name()] = true
 			skillDst := filepath.Join(dstDir, e.Name())
-			if dirExists(skillDst) {
+			merged := dirExists(skillDst)
+			if merged {
 				if err := mergeCodexSkillIntoExisting(skillSrc, skillDst); err != nil {
 					return count, fmt.Errorf("merge skill %s: %w", e.Name(), err)
 				}
 			} else if err := copyDirTree(skillSrc, skillDst); err != nil {
 				return count, fmt.Errorf("copy skill %s: %w", e.Name(), err)
+			}
+			// Auto-scope `target: codex` only when this is a fresh
+			// import (no claude sibling on disk and no claude-merged
+			// SKILL.md already at the destination).
+			if !merged && claudePresent && !claudeHasSkill(root, e.Name()) {
+				if err := injectTargetInSkillMD(filepath.Join(skillDst, "SKILL.md"), "codex"); err != nil {
+					return count, fmt.Errorf("scope skill %s: %w", e.Name(), err)
+				}
 			}
 			count++
 		}

--- a/tests/integration/roundtrip_edge_cases_test.go
+++ b/tests/integration/roundtrip_edge_cases_test.go
@@ -318,9 +318,12 @@ func TestEdgeCase_SkillNestedAssetsRoundTrip(t *testing.T) {
 		}
 	}
 
-	// Wipe specs, re-import from codex, sync back to claude.
+	// Wipe specs and the entire claude tree so the second leg simulates
+	// a fresh codex-only project. Leaving `.claude/` in place would
+	// trip the #299 auto-target heuristic (no matching claude skill →
+	// import codex stamps `target: codex` and sync never round-trips).
 	must(t, os.RemoveAll(filepath.Join(dir, ".agnostic-ai/skills")))
-	must(t, os.RemoveAll(filepath.Join(dir, ".claude/skills")))
+	must(t, os.RemoveAll(filepath.Join(dir, ".claude")))
 	runCmd(t, "import", "codex")
 	runCmd(t, "sync", "-t", "claude")
 


### PR DESCRIPTION
## Summary

- `import claude` and `import codex` now stamp `target: <tool>` into the captured agent/skill frontmatter when the project has both tools but only one of them carries the spec.
- Pure single-tool projects (no sibling tree on disk) stay un-scoped so byte-identical round-trips keep holding.
- Specs present in both tools also stay un-scoped because cross-emit is the right default there.

## Why

Hand-authored projects with intentionally tool-only agents/skills (e.g. `phel-explorer` codex-only, `explorer` claude-only) used to cross-emit unconditionally on first sync. Authors had to add `target:` manually after every import.

## Test plan

- [x] `go test ./...` (922 tests pass)
- [x] `golangci-lint run ./...` clean
- [x] New unit tests cover: claude-only repo unchanged, codex-lacks-agent → `target: claude`, codex-has-agent → no tag, same for skills, codex side mirrored, idempotent re-injection, no-frontmatter synthesis.
- [x] Updated existing integration round-trip to wipe the entire `.claude/` tree on the second leg so the auto-scope gate stays false (matches a fresh codex-only project).

Closes #299