### PR TITLE
fix(import): route divergent description/model via x-codex so each emit reproduces its source

### DIFF
--- a/internal/adapters/internal/emit/meta.go
+++ b/internal/adapters/internal/emit/meta.go
@@ -115,8 +115,30 @@ func ResolveMetaOrdered(meta map[string]any, keys []string, target string) (map[
 	}
 	if nested, ok := meta[XPrefix+target].(map[string]any); ok {
 		for nk, nv := range nested {
+			if nv == nil {
+				// nil under x-<target> is a delete marker: drop the key
+				// entirely so the per-target emit reproduces the source
+				// of truth (e.g. a codex agent that never had `model:`
+				// must not inherit claude's `model: haiku`). See #304.
+				removeKey(out, &outKeys, nk)
+				continue
+			}
 			appendKV(nk, nv)
 		}
 	}
 	return out, outKeys
+}
+
+// removeKey strips key from both the resolved map and the ordered keys
+// slice so a downstream renderer emits neither a value nor a position
+// for it. Used by ResolveMetaOrdered to honor nil delete markers under
+// `x-<target>`.
+func removeKey(out map[string]any, keys *[]string, key string) {
+	delete(out, key)
+	for i, k := range *keys {
+		if k == key {
+			*keys = append((*keys)[:i], (*keys)[i+1:]...)
+			return
+		}
+	}
 }

--- a/internal/adapters/internal/emit/meta_test.go
+++ b/internal/adapters/internal/emit/meta_test.go
@@ -83,3 +83,62 @@ func TestResolveMetaOrdered_StripsRoutingKeysFromOrder(t *testing.T) {
 		t.Errorf("target should be stripped, got %#v", got)
 	}
 }
