### PR TITLE
fix(import): recordCodexSkillAssets preserves yaml scalar style via Node upsert

### DIFF
--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -555,6 +555,11 @@ func codexOnlyTopLevelEntries(src, dst string) ([]string, error) {
 // `x-codex.assets` inside the SKILL.md frontmatter at skillPath. The
 // claude adapter consults this list at emit time to skip codex-only
 // subtrees instead of leaking them into `.claude/skills/<name>/`.
+//
+// The rewrite uses the same yaml.Node-based upsert as the description
+// merge (#313) so existing top-level scalars keep their original style
+// (a hand-quoted `allowed-tools: "Read, Bash(*)"` survives byte-for-
+// byte).
 func recordCodexSkillAssets(skillPath string, names []string) error {
 	data, err := os.ReadFile(skillPath)
 	if err != nil {
@@ -569,9 +574,6 @@ func recordCodexSkillAssets(skillPath string, names []string) error {
 		return fmt.Errorf("parse frontmatter: %w", err)
 	}
 	xcodex, _ := fm["x-codex"].(map[string]any)
-	if xcodex == nil {
-		xcodex = map[string]any{}
-	}
 	seen := map[string]bool{}
 	var merged []string
 	if existing, ok := xcodex["assets"].([]any); ok {
@@ -588,13 +590,11 @@ func recordCodexSkillAssets(skillPath string, names []string) error {
 			merged = append(merged, n)
 		}
 	}
-	xcodex["assets"] = merged
-	fm["x-codex"] = xcodex
-	raw, err := marshalAgentFrontmatter(fm)
+	newFront, err := upsertXCodexInFrontmatter(front, map[string]any{"assets": merged})
 	if err != nil {
-		return fmt.Errorf("re-marshal frontmatter: %w", err)
+		return fmt.Errorf("upsert x-codex.assets: %w", err)
 	}
-	out := "---\n" + string(raw) + "---\n\n" + strings.TrimLeft(body, "\n")
+	out := "---\n" + newFront + "\n---\n\n" + strings.TrimLeft(body, "\n")
 	return importWriteFile(skillPath, []byte(out), 0o644)
 }
 

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -362,6 +362,33 @@ func TestImportFromCodex_CopiesSkillAssets(t *testing.T) {
 	}
 }
 
+// `recordCodexSkillAssets` rewrites the SKILL.md frontmatter to inject
+// `x-codex.assets`. The rewrite must not round-trip every other key
+// through a map (which strips yaml scalar style) so a hand-quoted
+// `allowed-tools: "Read, Bash(*)"` survives byte-for-byte (#315).
+func TestImportFromCodex_RecordCodexSkillAssets_PreservesScalarStyle(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude/skills/probe/SKILL.md"),
+		"---\nname: probe\ndescription: claude desc\nallowed-tools: \"Read, Bash(*)\"\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex/skills/probe/SKILL.md"),
+		"---\nname: probe\ndescription: claude desc\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".codex/skills/probe/scripts/run.sh"), "#!/bin/sh\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills/probe/SKILL.md"))
+	if !strings.Contains(got, `allowed-tools: "Read, Bash(*)"`) {
+		t.Errorf("hand-quoted allowed-tools must keep its quotes after recordCodexSkillAssets:\n%s", got)
+	}
+	if !strings.Contains(got, "- scripts") {
+		t.Errorf("expected x-codex.assets to record scripts:\n%s", got)
+	}
+}
+
 // When a skill exists in both .claude and .codex, codex-only top-level
 // entries (scripts/, agents/, anything claude side never had) must be
 // recorded in the merged SKILL.md under `x-codex.assets` so the claude


### PR DESCRIPTION
## Summary

Follow-up to #313 — \`recordCodexSkillAssets\` still rewrote the SKILL.md frontmatter via \`marshalAgentFrontmatter\` (map round-trip), so any skill whose codex side had codex-only subdirs (e.g. \`agents/\`, \`scripts/\`) lost scalar style on every other key. Hand-quoted \`allowed-tools: \"Read, Bash(*)\"\` came back unquoted.

Switched to \`upsertXCodexInFrontmatter\` (yaml.Node helper from #313) so only the \`x-codex\` subtree mutates.

Regression test: \`TestImportFromCodex_RecordCodexSkillAssets_PreservesScalarStyle\`.

## Test plan
- [x] \`go test ./...\` — 945 tests pass
- [x] Re-verify against phel-lang PR #2085 ground truth after merge

Closes #315