### PR TITLE
fix(import): quote codex SKILL.md plain scalars containing '#'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - Codex agent TOML emits keys in codex-docs convention order for byte-stable round-trips. Closes #294, #295.
 - Routing keys (`target`, `targets`, `target-exclude`, `targets-exclude`) stripped from emitted frontmatter so they do not leak into generated files. Closes #303.
 - Auto-fenced spec bodies no longer contain spurious blank lines between sections. Closes #306.
+- `import codex` quotes plain-scalar SKILL.md frontmatter values containing `#` so strict YAML no longer truncates descriptions at the first hash. Closes #317.
 
 ## v0.25.0 - 2026-05-23
 

--- a/internal/cli/import_codex_hash_quote.go
+++ b/internal/cli/import_codex_hash_quote.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// plainScalarLineRE matches a `key: value` line whose value is a plain
+// (un-quoted, non-block) YAML scalar. The capture groups are indent,
+// key, and value. Lines whose value begins with `"`, `'`, `|`, `>`, `[`,
+// or `{` are skipped to avoid touching quoted scalars, block scalars,
+// or flow collections. Blank-value lines are skipped too — they are
+// container mappings, not scalar assignments.
+var plainScalarLineRE = regexp.MustCompile(`^([\t ]*)([A-Za-z0-9_-]+):[\t ]+([^"'|>\[{\n][^\n]*)$`)
+
+// quoteHashInPlainScalars rewrites every plain-scalar frontmatter line
+// whose value contains '#' as `key: "<escaped>"`. Strict YAML treats
+// '#' preceded by whitespace as a comment delimiter and silently drops
+// the rest of the line; the codex CLI's relaxed parser does not, so an
+// unquoted `description: ... #number ...` survives in codex but gets
+// truncated the moment `yaml.Unmarshal` sees it (#317).
+//
+// Lines already wrapped in quotes, block scalars (`|`/`>`), and flow
+// collections pass through unchanged. Lines whose value starts with a
+// `#` (pure comments masquerading as values) are left alone.
+func quoteHashInPlainScalars(front string) string {
+	lines := strings.Split(front, "\n")
+	changed := false
+	for i, line := range lines {
+		m := plainScalarLineRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		indent, key, val := m[1], m[2], strings.TrimRight(m[3], " \t")
+		if !strings.ContainsRune(val, '#') {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(val), "#") {
+			continue
+		}
+		escaped := strings.ReplaceAll(val, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		lines[i] = indent + key + `: "` + escaped + `"`
+		changed = true
+	}
+	if !changed {
+		return front
+	}
+	return strings.Join(lines, "\n")
+}
+
+// quoteHashInSkillFrontmatter reads the SKILL.md at path and rewrites
+// any plain-scalar frontmatter values that contain '#' as double-
+// quoted strings. A no-op when the file lacks frontmatter or no values
+// need quoting.
+//
+// Called immediately after a fresh codex skill copy so the resulting
+// agnostic source survives a strict-YAML round-trip without losing the
+// half-string after '#' (#317).
+func quoteHashInSkillFrontmatter(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	front, body, ok := splitCodexAgentFrontmatter(string(data))
+	if !ok {
+		return nil
+	}
+	quoted := quoteHashInPlainScalars(front)
+	if quoted == front {
+		return nil
+	}
+	out := "---\n" + strings.TrimRight(quoted, "\n") + "\n---\n\n" + body
+	return importWriteFile(path, []byte(out), 0o644)
+}

--- a/internal/cli/import_codex_hash_quote_test.go
+++ b/internal/cli/import_codex_hash_quote_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestQuoteHashInPlainScalars_DescriptionWithHash(t *testing.T) {
+	in := "name: gh-issue\ndescription: End-to-end. Use when given #number or URL.\nmodel: gpt-4"
+	got := quoteHashInPlainScalars(in)
+	if !strings.Contains(got, `description: "End-to-end. Use when given #number or URL."`) {
+		t.Errorf("expected description to be quoted, got:\n%s", got)
+	}
+	var fm map[string]any
+	if err := yaml.Unmarshal([]byte(got), &fm); err != nil {
+		t.Fatal(err)
+	}
+	if d, _ := fm["description"].(string); d != "End-to-end. Use when given #number or URL." {
+		t.Errorf("strict YAML lost data after quoting; got %q", d)
+	}
+}
+
+func TestQuoteHashInPlainScalars_AlreadyQuoted(t *testing.T) {
+	in := `description: "End-to-end #number"` + "\n"
+	got := quoteHashInPlainScalars(in)
+	if got != in {
+		t.Errorf("already-quoted value must not be rewritten:\ngot %q\nwant %q", got, in)
+	}
+}
+
+func TestQuoteHashInPlainScalars_NoHashUnchanged(t *testing.T) {
+	in := "name: plain\ndescription: nothing fancy here\n"
+	got := quoteHashInPlainScalars(in)
+	if got != in {
+		t.Errorf("plain scalars without '#' must pass through:\ngot %q\nwant %q", got, in)
+	}
+}
+
+func TestQuoteHashInPlainScalars_EscapesQuotesAndBackslash(t *testing.T) {
+	in := `description: a " and \ then #hash` + "\n"
+	got := quoteHashInPlainScalars(in)
+	var fm map[string]any
+	if err := yaml.Unmarshal([]byte(got), &fm); err != nil {
+		t.Fatal(err)
+	}
+	if d, _ := fm["description"].(string); d != `a " and \ then #hash` {
+		t.Errorf("quote/backslash escape round-trip failed; got %q", d)
+	}
+}
+
+func TestQuoteHashInPlainScalars_BlockScalarUntouched(t *testing.T) {
+	in := "description: |\n  multi-line #literal\n  stays here\n"
+	got := quoteHashInPlainScalars(in)
+	if got != in {
+		t.Errorf("block scalar must not be rewritten:\n%s", got)
+	}
+}
+
+func TestQuoteHashInSkillFrontmatter_RewritesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SKILL.md")
+	writeFile(t, path, "---\nname: x\ndescription: with #hash in it\n---\n\nbody.\n")
+	if err := quoteHashInSkillFrontmatter(path); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, path)
+	if !strings.Contains(got, `description: "with #hash in it"`) {
+		t.Errorf("description not quoted on disk:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "body.\n") {
+		t.Errorf("body lost during rewrite:\n%s", got)
+	}
+}
+
+func TestQuoteHashInSkillFrontmatter_NoFrontmatterNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SKILL.md")
+	orig := "no frontmatter here\n"
+	writeFile(t, path, orig)
+	if err := quoteHashInSkillFrontmatter(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, path); got != orig {
+		t.Errorf("file without frontmatter should be untouched:\ngot  %q\nwant %q", got, orig)
+	}
+}
+
+func TestImportFromCodex_FreshSkillDescriptionWithHash_NotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "gh-issue", "SKILL.md"),
+		"---\nname: gh-issue\ndescription: End-to-end workflow. Use when given #number or issue URL.\n---\n\nBody here.\n")
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "gh-issue", "SKILL.md"))
+	if !strings.Contains(got, "#number or issue URL") {
+		t.Errorf("description lost data after import:\n%s", got)
+	}
+	front, _, ok := splitCodexAgentFrontmatter(got)
+	if !ok {
+		t.Fatalf("imported SKILL.md missing frontmatter:\n%s", got)
+	}
+	var fm map[string]any
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		t.Fatalf("imported frontmatter does not parse: %v\n%s", err, front)
+	}
+	if d, _ := fm["description"].(string); d != "End-to-end workflow. Use when given #number or issue URL." {
+		t.Errorf("strict-YAML round-trip truncated description: got %q", d)
+	}
+}
+
+func TestImportFromCodex_MergedSkillDescriptionWithHash_NotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".claude", "skills", "gh-issue", "SKILL.md"),
+		"---\nname: gh-issue\ndescription: claude version\n---\n\nclaude body.\n")
+	writeFile(t, filepath.Join(dir, ".codex", "skills", "gh-issue", "SKILL.md"),
+		"---\nname: gh-issue\ndescription: End-to-end. Use when given #number or URL.\n---\n\ncodex body.\n")
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, "skills", "gh-issue", "SKILL.md"))
+	if !strings.Contains(got, "#number or URL") {
+		t.Errorf("codex description truncated during merge:\n%s", got)
+	}
+}

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -456,6 +456,16 @@ func importCodexSkills(root, dstDir string) (int, error) {
 			} else if err := copyDirTree(skillSrc, skillDst); err != nil {
 				return count, fmt.Errorf("copy skill %s: %w", e.Name(), err)
 			}
