### PR TITLE
feat: per-target model selection in spec frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- Per-target models: `model:` frontmatter now accepts a map keyed by target name with an optional `default` fallback (e.g. `model: {claude: opus, codex: gpt-5.5, default: gpt-4o}`). A bare string still applies to every target.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
-- Per-target models: `model:` frontmatter now accepts a map keyed by target name with an optional `default` fallback (e.g. `model: {claude: opus, codex: gpt-5.5, default: gpt-4o}`). A bare string still applies to every target.
+- Per-target models: `model:` frontmatter accepts a map keyed by target (e.g. `model: {claude: opus, codex: gpt-5.5}`). A bare string applies to every target. Optional `default` sets a fallback; omit it and unlisted targets use their own native default.
 
 ### Changed
 

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -66,9 +66,25 @@ Report concise findings with `file:line` references.
 | `name` | no | filename without `.md` | Agent identifier. Used for the output filename. |
 | `description` | no | empty | One-liner shown in tool listings. |
 | `tools` | no | unset | Tools the agent may invoke. Format depends on target CLI. |
-| `model` | no | unset | Preferred model. Common values: `sonnet`, `opus`, `haiku`. |
+| `model` | no | unset | Preferred model. A string applies to every target, or a map selects per target (see below). |
 
 Any other frontmatter fields pass through to the target CLI unchanged.
+
+### Per-target models
+
+`model:` accepts a string (same model everywhere) or a map keyed by target name with an optional `default` fallback:
+
+```yaml
+---
+name: code-reviewer
+model:
+  claude: opus
+  codex: gpt-5.5
+  default: gpt-4o
+---
+```
+
+Resolution per target: the matching key wins, else `default`, else the model is dropped for that target (it inherits nothing). A bare string keeps working unchanged. An `x-<target>.model` override still beats the map for that target, and `x-<target>.model: null` deletes it.
 
 ## Skills
 

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -86,6 +86,24 @@ model:
 
 Resolution per target: the matching key wins, else `default`, else the model is dropped for that target (it inherits nothing). A bare string keeps working unchanged. An `x-<target>.model` override still beats the map for that target, and `x-<target>.model: null` deletes it.
 
+Omitting `default` is how you say "use each target's own native default." A target with no matching key and no `default` gets no `model` line emitted, so the CLI falls back to whatever model it ships with:
+
+```yaml
+---
+name: code-reviewer
+model:
+  claude: sonnet   # Claude uses sonnet; every other target emits no model
+---                # and falls back to its own built-in default
+```
+
+Three intents, all expressible:
+
+| Want | Write |
+|------|-------|
+| Same model everywhere | `model: sonnet` |
+| Per-target, with a concrete fallback | `model: {claude: sonnet, default: gpt-4o}` |
+| Per-target, native default elsewhere | `model: {claude: sonnet}` |
+
 ## Skills
 
 Two layouts:

--- a/internal/adapters/internal/emit/meta.go
+++ b/internal/adapters/internal/emit/meta.go
@@ -126,7 +126,43 @@ func ResolveMetaOrdered(meta map[string]any, keys []string, target string) (map[
 			appendKV(nk, nv)
 		}
 	}
+	collapseModel(out, &outKeys, target)
 	return out, outKeys
+}
+
+// collapseModel resolves a per-target `model` map down to the single
+// string the named target should use. A bare string `model:` value is
+// left untouched, so the simple case keeps working. A map form picks
+// `model.<target>` first, then `model.default`; if neither matches the
+// key is removed so the target inherits no model (mirrors the #304
+// delete-marker behavior). Keys overwritten by `x-<target>.model` arrive
+// here already as strings and pass through unchanged.
+//
+//	model: gpt-4o                          -> gpt-4o (every target)
+//	model: {claude: opus, default: gpt-4o} -> opus for claude, gpt-4o for codex
+//	model: {claude: opus}                  -> opus for claude, dropped for codex
+func collapseModel(out map[string]any, keys *[]string, target string) {
+	m, ok := out["model"].(map[string]any)
+	if !ok {
+		return
+	}
+	pick := func(k string) (string, bool) {
+		v, ok := m[k]
+		if !ok {
+			return "", false
+		}
+		s, ok := v.(string)
+		return s, ok
+	}
+	if s, ok := pick(target); ok {
+		out["model"] = s
+		return
+	}
+	if s, ok := pick("default"); ok {
+		out["model"] = s
+		return
+	}
+	removeKey(out, keys, "model")
 }
 
 // removeKey strips key from both the resolved map and the ordered keys

