### PR TITLE
feat(import): auto-fence divergent agent/skill bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - `target:` / `targets:` / `target-exclude:` / `targets-exclude:` frontmatter scoping applies to every spec kind (agents, skills, rules, commands, mcps), not just hooks. Closes #292.
 - Per-target body fences: wrap prose in `::target codex` / `::end` markers to emit that block only to the named target. Closes #293.
 - `import claude` / `import codex` auto-set `target: <tool>` on agents/skills present in only one tool's tree so first-time imports preserve tool-only intent without manual frontmatter edits. Closes #299.
+- `import codex` auto-fences divergent agent / skill bodies when both tools ship the same spec name: shared prose stays un-fenced, each tool's unique middle gets wrapped in `::target` blocks. Closes #300.
 
 ### Changed
 - `import <tool>` auto-sets `target: <tool>` on imported hooks so codex-specific scripts no longer leak into claude `settings.json` on cross-tool sync.

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -199,6 +199,7 @@ Shared outro.
 - `::end` closes the most recent fence.
 - An unterminated fence runs to end-of-body so a missing `::end` does not drop the tail of the file.
 - The empty target (e.g. the source view used by `import` round-trips) returns the body with fences intact so a re-emit stays byte-stable.
+- `import codex` builds these fences automatically when both tools ship the same agent or skill name with diverging bodies: the longest common prefix and suffix stay un-fenced and each tool's unique middle gets its own `::target` block.
 
 ```yaml
 event: PostToolUse

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -245,7 +245,12 @@ func mergeCodexAgentIntoExisting(existing, codexName string, doc map[string]any)
 	if err != nil {
 		return "", fmt.Errorf("re-marshal frontmatter: %w", err)
 	}
-	return "---\n" + string(raw) + "---\n\n" + body, nil
+	codexBody, _ := doc["developer_instructions"].(string)
+	mergedBody := mergeAgentBody(body, codexBody)
+	if !strings.HasSuffix(mergedBody, "\n") {
+		mergedBody += "\n"
+	}
+	return "---\n" + string(raw) + "---\n\n" + mergedBody, nil
 }
 
 // agentFrontmatterOrder is the canonical claude-conventional key order
@@ -388,12 +393,17 @@ func importCodexSkills(root, dstDir string) (int, error) {
 }
 
 // mergeCodexSkillIntoExisting layers a codex skill folder on top of an
-// already-imported skill (claude origin) without overwriting the claude
-// SKILL.md. The claude variant retains its frontmatter (argument-hint,
-// disable-model-invocation, allowed-tools — Claude reads these to wire
-// the skill correctly); codex-only assets (agents/openai.yaml, scripts/,
+// already-imported skill (claude origin). Claude frontmatter survives
+// (argument-hint, disable-model-invocation, allowed-tools — Claude
+// reads these to wire the skill correctly). When the codex SKILL.md
+// body diverges from claude's the unique sections get wrapped in
+// `::target` fences so both tools' authored prose survives the
+// round-trip (#300). Codex-only assets (agents/openai.yaml, scripts/,
 // helper files) copy across.
 func mergeCodexSkillIntoExisting(src, dst string) error {
+	if err := mergeSkillBodies(filepath.Join(dst, "SKILL.md"), filepath.Join(src, "SKILL.md")); err != nil {
+		return err
+	}
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -402,14 +412,7 @@ func mergeCodexSkillIntoExisting(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		if rel == "." {
-			return nil
-		}
-		// Never clobber the existing SKILL.md — claude frontmatter must
-		// survive. Codex SKILL.md frontmatter (description, name) stays
-		// reachable through the `.codex/skills/` emit which still
-		// reads from the captured spec, just from the claude side now.
-		if rel == "SKILL.md" {
+		if rel == "." || rel == "SKILL.md" {
 			return nil
 		}
 		target := filepath.Join(dst, rel)

--- a/internal/cli/import_fence_bodies.go
+++ b/internal/cli/import_fence_bodies.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// fenceDivergent merges two same-name spec bodies, wrapping the parts
+// that differ in `::target` fences so both tools keep their authored
+// content after a round-trip import.
+//
+// The diff runs at line granularity: the longest common prefix and
+// suffix stay un-fenced and each tool's middle gets its own
+// `::target <name>` / `::end` block. Identical bodies pass through
+// unchanged; if one side is empty the other ends up wholly inside a
+// fence.
+func fenceDivergent(claudeBody, codexBody, claudeName, codexName string) string {
+	if claudeBody == codexBody {
+		return claudeBody
+	}
+	if strings.TrimSpace(claudeBody) == "" {
+		return wrapInFence(codexBody, codexName)
+	}
+	if strings.TrimSpace(codexBody) == "" {
+		return wrapInFence(claudeBody, claudeName)
+	}
+
+	cLines := splitLines(claudeBody)
+	xLines := splitLines(codexBody)
+
+	prefix := 0
+	for prefix < len(cLines) && prefix < len(xLines) && cLines[prefix] == xLines[prefix] {
+		prefix++
+	}
+	suffix := 0
+	for prefix+suffix < len(cLines) && prefix+suffix < len(xLines) &&
+		cLines[len(cLines)-1-suffix] == xLines[len(xLines)-1-suffix] {
+		suffix++
+	}
+
+	commonPrefix := strings.Join(cLines[:prefix], "\n")
+	commonSuffix := strings.Join(cLines[len(cLines)-suffix:], "\n")
+	cMiddle := strings.Join(cLines[prefix:len(cLines)-suffix], "\n")
+	xMiddle := strings.Join(xLines[prefix:len(xLines)-suffix], "\n")
+
+	var b strings.Builder
+	if commonPrefix != "" {
+		b.WriteString(commonPrefix)
+		b.WriteString("\n\n")
+	}
+	if cMiddle != "" {
+		b.WriteString("::target ")
+		b.WriteString(claudeName)
+		b.WriteString("\n")
+		b.WriteString(cMiddle)
+		b.WriteString("\n::end\n\n")
+	}
+	if xMiddle != "" {
+		b.WriteString("::target ")
+		b.WriteString(codexName)
+		b.WriteString("\n")
+		b.WriteString(xMiddle)
+		b.WriteString("\n::end\n")
+	}
+	if commonSuffix != "" {
+		if xMiddle != "" {
+			b.WriteString("\n")
+		}
+		b.WriteString(commonSuffix)
+	}
+	out := b.String()
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return out
+}
+
+func wrapInFence(body, target string) string {
+	trimmed := strings.TrimRight(body, "\n")
+	return "::target " + target + "\n" + trimmed + "\n::end\n"
+}
+
+// splitLines splits body on '\n' without consuming the trailing newline.
+// A body ending in '\n' yields an empty final entry which the join step
+// converts back into a trailing newline, preserving line counts.
+func splitLines(s string) []string {
+	return strings.Split(strings.TrimRight(s, "\n"), "\n")
+}
+
+// mergeSkillBodies rewrites claudePath's SKILL.md so divergent body
+// content from codexPath's SKILL.md survives as a `::target codex`
+// fence. Claude's frontmatter is the source of truth (per the
+// claude-wins precedence documented in #287); only the body changes.
+// A no-op when the bodies are byte-identical or either file lacks
+// frontmatter.
+func mergeSkillBodies(claudePath, codexPath string) error {
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", claudePath, err)
+	}
+	codexData, err := os.ReadFile(codexPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", codexPath, err)
+	}
+
+	claudeFront, claudeBody, claudeOK := splitCodexAgentFrontmatter(string(claudeData))
+	_, codexBody, codexOK := splitCodexAgentFrontmatter(string(codexData))
+	if !claudeOK || !codexOK {
+		return nil
+	}
+	if strings.TrimRight(claudeBody, "\n") == strings.TrimRight(codexBody, "\n") {
+		return nil
+	}
+
+	merged := fenceDivergent(
+		strings.TrimRight(claudeBody, "\n"),
+		strings.TrimRight(codexBody, "\n"),
+		"claude", "codex",
+	)
+	out := "---\n" + claudeFront + "\n---\n\n" + merged
+	if out == string(claudeData) {
+		return nil
+	}
+	return importWriteFile(claudePath, []byte(out), 0o644)
+}
+
+// mergeAgentBody returns claudeBody with divergent codex content
+// fenced. claudeBody is the existing post-frontmatter body; codexBody
+// is the codex `developer_instructions` value. The result is intended
+// to slot back below the merged frontmatter.
+func mergeAgentBody(claudeBody, codexBody string) string {
+	cb := strings.TrimRight(claudeBody, "\n")
+	xb := strings.TrimRight(codexBody, "\n")
+	if cb == xb {
+		return claudeBody
+	}
+	merged := fenceDivergent(cb, xb, "claude", "codex")
+	return merged
+}

--- a/internal/cli/import_fence_bodies_test.go
+++ b/internal/cli/import_fence_bodies_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFenceDivergent_Identical(t *testing.T) {
+	body := "Same body.\n"
+	got := fenceDivergent(body, body, "claude", "codex")
+	if got != body {
+		t.Errorf("expected unchanged body, got %q", got)
+	}
+}
+
+func TestFenceDivergent_OnlyClaude(t *testing.T) {
+	got := fenceDivergent("claude content", "", "claude", "codex")
+	want := "::target claude\nclaude content\n::end\n"
+	if got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestFenceDivergent_OnlyCodex(t *testing.T) {
+	got := fenceDivergent("", "codex content", "claude", "codex")
+	want := "::target codex\ncodex content\n::end\n"
+	if got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestFenceDivergent_SharedPrefixAndSuffix(t *testing.T) {
+	claude := "# Skill\n\nShared intro.\n\n## Workflow\n1. claude step\n2. claude step 2\n\nShared outro."
+	codex := "# Skill\n\nShared intro.\n\n## Workflow\n1. codex step\n\nShared outro."
+	got := fenceDivergent(claude, codex, "claude", "codex")
+	if !strings.Contains(got, "# Skill") {
+		t.Errorf("lost common prefix:\n%s", got)
+	}
+	if !strings.Contains(got, "## Workflow") {
+		t.Errorf("lost common middle (workflow heading):\n%s", got)
+	}
+	if !strings.Contains(got, "Shared outro.") {
+		t.Errorf("lost common suffix:\n%s", got)
+	}
+	if !strings.Contains(got, "::target claude\n1. claude step\n2. claude step 2\n::end") {
+		t.Errorf("missing claude fence:\n%s", got)
+	}
+	if !strings.Contains(got, "::target codex\n1. codex step\n::end") {
+		t.Errorf("missing codex fence:\n%s", got)
+	}
+}
+
+func TestFenceDivergent_TotalDivergence(t *testing.T) {
+	got := fenceDivergent("Alpha.", "Beta.", "claude", "codex")
+	if !strings.Contains(got, "::target claude\nAlpha.\n::end") {
+		t.Errorf("missing claude fence:\n%s", got)
+	}
+	if !strings.Contains(got, "::target codex\nBeta.\n::end") {
+		t.Errorf("missing codex fence:\n%s", got)
+	}
+	if strings.Contains(got, "Alpha.\nBeta.") {
+		t.Errorf("bodies should be in separate fences:\n%s", got)
+	}
+}
+
+func TestMergeSkillBodies_IdenticalNoOp(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nname: test\n---\nSame body.\n"
+	claudePath := filepath.Join(dir, "claude.md")
+	codexPath := filepath.Join(dir, "codex.md")
+	writeFile(t, claudePath, body)
+	writeFile(t, codexPath, body)
+	if err := mergeSkillBodies(claudePath, codexPath); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, claudePath)
+	if got != body {
+		t.Errorf("identical bodies should not be rewritten:\ngot %q\nwant %q", got, body)
+	}
+}
+
+func TestMergeSkillBodies_DivergentRewrites(t *testing.T) {
+	dir := t.TempDir()
+	claudePath := filepath.Join(dir, "claude.md")
+	codexPath := filepath.Join(dir, "codex.md")
+	writeFile(t, claudePath,
+		"---\nname: test\ndescription: x\n---\n# Skill\n\nIntro.\n\n## Steps\n1. claude only\n\nOutro.\n")
+	writeFile(t, codexPath,
+		"---\nname: test\n---\n# Skill\n\nIntro.\n\n## Steps\n1. codex only\n\nOutro.\n")
+	if err := mergeSkillBodies(claudePath, codexPath); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, claudePath)
+	if !strings.Contains(got, "description: x") {
+		t.Errorf("claude frontmatter must survive:\n%s", got)
+	}
+	if !strings.Contains(got, "::target claude\n1. claude only\n::end") {
+		t.Errorf("missing claude fence:\n%s", got)
+	}
+	if !strings.Contains(got, "::target codex\n1. codex only\n::end") {
+		t.Errorf("missing codex fence:\n%s", got)
+	}
+}
+
+func TestImportFromCodex_SkillBodyDiverges_AddsFences(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "test", "SKILL.md"),
+		"---\nname: test\ndescription: from claude\n---\n# Test\n\nShared intro.\n\n## Scope\n- claude only\n\nShared outro.\n")
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "test", "SKILL.md"),
+		"---\nname: test\n---\n# Test\n\nShared intro.\n\n## Scope\n- codex only\n\nShared outro.\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "test", "SKILL.md"))
+	if !strings.Contains(got, "description: from claude") {
+		t.Errorf("claude frontmatter must win:\n%s", got)
+	}
+	if !strings.Contains(got, "::target claude\n- claude only\n::end") {
+		t.Errorf("missing claude fence:\n%s", got)
+	}
+	if !strings.Contains(got, "::target codex\n- codex only\n::end") {
+		t.Errorf("missing codex fence:\n%s", got)
+	}
+	if !strings.Contains(got, "Shared intro.") || !strings.Contains(got, "Shared outro.") {
+		t.Errorf("shared sections lost:\n%s", got)
+	}
+}
+
+func TestImportFromCodex_AgentBodyDiverges_AddsFences(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "explorer.md"),
+		"---\nname: explorer\ndescription: from claude\n---\nShared intro.\n\nclaude step.\n\nShared outro.\n")
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "explorer.toml"),
+		`name = "explorer"`+"\n"+
+			`description = "from codex"`+"\n"+
+			`developer_instructions = """Shared intro.
+
+codex step.
+
+Shared outro."""`+"\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "explorer.md"))
+	if !strings.Contains(got, "description: from claude") {
+		t.Errorf("claude frontmatter must win:\n%s", got)
+	}
+	if !strings.Contains(got, "::target claude\nclaude step.\n::end") {
+		t.Errorf("missing claude fence:\n%s", got)
+	}
+	if !strings.Contains(got, "::target codex\ncodex step.\n::end") {
+		t.Errorf("missing codex fence:\n%s", got)
+	}
+}
+
+func TestImportFromCodex_AgentBodyIdentical_NoFences(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "explorer.md"),
+		"---\nname: explorer\n---\nShared body.\n")
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "explorer.toml"),
+		`name = "explorer"`+"\n"+
+			`developer_instructions = "Shared body."`+"\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "explorer.md"))
+	if strings.Contains(got, "::target") {
+		t.Errorf("did not expect fences for identical body:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `import codex` now diffs same-name agent/skill bodies against the claude-imported version line by line. Shared prefix and suffix stay un-fenced; each tool's unique middle gets wrapped in `::target claude` / `::target codex` blocks.
- Identical bodies remain a no-op (no fence markers introduced).
- Frontmatter precedence is unchanged: claude wins per #287.

## Why

After #297 added per-target body fences, the emit side splits and routes prose by target. The import side did not auto-fence when both tools shipped the same spec name with diverging bodies — codex's body was silently lost (claude-wins). Authors had to fence by hand. This change automates the common case so the round-trip preserves both tools' authored content.

## Test plan

- [x] `go test ./...` (920 tests pass)
- [x] `golangci-lint run ./...` clean
- [x] New unit tests for `fenceDivergent` (identical / only-one-side / shared-prefix-suffix / total-divergence) and end-to-end coverage for both skill and agent body merging.

Closes #300