+			if !merged {
+				// Codex CLI tolerates unquoted '#' in plain scalar
+				// frontmatter values; strict YAML treats it as a comment
+				// and truncates. Quote those scalars in the imported
+				// SKILL.md so a downstream sync survives the round-trip
+				// (#317).
+				if err := quoteHashInSkillFrontmatter(filepath.Join(skillDst, "SKILL.md")); err != nil {
+					return count, fmt.Errorf("quote-hash skill %s: %w", e.Name(), err)
+				}
+			}
 			// Auto-scope `target: codex` only when this is a fresh
 			// import (no claude sibling on disk and no claude-merged
 			// SKILL.md already at the destination).

--- a/internal/cli/import_fence_bodies.go
+++ b/internal/cli/import_fence_bodies.go
@@ -115,6 +115,11 @@ func mergeSkillBodies(claudePath, codexPath string) error {
 	if !claudeOK || !codexOK {
 		return nil
 	}
+	// Codex CLI accepts unquoted '#' in plain scalars; strict YAML does
+	// not. Quote those scalars before yaml.Unmarshal so the codex
+	// description survives intact instead of being truncated at the
+	// first '#' (#317).
+	codexFront = quoteHashInPlainScalars(codexFront)
 
 	mergedFront, frontChanged, err := mergeSkillFrontmatter(claudeFront, codexFront)
 	if err != nil {


### PR DESCRIPTION
## Summary

Codex CLI tolerates unquoted `#` in plain-scalar YAML frontmatter values; strict YAML (what `yaml.Unmarshal` enforces) treats `#` preceded by whitespace as a comment delimiter and drops everything after it. Result: an `agnostic-ai import codex` of a SKILL.md whose codex-authored description reads

```yaml
description: End-to-end workflow. Use when given #number, issue URL, ...
```

silently became

```yaml
description: End-to-end workflow. Use when given,
```

once a sync re-emitted the agnostic source through strict YAML.

Pre-quote plain-scalar values containing `#` before `yaml.Unmarshal` sees them. Two entry points covered:

- Fresh import path (`copyDirTree` + `quoteHashInSkillFrontmatter`): rewrites SKILL.md on disk so the agnostic source is valid strict YAML.
- Merge path (`mergeSkillBodies`): pre-processes `codexFront` before parsing so the codex value lands intact under `x-codex.description`.

Already-quoted scalars, block scalars (`|`, `>`), flow collections (`[`, `{`), and comment-only values pass through unchanged.

Closes #317.

## Test plan

- [x] `quoteHashInPlainScalars` unit tests: description with `#`, already-quoted, no-hash, escape `"`/`\`, block scalar untouched.
- [x] `quoteHashInSkillFrontmatter` unit tests: rewrites file, no-op without frontmatter.
- [x] End-to-end `importFromCodex`: fresh skill description with `#` survives strict-YAML round-trip.
- [x] End-to-end `importFromCodex` merge path: codex description with `#` survives intact alongside claude side.
- [x] `go test ./...` green (954 passed across 28 packages).