### PR TITLE
fix(codex+import): honor x-codex.description on emit and preserve scalar style on merge

### DIFF
--- a/internal/adapters/codex/codex_test.go
+++ b/internal/adapters/codex/codex_test.go
@@ -268,6 +268,36 @@ func TestEmit_SkillFolder_DefaultsDescriptionToName(t *testing.T) {
 	}
 }
 
+// When a skill spec carries divergent claude/codex descriptions via
+// `x-codex.description`, the codex emit must reproduce the codex value
+// instead of the claude top-level one (#312). Without this, every
+// merged skill leaked the claude description into .codex/skills/.
+func TestEmit_SkillFolder_HonorsXCodexDescription(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindSkill, Name: "changelog",
+			Meta: map[string]any{
+				"name":        "changelog",
+				"description": "claude-side description",
+				"x-codex": map[string]any{
+					"description": "codex-side description",
+				},
+			},
+			Body: "body"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/skills/changelog/SKILL.md"))
+	if !strings.Contains(got, "description: codex-side description") {
+		t.Errorf("expected x-codex.description to win on codex emit:\n%s", got)
+	}
+	if strings.Contains(got, "claude-side description") {
+		t.Errorf("claude-side description leaked into codex emit:\n%s", got)
+	}
+}
+
 func TestEmit_SkillFolder_OpenAIYAMLFromXCodex(t *testing.T) {
 	dir := testutil.TempCwd(t)
 

--- a/internal/adapters/codex/skill.go
+++ b/internal/adapters/codex/skill.go
@@ -67,7 +67,12 @@ func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
 }
 
 func skillMarkdown(s spec.Entry) string {
-	desc := s.Description()
+	// Resolve description through the per-target meta so a spec
+	// carrying `x-codex.description` wins over the (claude-side) top-
+	// level value. Without this, every divergent skill imported via
+	// PR #310 still emitted the claude description (#312).
+	resolved := emit.ResolveMeta(s.Meta, target)
+	desc, _ := resolved["description"].(string)
 	if desc == "" {
 		desc = s.Name
 	}

--- a/internal/cli/import_fence_bodies.go
+++ b/internal/cli/import_fence_bodies.go
@@ -154,6 +154,11 @@ func mergeSkillBodies(claudePath, codexPath string) error {
 // claude has the key and codex doesn't). Returns the rewritten claude
 // frontmatter (or the original on no-op) and a flag indicating whether
 // any change happened.
+//
+// Claude's existing frontmatter keys keep their original yaml.Node form
+// (scalar style, comments, key order) so a hand-quoted `allowed-tools:
+// "Read, Bash(*)"` survives byte-for-byte. Only the x-codex subtree is
+// added or modified (#313).
 func mergeSkillFrontmatter(claudeFront, codexFront string) (string, bool, error) {
 	claudeFM := map[string]any{}
 	codexFM := map[string]any{}
@@ -167,23 +172,88 @@ func mergeSkillFrontmatter(claudeFront, codexFront string) (string, bool, error)
 	if xcodex == nil {
 		xcodex = map[string]any{}
 	}
-	changed := false
+	overrides := map[string]any{}
 	for _, key := range divergentSkillTopLevelKeys {
 		before := len(xcodex)
 		mergeDivergentMetaKey(claudeFM, xcodex, codexFM, key)
 		if len(xcodex) != before {
-			changed = true
+			overrides[key] = xcodex[key]
 		}
 	}
-	if !changed {
+	if len(overrides) == 0 {
 		return claudeFront, false, nil
 	}
-	claudeFM["x-codex"] = xcodex
-	raw, err := marshalAgentFrontmatter(claudeFM)
+	merged, err := upsertXCodexInFrontmatter(claudeFront, overrides)
 	if err != nil {
-		return "", false, fmt.Errorf("re-marshal frontmatter: %w", err)
+		return "", false, fmt.Errorf("upsert x-codex: %w", err)
 	}
-	return string(raw), true, nil
+	return merged, true, nil
+}
+
+// upsertXCodexInFrontmatter rewrites the given YAML frontmatter so its
+// `x-codex` mapping contains every key in overrides (creating the
+// subtree when absent). Existing top-level entries keep their original
+// yaml.Node form, preserving scalar style, key order, and comments
+// (#313).
+func upsertXCodexInFrontmatter(front string, overrides map[string]any) (string, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(front), &doc); err != nil {
+		return "", err
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return "", fmt.Errorf("frontmatter is not a mapping")
+	}
+	mapping := doc.Content[0]
+	xcodex := findOrAppendMapping(mapping, "x-codex")
+	for k, v := range overrides {
+		setMappingValue(xcodex, k, v)
+	}
+	raw, err := yaml.Marshal(&doc)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(raw), "\n"), nil
+}
+
+// findOrAppendMapping locates the value node for key in mapping. When
+// key is absent or its value isn't a mapping, a fresh mapping node
+// replaces the slot. Returns the mapping value node so callers can
+// mutate it directly.
+func findOrAppendMapping(mapping *yaml.Node, key string) *yaml.Node {
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			if mapping.Content[i+1].Kind != yaml.MappingNode {
+				mapping.Content[i+1] = &yaml.Node{Kind: yaml.MappingNode}
+			}
+			return mapping.Content[i+1]
+		}
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+	valNode := &yaml.Node{Kind: yaml.MappingNode}
+	mapping.Content = append(mapping.Content, keyNode, valNode)
+	return valNode
+}
+
+// setMappingValue assigns or replaces the value under key in mapping.
+// A nil value emits as the YAML scalar `null`, which ResolveMeta treats
+// as a deletion marker for the per-target emit (#304).
+func setMappingValue(mapping *yaml.Node, key string, value any) {
+	valNode := &yaml.Node{}
+	if value == nil {
+		valNode.Kind = yaml.ScalarNode
+		valNode.Tag = "!!null"
+		valNode.Value = "null"
+	} else {
+		_ = valNode.Encode(value)
+	}
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = valNode
+			return
+		}
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+	mapping.Content = append(mapping.Content, keyNode, valNode)
 }
 
 // divergentSkillTopLevelKeys lists the skill-frontmatter keys whose

