### PR TITLE
fix(emit): strip routing keys from emitted frontmatter

### DIFF
--- a/internal/adapters/internal/emit/meta.go
+++ b/internal/adapters/internal/emit/meta.go
@@ -8,6 +8,18 @@ import "strings"
 // portable.
 const XPrefix = "x-"
 
+// routingKeys are agnostic-ai-only frontmatter keys that steer which
+// target receives a spec. They have no semantics inside the tool's
+// consumer (Claude, Codex, etc.), so the adapter must strip them on
+// emit; otherwise round-trip imports leak `target: claude` into hand-
+// authored files that never declared it (#303).
+var routingKeys = map[string]bool{
+	"target":          true,
+	"targets":         true,
+	"target-exclude":  true,
+	"targets-exclude": true,
+}
+
 // StringSlice coerces a `[]any` of strings (YAML's default unmarshalled
 // shape for list-of-strings) into `[]string`. Non-string elements and
 // non-slice inputs return nil. Adapters use this to read `args`,
@@ -88,7 +100,7 @@ func ResolveMetaOrdered(meta map[string]any, keys []string, target string) (map[
 	walked := make(map[string]bool, len(meta))
 	for _, k := range keys {
 		walked[k] = true
-		if strings.HasPrefix(k, XPrefix) {
+		if strings.HasPrefix(k, XPrefix) || routingKeys[k] {
 			continue
 		}
 		if v, ok := meta[k]; ok {
@@ -96,7 +108,7 @@ func ResolveMetaOrdered(meta map[string]any, keys []string, target string) (map[
 		}
 	}
 	for k, v := range meta {
-		if walked[k] || strings.HasPrefix(k, XPrefix) || seen[k] {
+		if walked[k] || strings.HasPrefix(k, XPrefix) || routingKeys[k] || seen[k] {
 			continue
 		}
 		appendKV(k, v)

--- a/internal/adapters/internal/emit/meta_test.go
+++ b/internal/adapters/internal/emit/meta_test.go
@@ -50,3 +50,36 @@ func TestResolveMeta_NilMap(t *testing.T) {
 		t.Errorf("expected nil pass-through, got %#v", got)
 	}
 }
+
+func TestResolveMeta_StripsRoutingKeys(t *testing.T) {
+	in := map[string]any{
+		"name":            "r1",
+		"description":     "desc",
+		"target":          "claude",
+		"targets":         []any{"claude", "codex"},
+		"target-exclude":  "gemini",
+		"targets-exclude": []any{"cursor"},
+	}
+	got := ResolveMeta(in, "claude")
+	want := map[string]any{"name": "r1", "description": "desc"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveMetaOrdered_StripsRoutingKeysFromOrder(t *testing.T) {
+	in := map[string]any{
+		"name":        "r1",
+		"target":      "claude",
+		"description": "desc",
+	}
+	keys := []string{"name", "target", "description"}
+	got, gotKeys := ResolveMetaOrdered(in, keys, "claude")
+	wantKeys := []string{"name", "description"}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Errorf("ordered keys: got %v, want %v", gotKeys, wantKeys)
+	}
+	if _, present := got["target"]; present {
+		t.Errorf("target should be stripped, got %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `ResolveMetaOrdered` now drops `target`, `targets`, `target-exclude`, `targets-exclude` alongside `x-*` keys, so every adapter call site benefits at once.
- Added `TestResolveMeta_StripsRoutingKeys` + an ordered-keys regression that asserts both the map AND the key order skip the routing keys.

## Why

These keys are agnostic-ai-only — they steer which target receives a spec. The consuming tool (Claude, Codex, etc.) does not read them. Leaving them in the emitted file caused `import` + `sync` to leak `target: claude` into hand-authored agents that never declared it, breaking byte-equal round-trip parity (verified against phel-lang PR #2085 base).

## Test plan
- [x] `go test ./...` — 934 tests pass
- [x] Re-verify against phel-lang ground truth after merge

Closes #303