--- a/internal/adapters/internal/emit/meta_test.go
+++ b/internal/adapters/internal/emit/meta_test.go
@@ -142,3 +142,80 @@ func TestResolveMetaOrdered_NilUnderXTargetDropsOrder(t *testing.T) {
 		t.Errorf("got %v, want %v", gotKeys, wantKeys)
 	}
 }
+
+func TestResolveMeta_StringModelPassesThrough(t *testing.T) {
+	in := map[string]any{"name": "a", "model": "gpt-4o"}
+	got := ResolveMeta(in, "codex")
+	if got["model"] != "gpt-4o" {
+		t.Errorf("string model should pass through, got %v", got["model"])
+	}
+}
+
+func TestResolveMeta_PerTargetModelPicksTarget(t *testing.T) {
+	in := map[string]any{
+		"name": "a",
+		"model": map[string]any{
+			"claude":  "claude-opus-4-8",
+			"codex":   "gpt-5.5",
+			"default": "gpt-4o",
+		},
+	}
+	if got := ResolveMeta(in, "claude")["model"]; got != "claude-opus-4-8" {
+		t.Errorf("claude got %v", got)
+	}
+	if got := ResolveMeta(in, "codex")["model"]; got != "gpt-5.5" {
+		t.Errorf("codex got %v", got)
+	}
+}
+
+func TestResolveMeta_PerTargetModelFallsBackToDefault(t *testing.T) {
+	in := map[string]any{
+		"name": "a",
+		"model": map[string]any{
+			"claude":  "claude-opus-4-8",
+			"default": "gpt-4o",
+		},
+	}
+	if got := ResolveMeta(in, "cursor")["model"]; got != "gpt-4o" {
+		t.Errorf("unmatched target should use default, got %v", got)
+	}
+}
+
+func TestResolveMeta_PerTargetModelNoMatchNoDefaultDrops(t *testing.T) {
+	in := map[string]any{
+		"name":  "a",
+		"model": map[string]any{"claude": "claude-opus-4-8"},
+	}
+	got := ResolveMeta(in, "codex")
+	if _, ok := got["model"]; ok {
+		t.Errorf("no target match and no default should drop model, got %v", got["model"])
+	}
+}
+
+func TestResolveMetaOrdered_PerTargetModelDropKeepsOrderClean(t *testing.T) {
+	in := map[string]any{
+		"name":  "a",
+		"model": map[string]any{"claude": "opus"},
+	}
+	keys := []string{"name", "model"}
+	_, gotKeys := ResolveMetaOrdered(in, keys, "codex")
+	wantKeys := []string{"name"}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Errorf("got %v, want %v", gotKeys, wantKeys)
+	}
+}
+
+func TestResolveMeta_XTargetOverridesPerTargetMap(t *testing.T) {
+	in := map[string]any{
+		"name":     "a",
+		"model":    map[string]any{"claude": "opus", "default": "gpt-4o"},
+		"x-codex":  map[string]any{"model": "gpt-5.5-codex"},
+		"x-cursor": map[string]any{"model": nil},
+	}
+	if got := ResolveMeta(in, "codex")["model"]; got != "gpt-5.5-codex" {
+		t.Errorf("x-codex.model should win over map, got %v", got)
+	}
+	if got, ok := ResolveMeta(in, "cursor")["model"]; ok {
+		t.Errorf("x-cursor nil delete should drop model, got %v", got)
+	}
+}

