### PR TITLE
fix(import): tight-stitch fenceDivergent so rendered targets see no stray blanks

### DIFF
--- a/internal/cli/import_fence_bodies.go
+++ b/internal/cli/import_fence_bodies.go
@@ -45,16 +45,22 @@ func fenceDivergent(claudeBody, codexBody, claudeName, codexName string) string 
 	xMiddle := strings.Join(xLines[prefix:len(xLines)-suffix], "\n")
 
 	var b strings.Builder
+	// Tight stitch: ::end runs into the next ::target with no blank in
+	// between, and the common suffix attaches directly to the last ::end.
+	// `renderBodyForTarget` keeps every blank line outside a fence, so any
+	// visual padding here would survive into the active target's emit as
+	// a stray blank between sections (#306). The fence markers are
+	// already on dedicated lines, so the spec stays readable.
 	if commonPrefix != "" {
 		b.WriteString(commonPrefix)
-		b.WriteString("\n\n")
+		b.WriteString("\n")
 	}
 	if cMiddle != "" {
 		b.WriteString("::target ")
 		b.WriteString(claudeName)
 		b.WriteString("\n")
 		b.WriteString(cMiddle)
-		b.WriteString("\n::end\n\n")
+		b.WriteString("\n::end\n")
 	}
 	if xMiddle != "" {
 		b.WriteString("::target ")
@@ -64,9 +70,6 @@ func fenceDivergent(claudeBody, codexBody, claudeName, codexName string) string 
 		b.WriteString("\n::end\n")
 	}
 	if commonSuffix != "" {
-		if xMiddle != "" {
-			b.WriteString("\n")
-		}
 		b.WriteString(commonSuffix)
 	}
 	out := b.String()

--- a/internal/cli/import_fence_bodies_test.go
+++ b/internal/cli/import_fence_bodies_test.go
@@ -4,7 +4,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
+
+// Entry is a local alias so the test file can name the spec entry type
+// without colliding with the cli package's own types. Keeps the round-
+// trip assertion below readable.
+type Entry = spec.Entry
 
 func TestFenceDivergent_Identical(t *testing.T) {
 	body := "Same body.\n"
@@ -61,6 +68,24 @@ func TestFenceDivergent_TotalDivergence(t *testing.T) {
 	}
 	if strings.Contains(got, "Alpha.\nBeta.") {
 		t.Errorf("bodies should be in separate fences:\n%s", got)
+	}
+}
+
+// renderBodyForTarget keeps every blank line outside a fence, so any
+// stitching padding the auto-fencer adds between fences leaks into the
+// emit as a stray blank between sections (#306). Stack the fences and
+// confirm rendering for each target reads as if the fences were never
+// there.
+func TestFenceDivergent_TightStitch_NoStrayBlankOnRender(t *testing.T) {
+	claudeBody := "## Header\nshared lead.\n\n## Claude Only\nclaude detail.\n\n## Footer\n... shared tail ...\n"
+	codexBody := "## Header\nshared lead.\n\n## Codex Only\ncodex detail.\n\n## Footer\n... shared tail ...\n"
+	merged := fenceDivergent(claudeBody, codexBody, "claude", "codex")
+	e := Entry{Body: merged}
+	if got := e.BodyFor("claude"); got != claudeBody {
+		t.Errorf("claude round-trip drift:\ngot:  %q\nwant: %q", got, claudeBody)
+	}
+	if got := e.BodyFor("codex"); got != codexBody {
+		t.Errorf("codex round-trip drift:\ngot:  %q\nwant: %q", got, codexBody)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Drop the \`\\n\\n\` after each \`::end\` and the extra \`\\n\` before \`commonSuffix\` in \`fenceDivergent\`.
- Added \`TestFenceDivergent_TightStitch_NoStrayBlankOnRender\` that asserts byte-equal round-trip through \`BodyFor\` for both targets.

## Why

\`renderBodyForTarget\` keeps every blank line outside a fence (intentional — hand-authored \`::target\` blocks must respect the author's paragraph breaks). So any padding the auto-fencer inserted between fences survived into the emit as a stray blank line, producing drift like:

\`\`\`diff
 ## Minor Issues (Low Priority)
+
 ...

 ## Recommended Refactoring Steps
\`\`\`

By emitting a compact \`::end\\n::target X\` stitch and zero-blank suffix glue, the round-trip stays byte-stable without changing the renderer (which still preserves hand-authored blanks).

## Test plan
- [x] \`go test ./...\` — 933 tests pass
- [x] Verified against phel-lang PR #2085 ground truth (refactor-check, phel-repl) post-merge

Closes #306