### PR TITLE
fix(upgrade): pre-flight cask binstub collision before brew upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ### Changed
 
 ### Fixed
+- `agnostic-ai upgrade --run` aborts pre-flight with a `rm + brew install --cask` hint when `<brew>/bin/agnostic-ai` is a regular file (or symlink outside the brew prefix), instead of letting `brew upgrade --cask` fail and revert into a half-broken install.
 
 ### Removed
 

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -46,13 +46,14 @@ func (m installMethod) String() string {
 // the current one (or be beaten by it), so the user can spot a stale
 // shadow before running the upgrade.
 type upgradeInfo struct {
-	Path    string
-	Method  installMethod
-	Version string
-	Latest  string
-	Command string
-	Shadows []string
-	Notes   []string
+	Path     string
+	LinkPath string
+	Method   installMethod
+	Version  string
+	Latest   string
+	Command  string
+	Shadows  []string
+	Notes    []string
 }
 
 func newUpgradeCmd() *cobra.Command {
@@ -111,8 +112,51 @@ func runUpgrade(out io.Writer, doRun, checkOnly bool, currentVersion string) err
 	if info.Command == "" {
 		return fmt.Errorf("upgrade: install method unknown; download a release from https://github.com/Chemaclass/agnostic-ai/releases")
 	}
+	if info.Method == installHomebrew {
+		if ok, hint := homebrewBinaryOK(info.LinkPath); !ok {
+			return fmt.Errorf("upgrade: homebrew cask state is inconsistent.\n%s", hint)
+		}
+	}
 	_, _ = fmt.Fprintf(out, "\n→ %s\n", info.Command)
 	return execShell(info.Command)
+}
+
+// homebrewBinaryOK verifies that the binstub path is a symlink owned by
+// Homebrew. The cask post-install links `<brew>/bin/agnostic-ai` to a file
+// inside `<brew>/Caskroom/agnostic-ai/<version>/`. If a regular file lives
+// at the binstub path instead (e.g. a raw binary copied in before the cask
+// existed), `brew upgrade --cask` refuses to overwrite it, reverts mid-run,
+// and leaves the cask uninstalled while the orphan file remains. Catching
+// that pre-flight gives the user a clear `rm + brew install --cask`
+// remediation instead of a confusing brew error followed by a half-broken
+// install.
+func homebrewBinaryOK(linkPath string) (ok bool, hint string) {
+	if linkPath == "" {
+		return true, ""
+	}
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		return true, ""
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false, brewCollisionHint(linkPath, fmt.Sprintf("%s is a regular file, not a brew-owned symlink", linkPath))
+	}
+	target, err := filepath.EvalSymlinks(linkPath)
+	if err != nil {
+		return false, brewCollisionHint(linkPath, fmt.Sprintf("%s is a dangling symlink: %v", linkPath, err))
+	}
+	t := filepath.ToSlash(target)
+	if !strings.Contains(t, "/Caskroom/") && !strings.Contains(t, "/Cellar/") {
+		return false, brewCollisionHint(linkPath, fmt.Sprintf("%s resolves to %s, outside the brew prefix", linkPath, target))
+	}
+	return true, ""
+}
+
+func brewCollisionHint(path, reason string) string {
+	return fmt.Sprintf("%s.\n"+
+		"`brew upgrade --cask` would fail and revert. Recover with:\n"+
+		"  rm %s && brew install --cask Chemaclass/tap/agnostic-ai",
+		reason, path)
 }
 
 func detectUpgrade(currentVersion string) (upgradeInfo, error) {
@@ -120,14 +164,16 @@ func detectUpgrade(currentVersion string) (upgradeInfo, error) {
 	if err != nil {
 		return upgradeInfo{}, fmt.Errorf("locate executable: %w", err)
 	}
+	linkPath := exe
 	resolved, err := filepath.EvalSymlinks(exe)
 	if err == nil {
 		exe = resolved
 	}
 	info := upgradeInfo{
-		Path:    exe,
-		Method:  detectInstallMethod(exe),
-		Version: strings.TrimSpace(currentVersion),
+		Path:     exe,
+		LinkPath: linkPath,
+		Method:   detectInstallMethod(exe),
+		Version:  strings.TrimSpace(currentVersion),
 	}
 	info.Command = upgradeCommandFor(info.Method)
 	info.Shadows = otherInstancesOnPATH(exe)

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -172,6 +172,107 @@ func TestRunUpgrade_CheckOnlyPrintsAndReturns(t *testing.T) {
 	}
 }
 
+func TestHomebrewBinaryOK_MissingPathIsOK(t *testing.T) {
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "agnostic-ai")
+	ok, hint := homebrewBinaryOK(missing)
+	if !ok || hint != "" {
+		t.Errorf("missing path: ok=%v hint=%q, want ok=true hint=\"\"", ok, hint)
+	}
+}
+
+func TestHomebrewBinaryOK_RegularFileCollides(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "agnostic-ai")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ok, hint := homebrewBinaryOK(bin)
+	if ok {
+		t.Fatalf("regular file should not be OK")
+	}
+	for _, want := range []string{"regular file", "rm " + bin, "brew install --cask"} {
+		if !strings.Contains(hint, want) {
+			t.Errorf("hint missing %q\nfull:\n%s", want, hint)
+		}
+	}
+}
+
+func TestHomebrewBinaryOK_SymlinkIntoCaskroom(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	tmp := t.TempDir()
+	caskroom := filepath.Join(tmp, "Caskroom", "agnostic-ai", "0.26.0")
+	if err := os.MkdirAll(caskroom, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(caskroom, "agnostic-ai")
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(tmp, "bin", "agnostic-ai")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, bin); err != nil {
+		t.Fatal(err)
+	}
+	ok, hint := homebrewBinaryOK(bin)
+	if !ok {
+		t.Errorf("caskroom symlink should be OK, got hint:\n%s", hint)
+	}
+}
+
+func TestHomebrewBinaryOK_SymlinkOutsideBrew(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "elsewhere", "agnostic-ai")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(tmp, "bin", "agnostic-ai")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, bin); err != nil {
+		t.Fatal(err)
+	}
+	ok, hint := homebrewBinaryOK(bin)
+	if ok {
+		t.Fatalf("symlink outside brew prefix should not be OK")
+	}
+	if !strings.Contains(hint, "outside the brew prefix") {
+		t.Errorf("hint missing prefix reason:\n%s", hint)
+	}
+}
+
+func TestHomebrewBinaryOK_DanglingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "agnostic-ai")
+	if err := os.Symlink(filepath.Join(tmp, "Caskroom", "missing"), bin); err != nil {
+		t.Fatal(err)
+	}
+	ok, hint := homebrewBinaryOK(bin)
+	if ok {
+		t.Fatalf("dangling symlink should not be OK")
+	}
+	if !strings.Contains(hint, "dangling symlink") {
+		t.Errorf("hint missing dangling reason:\n%s", hint)
+	}
+}
+
 func TestUpgradeCmd_RegistersOnRoot(t *testing.T) {
 	root := NewRootCmd("test")
 	var found bool


### PR DESCRIPTION
## Summary
- Pre-existing regular file at `<brew>/bin/agnostic-ai` made `brew upgrade --cask` refuse to overwrite, revert mid-run, and leave the cask uninstalled while the orphan file remained. The next `agnostic-ai upgrade --run` then died with `Cask 'agnostic-ai' is not installed.`
- Detect the bad state in Go before exec'ing brew: when the binstub is a regular file, dangling symlink, or symlink outside the brew prefix, abort with a clear `rm + brew install --cask` remediation hint.
- Adds `homebrewBinaryOK` + `brewCollisionHint`; captures pre-resolve `LinkPath` on `upgradeInfo`; 5 new tests.

## Test plan
- [x] `go test ./internal/cli/ -run 'Upgrade|HomebrewBinary|DetectInstall|VersionsEqual|OtherInstances|PrintUpgrade' -count=1 -v` (15 passed)
- [x] `go build ./...`
- [x] `go vet ./internal/cli/...`
- [ ] Manual: simulate collision with `rm <brew>/bin/agnostic-ai && cp some-binary <brew>/bin/agnostic-ai && agnostic-ai upgrade --run` — expect abort with hint, no brew exec