+
+// `x-<target>.<key>: nil` is a deletion marker — the per-target emit
+// must drop the key entirely instead of keeping the top-level value
+// (#304). Without this, a codex agent that never had `model:` inherited
+// claude's `model: haiku` after a round-trip import.
+func TestResolveMeta_NilUnderXTargetDeletesKey(t *testing.T) {
+	in := map[string]any{
+		"name":  "agent",
+		"model": "haiku",
+		"x-codex": map[string]any{
+			"model": nil,
+		},
+	}
+	got := ResolveMeta(in, "codex")
+	if _, present := got["model"]; present {
+		t.Errorf("x-codex.model: nil should drop model, got %#v", got)
+	}
+	// Claude side must still see the top-level value.
+	gotClaude := ResolveMeta(in, "claude")
+	if gotClaude["model"] != "haiku" {
+		t.Errorf("claude side lost top-level model: got %#v", gotClaude)
+	}
+}
+
+// `x-<target>.<key>` with a value overrides the top-level value for
+// that target while leaving every other target's view alone (#304).
+func TestResolveMeta_XTargetOverridesValue(t *testing.T) {
+	in := map[string]any{
+		"name":        "agent",
+		"description": "claude-side description",
+		"x-codex": map[string]any{
+			"description": "codex-side description",
+		},
+	}
+	if got := ResolveMeta(in, "claude")["description"]; got != "claude-side description" {
+		t.Errorf("claude desc: got %v", got)
+	}
+	if got := ResolveMeta(in, "codex")["description"]; got != "codex-side description" {
+		t.Errorf("codex desc: got %v", got)
+	}
+}
+
+// Deletion under x-<target> must also drop the key from the ordered key
+// slice so renderers that iterate `ordered` don't emit a stray entry.
+func TestResolveMetaOrdered_NilUnderXTargetDropsOrder(t *testing.T) {
+	in := map[string]any{
+		"name":  "agent",
+		"model": "haiku",
+		"x-codex": map[string]any{
+			"model": nil,
+		},
+	}
+	keys := []string{"name", "model"}
+	_, gotKeys := ResolveMetaOrdered(in, keys, "codex")
+	wantKeys := []string{"name"}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Errorf("got %v, want %v", gotKeys, wantKeys)
+	}
+}

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -197,9 +197,10 @@ func writeCodexAgentSpec(path, canonical, codexName string, doc map[string]any, 
 
 // mergeCodexAgentIntoExisting parses an already-imported agent spec
 // (claude origin) and layers codex-specific frontmatter on top without
-// disturbing the body or existing top-level keys. Only the keys the
-// codex TOML actually provides get written, so claude's richer body
-// + description survive even when both tools defined the agent.
+// disturbing the body or existing top-level keys. Top-level keys with
+// divergent values across the two tools land under `x-codex.<key>` so
+// each target emit reproduces its source-of-truth value (#304). Claude's
+// richer body survives via mergeAgentBody.
 func mergeCodexAgentIntoExisting(existing, codexName string, doc map[string]any) (string, error) {
 	front, body, ok := splitCodexAgentFrontmatter(existing)
 	if !ok {
@@ -222,6 +223,13 @@ func mergeCodexAgentIntoExisting(existing, codexName string, doc map[string]any)
 	xcodex, _ := fm["x-codex"].(map[string]any)
 	if xcodex == nil {
 		xcodex = map[string]any{}
+	}
+	// Top-level frontmatter keys that codex also emits at the TOML root:
+	// when the codex value diverges (or is absent while claude has one),
+	// record the codex view under `x-codex.<key>` so ResolveMeta(codex)
+	// reproduces the codex source-of-truth.
+	for _, key := range divergentAgentTopLevelKeys {
+		mergeDivergentMetaKey(fm, xcodex, doc, key)
 	}
 	for key, val := range doc {
 		if codexAgentTopLevel[key] {
@@ -251,6 +259,76 @@ func mergeCodexAgentIntoExisting(existing, codexName string, doc map[string]any)
 		mergedBody += "\n"
 	}
 	return "---\n" + string(raw) + "---\n\n" + mergedBody, nil
+}
+
+// divergentAgentTopLevelKeys are the agent-frontmatter keys whose values
+// frequently differ between claude and codex (description, model). Each
+// gets compared during the codex merge: if codex's value disagrees with
+// claude's, the codex view goes under `x-codex.<key>`; if claude has the
+// key but codex does not, `x-codex.<key>: null` marks the deletion so
+// ResolveMeta(codex) drops it.
+var divergentAgentTopLevelKeys = []string{"description", "model"}
+
+// mergeDivergentMetaKey records a per-target override for key when the
+// codex doc value differs from the claude frontmatter value. Used by
+// the codex merger to keep both tools' divergent frontmatter intact.
+//
+//   - codex absent, claude present: x-codex[key] = nil (deletion marker)
+//   - codex present, claude absent: claude takes the codex value (no
+//     divergence to record — it's just the only source).
+//   - codex present and != claude: x-codex[key] = codex value.
+//   - equal values: nothing to record.
+func mergeDivergentMetaKey(fm, xcodex, doc map[string]any, key string) {
+	claudeVal, hasClaude := fm[key]
+	docVal, hasDoc := doc[key]
+	if hasDoc {
+		if s, ok := docVal.(string); ok && s == "" {
+			hasDoc = false
+		}
+	}
+	if !hasDoc && hasClaude {
+		// Mark the key as deleted-for-codex so emit drops it.
+		if _, present := xcodex[key]; !present {
+			xcodex[key] = nil
+		}
+		return
+	}
+	if !hasDoc {
+		return
+	}
+	if !hasClaude {
+		fm[key] = docVal
+		return
+	}
+	if !equalScalar(claudeVal, docVal) {
+		if _, present := xcodex[key]; !present {
+			xcodex[key] = docVal
+		}
+	}
+}
+
+// equalScalar compares two scalar `any` values without bringing in
+// reflect.DeepEqual for the hot import path. Handles the string / bool
+// / numeric shapes the codex merger walks.
+func equalScalar(a, b any) bool {
+	switch av := a.(type) {
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case int:
+		bv, ok := b.(int)
+		return ok && av == bv
+	case int64:
+		bv, ok := b.(int64)
+		return ok && av == bv
+	case float64:
+		bv, ok := b.(float64)
+		return ok && av == bv
+	}
+	return false
 }
 
 // agentFrontmatterOrder is the canonical claude-conventional key order

--- a/internal/cli/import_fence_bodies.go
+++ b/internal/cli/import_fence_bodies.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // fenceDivergent merges two same-name spec bodies, wrapping the parts
@@ -93,9 +95,10 @@ func splitLines(s string) []string {
 
 // mergeSkillBodies rewrites claudePath's SKILL.md so divergent body
 // content from codexPath's SKILL.md survives as a `::target codex`
-// fence. Claude's frontmatter is the source of truth (per the
-// claude-wins precedence documented in #287); only the body changes.
-// A no-op when the bodies are byte-identical or either file lacks
+// fence. Top-level frontmatter keys whose values diverge between the
+// two tools (description, etc.) get routed through `x-codex` so the
+// codex emit reproduces its source-of-truth (#304). A no-op when both
+// frontmatter and body are byte-identical, or when either file lacks
 // frontmatter.
 func mergeSkillBodies(claudePath, codexPath string) error {
 	claudeData, err := os.ReadFile(claudePath)
@@ -108,25 +111,86 @@ func mergeSkillBodies(claudePath, codexPath string) error {
 	}
 
 	claudeFront, claudeBody, claudeOK := splitCodexAgentFrontmatter(string(claudeData))
-	_, codexBody, codexOK := splitCodexAgentFrontmatter(string(codexData))
+	codexFront, codexBody, codexOK := splitCodexAgentFrontmatter(string(codexData))
 	if !claudeOK || !codexOK {
 		return nil
 	}
-	if strings.TrimRight(claudeBody, "\n") == strings.TrimRight(codexBody, "\n") {
+
+	mergedFront, frontChanged, err := mergeSkillFrontmatter(claudeFront, codexFront)
+	if err != nil {
+		return err
+	}
+	frontOut := claudeFront
+	if frontChanged {
+		frontOut = strings.TrimRight(mergedFront, "\n")
+	}
+
+	bodiesDiffer := strings.TrimRight(claudeBody, "\n") != strings.TrimRight(codexBody, "\n")
+	if !frontChanged && !bodiesDiffer {
 		return nil
 	}
 
-	merged := fenceDivergent(
-		strings.TrimRight(claudeBody, "\n"),
-		strings.TrimRight(codexBody, "\n"),
-		"claude", "codex",
-	)
-	out := "---\n" + claudeFront + "\n---\n\n" + merged
+	body := strings.TrimRight(claudeBody, "\n")
+	if bodiesDiffer {
+		body = fenceDivergent(
+			strings.TrimRight(claudeBody, "\n"),
+			strings.TrimRight(codexBody, "\n"),
+			"claude", "codex",
+		)
+	}
+	out := "---\n" + frontOut + "\n---\n\n" + body
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
 	if out == string(claudeData) {
 		return nil
 	}
 	return importWriteFile(claudePath, []byte(out), 0o644)
 }
+
+// mergeSkillFrontmatter parses the claude + codex frontmatters and, for
+// each divergent top-level key in `divergentSkillTopLevelKeys`, records
+// the codex value under `x-codex.<key>` (or `x-codex.<key>: null` when
+// claude has the key and codex doesn't). Returns the rewritten claude
+// frontmatter (or the original on no-op) and a flag indicating whether
+// any change happened.
+func mergeSkillFrontmatter(claudeFront, codexFront string) (string, bool, error) {
+	claudeFM := map[string]any{}
+	codexFM := map[string]any{}
+	if err := yaml.Unmarshal([]byte(claudeFront), &claudeFM); err != nil {
+		return "", false, fmt.Errorf("parse claude frontmatter: %w", err)
+	}
+	if err := yaml.Unmarshal([]byte(codexFront), &codexFM); err != nil {
+		return "", false, fmt.Errorf("parse codex frontmatter: %w", err)
+	}
+	xcodex, _ := claudeFM["x-codex"].(map[string]any)
+	if xcodex == nil {
+		xcodex = map[string]any{}
+	}
+	changed := false
+	for _, key := range divergentSkillTopLevelKeys {
+		before := len(xcodex)
+		mergeDivergentMetaKey(claudeFM, xcodex, codexFM, key)
+		if len(xcodex) != before {
+			changed = true
+		}
+	}
+	if !changed {
+		return claudeFront, false, nil
+	}
+	claudeFM["x-codex"] = xcodex
+	raw, err := marshalAgentFrontmatter(claudeFM)
+	if err != nil {
+		return "", false, fmt.Errorf("re-marshal frontmatter: %w", err)
+	}
+	return string(raw), true, nil
+}
+
+// divergentSkillTopLevelKeys lists the skill-frontmatter keys whose
+// values often differ between claude and codex (description, model).
+// Each gets compared during codex import: divergent codex values land
+// under `x-codex.<key>` so the codex emit reproduces them faithfully.
+var divergentSkillTopLevelKeys = []string{"description", "model"}
 
 // mergeAgentBody returns claudeBody with divergent codex content
 // fenced. claudeBody is the existing post-frontmatter body; codexBody

--- a/internal/cli/import_fence_bodies_test.go
+++ b/internal/cli/import_fence_bodies_test.go
@@ -187,6 +187,64 @@ Shared outro."""`+"\n")
 	}
 }
 
+// Divergent frontmatter description across the two tools is recorded
+// under `x-codex.description` so each emit reproduces its source-of-
+// truth (#304). Without this routing, the codex side silently inherited
+// the claude description on every re-sync.
+func TestImportFromCodex_AgentDescriptionDiverges_RoutesViaXCodex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "agents", "keeper.md"),
+		"---\nname: keeper\ndescription: claude says X\nmodel: haiku\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex", "agents", "keeper.toml"),
+		`name = "keeper"`+"\n"+
+			`description = "codex says Y"`+"\n"+
+			`developer_instructions = "body"`+"\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "agents", "keeper.md"))
+	if !strings.Contains(got, "description: claude says X") {
+		t.Errorf("claude description must survive at top level:\n%s", got)
+	}
+	if !strings.Contains(got, "description: codex says Y") {
+		t.Errorf("codex description must land under x-codex:\n%s", got)
+	}
+	// claude has model: haiku but codex doesn't → expect x-codex.model: null
+	// so codex emit drops the key.
+	if !strings.Contains(got, "model: null") {
+		t.Errorf("x-codex.model should mark deletion for codex:\n%s", got)
+	}
+}
+
+// Divergent skill frontmatter description also routes via x-codex on
+// import. #304 — without this, every codex skill description got
+// overwritten with claude's value after one round-trip.
+func TestImportFromCodex_SkillDescriptionDiverges_RoutesViaXCodex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "test", "SKILL.md"),
+		"---\nname: test\ndescription: claude says X\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "test", "SKILL.md"),
+		"---\nname: test\ndescription: codex says Y\n---\nbody\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "test", "SKILL.md"))
+	if !strings.Contains(got, "description: claude says X") {
+		t.Errorf("claude description must survive at top level:\n%s", got)
+	}
+	if !strings.Contains(got, "description: codex says Y") {
+		t.Errorf("codex description must land under x-codex:\n%s", got)
+	}
+}
+
 func TestImportFromCodex_AgentBodyIdentical_NoFences(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".claude", "agents", "explorer.md"),


### PR DESCRIPTION
## Summary

- Codex merge (agent + skill) compares top-level keys in \`divergentAgentTopLevelKeys\` / \`divergentSkillTopLevelKeys\` and routes divergent values under \`x-codex.<key>\`, plus \`x-codex.<key>: nil\` when claude has a key codex never set.
- \`ResolveMetaOrdered\` treats \`x-<target>.<key>: nil\` as a deletion marker and drops the key from both the resolved map and the ordered slice.
- Regression tests on every layer: \`ResolveMeta_NilUnderXTargetDeletesKey\`, \`ResolveMeta_XTargetOverridesValue\`, \`TestImportFromCodex_AgentDescriptionDiverges_RoutesViaXCodex\`, \`TestImportFromCodex_SkillDescriptionDiverges_RoutesViaXCodex\`.

## Why

When a spec lived in both \`.claude\` and \`.codex\` with divergent frontmatter values (description, model), the codex import discarded the codex value (claude won at the top level). After re-emit, codex side got the claude description; any claude-only \`model:\` leaked into the codex output.

In the phel-lang PR #2085 verify, this broke 14 skills + 1 agent (15 files), making byte-equal round-trip impossible until now.

This is the frontmatter counterpart to #302 / PR #308 which solved divergent BODIES via \`::target\` fences. Putting frontmatter divergence on \`x-codex\` keeps the resolution at the same layer (per-target meta) the emitters already consult.

## Test plan
- [x] \`go test ./...\` — 940 tests pass
- [x] Verified against phel-lang PR #2085 ground truth (changelog-keeper agent + every codex skill) post-merge

Closes #304