--- a/internal/cli/import_fence_bodies_test.go
+++ b/internal/cli/import_fence_bodies_test.go
@@ -220,6 +220,29 @@ func TestImportFromCodex_AgentDescriptionDiverges_RoutesViaXCodex(t *testing.T) 
 	}
 }
 
+// Style preservation: a hand-quoted scalar in the claude SKILL.md
+// frontmatter must survive the codex-merge step even when description
+// divergence triggers a frontmatter rewrite (#313). Round-tripping the
+// whole front through a map loses style; the yaml.Node upsert keeps it.
+func TestImportFromCodex_SkillMerge_PreservesScalarStyle(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "test", "SKILL.md"),
+		"---\nname: test\ndescription: claude says X\nallowed-tools: \"Read, Bash(*)\"\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "test", "SKILL.md"),
+		"---\nname: test\ndescription: codex says Y\n---\nbody\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "test", "SKILL.md"))
+	if !strings.Contains(got, `allowed-tools: "Read, Bash(*)"`) {
+		t.Errorf("hand-quoted allowed-tools must keep its quotes:\n%s", got)
+	}
+}
+
 // Divergent skill frontmatter description also routes via x-codex on
 // import. #304 — without this, every codex skill description got
 // overwritten with claude's value after one round-trip.


### PR DESCRIPTION
## Summary

Two follow-ups to PR #310 surfaced re-verifying against phel-lang PR #2085 ground truth.

- **#312** — \`internal/adapters/codex/skill.go:skillMarkdown\` resolved description via \`s.Description()\` (top-level only), bypassing the \`x-codex.description\` override #310 just installed. Codex emit now goes through \`emit.ResolveMeta(s.Meta, target)\`.
- **#313** — \`mergeSkillFrontmatter\` round-tripped the whole claude frontmatter through \`map[string]any\` + \`yaml.Marshal\`, stripping scalar style. A hand-quoted \`allowed-tools: \"Read, Bash(*)\"\` came back unquoted. Replaced with a yaml.Node-based upsert (\`upsertXCodexInFrontmatter\`) that only mutates the \`x-codex\` subtree.

Regression tests:
- \`TestEmit_SkillFolder_HonorsXCodexDescription\` (codex emit path)
- \`TestImportFromCodex_SkillMerge_PreservesScalarStyle\` (import path)

## Test plan
- [x] \`go test ./...\` — 944 tests pass
- [x] Re-verify against phel-lang PR #2085 ground truth after merge

Closes #312
Closes #313