### PR TITLE
fix(import): record codex-only skill subdirs as x-codex.assets so claude emit skips them

### DIFF
--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -140,11 +140,11 @@ func materializeHookScripts(hooks []spec.Entry, dryRun bool) error {
 
 // propagateSkillAssets mirrors every sibling file under the source
 // skill directory (`<skills-src>/<name>/`) into the emitted skill
-// folder, skipping SKILL.md (re-rendered from the spec) and any
-// `agents/openai.yaml` (codex-only metadata that Claude does not read).
-// Skills authored in agnostic-ai can ship helper scripts, fixtures, or
-// nested subdirectories alongside SKILL.md; this preserves them across
-// `sync` so the Claude Code skill continues to work after a round-trip.
+// folder, skipping SKILL.md (re-rendered from the spec), any
+// `agents/openai.yaml` (codex-only metadata that Claude does not read),
+// and any other top-level entry the spec marks under `x-codex.assets`
+// (folders the codex importer pulled in that the claude side never had,
+// e.g. helper `scripts/` directories — #305).
 //
 // No-op when the source path is unknown (e.g. specs loaded from raw
 // bytes in the WASM playground) so adapters stay safe for in-memory
@@ -154,7 +154,51 @@ func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
 		return nil
 	}
 	srcDir := filepath.Dir(s.Path)