--- a/tests/integration/per_target_model_test.go
+++ b/tests/integration/per_target_model_test.go
@@ -1,0 +1,122 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// TestPerTargetModel_EmitsResolvedModelPerTarget proves the per-target
+// `model:` map resolves end to end through a real sync: each target
+// reads the model meant for it, an unlisted target falls back to
+// `default`, and a target with neither a match nor a default emits no
+// model at all (inherits nothing). A bare string still applies to every
+// target. Three targets are exercised because each consumes `model`
+// from a different output path: codex agent TOML, cursor command
+// frontmatter, copilot chatmode frontmatter.
+func TestPerTargetModel_EmitsResolvedModelPerTarget(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	must(t, os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"),
+		[]byte(`version: 1
+sources:
+  agents: .agnostic-ai/agents
+targets:
+  - codex
+  - cursor
+  - copilot
+outputs:
+  cursor:
+    commands-dir: .cursor/commands
+  copilot:
+    chatmodes-dir: .github/chatmodes
+gitignore:
+  enabled: false
+`), 0o644))
+
+	must(t, os.MkdirAll(filepath.Join(dir, ".agnostic-ai/agents"), 0o755))
+
+	// alpha: full map. codex picks its own, cursor picks its own,
+	// copilot is unlisted so it falls back to default.
+	must(t, os.WriteFile(filepath.Join(dir, ".agnostic-ai/agents/alpha.md"),
+		[]byte(`---
+name: alpha
+description: agent alpha
+model:
+  codex: gpt-5.5
+  cursor: cursor-opus
+  default: gpt-4o
+---
+
+alpha body
+`), 0o644))
+
+	// beta: map without codex and without default. codex must emit no
+	// model; cursor still gets its match.
+	must(t, os.WriteFile(filepath.Join(dir, ".agnostic-ai/agents/beta.md"),
+		[]byte(`---
+name: beta
+description: agent beta
+model:
+  cursor: cursor-only
+---
+
+beta body
+`), 0o644))
+
+	// gamma: bare string applies to every target unchanged.
+	must(t, os.WriteFile(filepath.Join(dir, ".agnostic-ai/agents/gamma.md"),
+		[]byte(`---
+name: gamma
+description: agent gamma
+model: shared-model
+---
+
+gamma body
+`), 0o644))
+
+	runCmd(t, "sync")
+
+	read := func(rel string) string {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		return string(data)
+	}
+	wantModel := func(rel, model string) {
+		t.Helper()
+		if got := read(rel); !strings.Contains(got, model) {
+			t.Errorf("%s: expected model %q, not found in:\n%s", rel, model, got)
+		}
+	}
+	noModel := func(rel string) {
+		t.Helper()
+		for _, line := range strings.Split(read(rel), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "model:") || strings.HasPrefix(trimmed, "model =") {
+				t.Errorf("%s: expected no model line, got %q", rel, trimmed)
+			}
+		}
+	}
+
+	// alpha: per-target pick + default fallback.
+	wantModel(".codex/agents/alpha.toml", `model = "gpt-5.5"`)
+	wantModel(".cursor/commands/alpha.md", "model: cursor-opus")
+	wantModel(".github/chatmodes/alpha.chatmode.md", "model: gpt-4o")
+
+	// beta: cursor match, codex dropped (no match, no default).
+	wantModel(".cursor/commands/beta.md", "model: cursor-only")
+	noModel(".codex/agents/beta.toml")
+	noModel(".github/chatmodes/beta.chatmode.md")
+
+	// gamma: bare string everywhere.
+	wantModel(".codex/agents/gamma.toml", `model = "shared-model"`)
+	wantModel(".cursor/commands/gamma.md", "model: shared-model")
+	wantModel(".github/chatmodes/gamma.chatmode.md", "model: shared-model")
+}


### PR DESCRIPTION
## What

`model:` frontmatter now accepts a string **or** a per-target map.

```yaml
model: sonnet                              # same model everywhere

model:
  claude: opus
  codex: gpt-5.5
  default: gpt-4o                          # concrete fallback for unlisted targets

model:
  claude: sonnet                           # claude -> sonnet; everyone else
                                           # emits no model = native default
```

## Resolution

Per target: matching key wins, else `default`, else **no model is emitted** (the CLI uses its own built-in default). A bare string keeps working unchanged. `x-<target>.model` still overrides the map; `x-<target>.model: null` deletes it.

## How

Collapse the map to a string in `emit.ResolveMeta`, after `x-<target>` merging. One place: every adapter reads `model` as a string after `ResolveMeta`, so no per-adapter edits.

## Tests

- Unit (`meta_test.go`): string pass-through, per-target pick, default fallback, no-match drop, ordered-key cleanup, x-target override.
- Integration (`per_target_model_test.go`): real sync across codex, cursor, copilot proving per-target pick, default fallback, drop, and bare-string everywhere.

## Docs

- `docs/user/spec-format.md`: per-target models section + "omit default = native default" table.
- `CHANGELOG.md`: Added entry.