-	return emit.CopyTree(srcDir, dstDir, isClaudeSkillSkippedAsset, dryRun)
+	skip := claudeSkillSkipFor(s)
+	return emit.CopyTree(srcDir, dstDir, skip, dryRun)
+}
+
+// claudeSkillSkipFor returns a per-skill skip predicate honoring the
+// hardcoded codex-only entries (`SKILL.md`, `agents/`) plus any top-
+// level paths the importer recorded as codex-only under
+// `x-codex.assets`. Callers pass the predicate to emit.CopyTree.
+func claudeSkillSkipFor(s spec.Entry) func(string) bool {
+	codexOnly := codexOnlyAssets(s.Meta)
+	return func(rel string) bool {
+		if isClaudeSkillSkippedAsset(rel) {
+			return true
+		}
+		for _, top := range codexOnly {
+			if rel == top || strings.HasPrefix(rel, top+"/") {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// codexOnlyAssets reads the list under `meta["x-codex"]["assets"]` and
+// returns each entry as a string. Returns nil for the common case (no
+// codex-only assets recorded). Accepts both `[]any` (yaml.v3 decode)
+// and `[]string` (round-tripped through structs).
+func codexOnlyAssets(meta map[string]any) []string {
+	x, ok := meta["x-codex"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	switch xs := x["assets"].(type) {
+	case []string:
+		return xs
+	case []any:
+		out := make([]string, 0, len(xs))
+		for _, v := range xs {
+			if s, ok := v.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // isClaudeSkillSkippedAsset reports whether the given skill-relative path

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -184,6 +184,55 @@ func TestEmit_PropagatesSkillAssets(t *testing.T) {
 	}
 }
 
+// A spec that lists codex-only subtrees under `x-codex.assets` must skip
+// those subtrees during claude emit, even if they live in the agnostic
+// source dir (#305).
+func TestEmit_SkipsCodexOnlySkillAssets(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	srcSkill := filepath.Join(dir, ".agnostic-ai", "skills", "gh-issue")
+	if err := os.MkdirAll(filepath.Join(srcSkill, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(srcSkill, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "SKILL.md"), []byte("---\nname: gh-issue\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "scripts", "gh.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "agents", "openai.yaml"), []byte("interface: cli\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "gh-issue",
+			Path: filepath.Join(srcSkill, "SKILL.md"),
+			Meta: map[string]any{
+				"name": "gh-issue",
+				"x-codex": map[string]any{
+					"assets": []any{"scripts", "agents"},
+				},
+			},
+			Body: "body",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{"scripts", "agents", "scripts/gh.sh", "agents/openai.yaml"} {
+		if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", "gh-issue", filepath.FromSlash(rel))); err == nil {
+			t.Errorf("codex-only asset %q leaked into claude emit", rel)
+		}
+	}
+}
+
 func TestEmit_WritesRulesPerFile(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -400,9 +400,23 @@ func importCodexSkills(root, dstDir string) (int, error) {
 // `::target` fences so both tools' authored prose survives the
 // round-trip (#300). Codex-only assets (agents/openai.yaml, scripts/,
 // helper files) copy across.
+//
+// Codex-only top-level entries (anything in `src` not already present
+// in `dst`) get recorded in the merged SKILL.md frontmatter under
+// `x-codex.assets` so the claude adapter knows to skip them on emit
+// (#305).
 func mergeCodexSkillIntoExisting(src, dst string) error {
+	codexOnlyTopLevel, err := codexOnlyTopLevelEntries(src, dst)
+	if err != nil {
+		return err
+	}
 	if err := mergeSkillBodies(filepath.Join(dst, "SKILL.md"), filepath.Join(src, "SKILL.md")); err != nil {
 		return err
+	}
+	if len(codexOnlyTopLevel) > 0 {
+		if err := recordCodexSkillAssets(filepath.Join(dst, "SKILL.md"), codexOnlyTopLevel); err != nil {
+			return err
+		}
 	}
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -432,6 +446,78 @@ func mergeCodexSkillIntoExisting(src, dst string) error {
 		}
 		return os.WriteFile(target, body, info.Mode().Perm())
 	})
+}
+
+// codexOnlyTopLevelEntries lists the top-level names (excluding
+// SKILL.md) that exist under src but not under dst. The claude side
+// (dst) was imported first, so anything codex adds top-level is by
+// definition codex-only.
+func codexOnlyTopLevelEntries(src, dst string) ([]string, error) {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", src, err)
+	}
+	var out []string
+	for _, e := range entries {
+		name := e.Name()
+		if name == "SKILL.md" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dst, name)); err == nil {
+			continue
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("stat %s: %w", filepath.Join(dst, name), err)
+		}
+		out = append(out, name)
+	}
+	return out, nil
+}
+
+// recordCodexSkillAssets appends or merges the given names into
+// `x-codex.assets` inside the SKILL.md frontmatter at skillPath. The
+// claude adapter consults this list at emit time to skip codex-only
+// subtrees instead of leaking them into `.claude/skills/<name>/`.
+func recordCodexSkillAssets(skillPath string, names []string) error {
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", skillPath, err)
+	}
+	front, body, ok := splitCodexAgentFrontmatter(string(data))
+	if !ok {
+		return nil
+	}
+	fm := map[string]any{}
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return fmt.Errorf("parse frontmatter: %w", err)
+	}
+	xcodex, _ := fm["x-codex"].(map[string]any)
+	if xcodex == nil {
+		xcodex = map[string]any{}
+	}
+	seen := map[string]bool{}
+	var merged []string
+	if existing, ok := xcodex["assets"].([]any); ok {
+		for _, v := range existing {
+			if s, ok := v.(string); ok && !seen[s] {
+				seen[s] = true
+				merged = append(merged, s)
+			}
+		}
+	}
+	for _, n := range names {
+		if !seen[n] {
+			seen[n] = true
+			merged = append(merged, n)
+		}
+	}
+	xcodex["assets"] = merged
+	fm["x-codex"] = xcodex
+	raw, err := marshalAgentFrontmatter(fm)
+	if err != nil {
+		return fmt.Errorf("re-marshal frontmatter: %w", err)
+	}
+	out := "---\n" + string(raw) + "---\n\n" + strings.TrimLeft(body, "\n")
+	return importWriteFile(skillPath, []byte(out), 0o644)
 }
 
 // codexConfigDoc mirrors the relevant `.codex/config.toml` shape: nested

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -362,6 +362,34 @@ func TestImportFromCodex_CopiesSkillAssets(t *testing.T) {
 	}
 }
 
+// When a skill exists in both .claude and .codex, codex-only top-level
+// entries (scripts/, agents/, anything claude side never had) must be
+// recorded in the merged SKILL.md under `x-codex.assets` so the claude
+// adapter knows to skip them on emit (#305).
+func TestImportFromCodex_MergesSkillAndRecordsCodexOnlyAssets(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude/skills/probe/SKILL.md"),
+		"---\nname: probe\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex/skills/probe/SKILL.md"),
+		"---\nname: probe\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex/skills/probe/scripts/run.sh"), "#!/bin/sh\n")
+	writeFile(t, filepath.Join(dir, ".codex/skills/probe/agents/openai.yaml"), "interface: cli\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills/probe/SKILL.md"))
+	if !strings.Contains(got, "x-codex:") {
+		t.Fatalf("expected x-codex block in merged SKILL.md:\n%s", got)
+	}
+	if !strings.Contains(got, "- scripts") || !strings.Contains(got, "- agents") {
+		t.Errorf("expected codex-only assets recorded:\n%s", got)
+	}
+}
+
 func TestImportFromCodex_PreservesSkillScriptExecutableBit(t *testing.T) {
 	dir := t.TempDir()
 	skillRoot := filepath.Join(dir, ".agents", "skills", "build")


### PR DESCRIPTION
## Summary

- \`mergeCodexSkillIntoExisting\` compares top-level entries between the already-imported claude side and the codex side; anything codex-only gets recorded in the merged SKILL.md frontmatter under \`x-codex.assets\`.
- Claude adapter \`propagateSkillAssets\` now builds a per-spec skip predicate (\`claudeSkillSkipFor\`) that honors both the hardcoded \`SKILL.md\` + \`agents/\` rules AND the recorded \`x-codex.assets\` list.
- Regression tests on the import path (\`TestImportFromCodex_MergesSkillAndRecordsCodexOnlyAssets\`) and the emit path (\`TestEmit_SkipsCodexOnlySkillAssets\`).

## Why

When a skill exists in both \`.claude\` and \`.codex\` and the codex side ships sibling subdirs the claude side never had (helper \`scripts/\`, \`agents/\`), the codex import correctly captured them but a later \`sync\` propagated them to BOTH targets. Result: \`.claude/skills/<name>/scripts/\` materialized files the claude consumer never asked for, breaking byte-equal round-trip vs the source-of-truth files.

The \`x-codex.assets\` list keeps the routing decision next to the spec so future targets can opt in the same way (e.g. an \`x-cursor.assets\`) without growing the emit-time skip list.

## Test plan
- [x] \`go test ./...\` — 936 tests pass
- [x] Verified against phel-lang PR #2085 ground truth (gh-issue skill) post-merge

Closes #305