### PR TITLE
fix(import-claude): propagate nested .claude/CLAUDE.md to every target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Fixed
 
+- `import claude` now propagates a project's instructions to every target when they live in the nested `.claude/CLAUDE.md` (a documented Claude Code project-memory location) rather than the root `CLAUDE.md`. Previously the nested file was captured only as a claude-private helper overlay, so `sync` fed codex, gemini, and the rest the generic pointer template instead of the real instructions. The nested file is now promoted to the shared `.agnostic-ai/AGNOSTIC_AI.md` body (root `CLAUDE.md` still wins when both exist), and is no longer double-captured as an overlay.
 - Playground rendered nothing for any target whose adapter reads a captured overlay or helper file (claude, codex, and others): the in-browser `js/wasm` runtime has no filesystem, so those reads failed with `ENOSYS` (and other wasm-specific errors) instead of "file not found", aborting the emit. Optional source reads now treat a missing filesystem as "absent" and proceed.
 - Playground now renders each target's root entry-point file (CLAUDE.md, AGENTS.md, GEMINI.md, ...) alongside the per-spec artifacts, mirroring a real `sync`. Previously codex showed nothing for a `rule` spec (codex emits no per-rule file; rules surface only through AGENTS.md), and claude never showed CLAUDE.md.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- Docs: README explains whether to commit or gitignore generated outputs (recommends ignore); CONTRIBUTING documents that this repo's AI config is generated and regenerated via `agnostic-ai sync`.
+
 ### Changed
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,21 @@ Open a PR with a [Conventional Commits](https://www.conventionalcommits.org/) su
 | Add a new AI CLI target | [Adapter issue](.github/ISSUE_TEMPLATE/new_adapter.yml) · [adding-adapters.md](docs/internal/adding-adapters.md) |
 | Deep dive | [docs/internal/](docs/internal/) (architecture, contributing, decisions) |
 
+## AI config is generated (dogfooding)
+
+This repo drives its own AI config with agnostic-ai. The source of truth is `.agnostic-ai/`. Every target output is **gitignored** and regenerated, never committed:
+
+- Per-target folders: `.claude/`, `.cursor/`, `.gemini/`, `.codex/`, `.windsurf/`, `.continue/`, `.clinerules/`, `.opencode/`, `.agent/`.
+- Root entry-points: `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `.rules`, `.github/copilot-instructions.md`.
+
+After editing any spec under `.agnostic-ai/`, regenerate locally:
+
+```bash
+agnostic-ai sync   # or: go run ./cmd/agnostic-ai sync
+```
+
+Do not edit the generated files directly and do not commit them; they are overwritten on each sync. CI runs `agnostic-ai check` to fail drift.
+
 ## PR rules
 
 - Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`).

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ CI gate — fail PRs that drift from source specs:
   with: { command: check }
 ```
 
+**Commit or ignore generated outputs?** Recommended: gitignore them and keep `.agnostic-ai/` as the single source of truth, so contributors run `sync` to regenerate locally (this repo does exactly that). Committing them is also valid when teammates lack the CLI; the `check` gate guards drift either way.
+
 ## Documentation
 
 **Get started**

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -52,7 +52,18 @@ func importFromClaude(root string, src config.Sources) error {
 	if err := captureHookScripts(root, "claude"); err != nil {
 		return err
 	}
-	helpers, err := captureHelperFiles(root, "claude")
+	mainSeeded, mainSrc, promotedNested, err := mirrorClaudeMainFile(root)
+	if err != nil {
+		return err
+	}
+	// When the nested .claude/CLAUDE.md is promoted to the shared body,
+	// do not also capture it as a claude-private helper overlay: that
+	// would restore a duplicate copy under .claude/ on the next sync.
+	var helperExclude []string
+	if promotedNested {
+		helperExclude = append(helperExclude, claudeMainFile)
+	}
+	helpers, err := captureHelperFiles(root, "claude", helperExclude...)
 	if err != nil {
 		return err
 	}
@@ -66,15 +77,11 @@ func importFromClaude(root string, src config.Sources) error {
 	if err != nil {
 		return err
 	}
-	mainSeeded, err := mirrorClaudeMainFile(root)
-	if err != nil {
-		return err
-	}
 	summaryf("imported %d rules, %d agents, %d skills, %d hooks, %d mcps, %d commands\n",
 		c.rules, c.agents, c.skills, c.hooks, c.mcps, c.commands)
 	if mainSeeded {
 		summaryf("  → %s seeded from %s (commit this file — sync distributes it to all targets)\n",
-			agnosticMainFile, claudeMainFile)
+			agnosticMainFile, mainSrc)
 	}
 	if overlaySeeded {
 		summaryf("  → %s seeded from %s/settings.json (carries non-hook settings across re-syncs)\n",
@@ -88,12 +95,36 @@ func importFromClaude(root string, src config.Sources) error {
 	return nil
 }
 
-// mirrorClaudeMainFile mirrors <root>/CLAUDE.md to
-// <root>/.agnostic-ai/AGNOSTIC_AI.md. Returns (true, nil) when the
-// mirror actually wrote so callers can suppress a misleading summary
-// line on a CLAUDE.md-less project.
-func mirrorClaudeMainFile(root string) (bool, error) {
-	return mirrorMainFile(root, claudeMainFile)
+// nestedClaudeMainFile is the project-nested Claude Code instructions
+// file. Per the Claude Code docs a project CLAUDE.md may live at either
+// `./CLAUDE.md` or `./.claude/CLAUDE.md`; both are auto-loaded project
+// memory. agnostic-ai treats the nested form as the project's main
+// instructions when no root CLAUDE.md exists.
+var nestedClaudeMainFile = filepath.Join(claudeDir, claudeMainFile)
+
+// mirrorClaudeMainFile mirrors the project's Claude main instructions to
+// <root>/.agnostic-ai/AGNOSTIC_AI.md so `sync` distributes the body to
+// every target's native entry-point (AGENTS.md, GEMINI.md, ...).
+//
+// Source precedence: the project-root CLAUDE.md wins; when it is absent
+// the nested .claude/CLAUDE.md is promoted to the shared body. Promoting
+// the nested file is what lets a project that keeps its instructions
+// under .claude/ (a documented Claude Code location) still feed codex,
+// gemini, and the rest — without it, those targets receive only the
+// generic pointer template.
+//
+// Returns (wrote, srcName, promotedNested, err): wrote is false on a
+// project with no Claude instructions at all (callers suppress the
+// summary line); srcName names the file the body came from; promotedNested
+// is true when the nested file was used, signalling the caller to skip
+// capturing it as a claude-private helper overlay.
+func mirrorClaudeMainFile(root string) (wrote bool, srcName string, promotedNested bool, err error) {
+	if _, statErr := os.Stat(filepath.Join(root, claudeMainFile)); statErr == nil {
+		wrote, err = mirrorMainFile(root, claudeMainFile)
+		return wrote, claudeMainFile, false, err
+	}
+	wrote, err = mirrorMainFile(root, nestedClaudeMainFile)
+	return wrote, nestedClaudeMainFile, wrote, err
 }
 
 // mirrorMainFile copies <root>/<srcName> byte-for-byte to

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -116,7 +116,7 @@ var nestedClaudeMainFile = filepath.Join(claudeDir, claudeMainFile)
 // Returns (wrote, srcName, promotedNested, err): wrote is false on a
 // project with no Claude instructions at all (callers suppress the
 // summary line); srcName names the file the body came from; promotedNested
-// is true when the nested file was used, signalling the caller to skip
+// is true when the nested file was used, signaling the caller to skip
 // capturing it as a claude-private helper overlay.
 func mirrorClaudeMainFile(root string) (wrote bool, srcName string, promotedNested bool, err error) {
 	if _, statErr := os.Stat(filepath.Join(root, claudeMainFile)); statErr == nil {

--- a/internal/cli/import_helper_files.go
+++ b/internal/cli/import_helper_files.go
@@ -47,9 +47,21 @@ func helperOverlayPath(root, tool, basename string) string {
 // per file when the source is missing — most projects do not ship every
 // helper. Returns the basenames that were actually captured so the
 // import summary can surface them.
-func captureHelperFiles(root, tool string) ([]string, error) {
+//
+// Basenames listed in exclude are skipped. The claude importer uses this
+// to avoid double-capturing `.claude/CLAUDE.md` as a claude-private
+// overlay when it was promoted to the shared `AGNOSTIC_AI.md` body
+// (project keeps its instructions nested, with no root CLAUDE.md).
+func captureHelperFiles(root, tool string, exclude ...string) ([]string, error) {
+	skip := make(map[string]bool, len(exclude))
+	for _, name := range exclude {
+		skip[name] = true
+	}
 	var captured []string
 	for _, h := range helperFilesByTool[tool] {
+		if skip[h.basename] {
+			continue
+		}
 		src := filepath.Join(root, "."+h.tool, h.basename)
 		info, err := os.Stat(src)
 		if errors.Is(err, fs.ErrNotExist) {

--- a/internal/cli/import_helper_files_test.go
+++ b/internal/cli/import_helper_files_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -39,6 +40,77 @@ func TestCaptureHelperFiles_Claude(t *testing.T) {
 		}
 		if info.Mode().Perm()&0o111 == 0 {
 			t.Errorf("captured statusline.sh lost exec bit: mode=%v", info.Mode().Perm())
+		}
+	}
+}
+
+// A project that keeps its instructions nested under .claude/CLAUDE.md
+// (no root CLAUDE.md) has that body promoted to the shared AGNOSTIC_AI.md
+// so `sync` distributes it to every target's entry-point — not buried in
+// a claude-private overlay where codex/gemini never see it.
+func TestImportClaude_NestedMainFilePromotedToSharedBody(t *testing.T) {
+	dir := t.TempDir()
+	body := "# phel-doom\n\nTerminal raycaster. Nested instructions body.\n"
+	writeFile(t, filepath.Join(dir, ".claude/CLAUDE.md"), body)
+	writeFile(t, filepath.Join(dir, ".claude/README.md"), "operator docs\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nested CLAUDE.md becomes the shared body.
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("AGNOSTIC_AI.md not seeded: %v", err)
+	}
+	if !strings.Contains(string(got), "Nested instructions body.") {
+		t.Errorf("AGNOSTIC_AI.md missing nested body, got %q", got)
+	}
+
+	// It must NOT also be captured as a claude-private helper overlay
+	// (that would restore a duplicate copy under .claude/ on sync).
+	if _, err := os.Stat(filepath.Join(dir, ".agnostic-ai/overlays/claude/CLAUDE.md")); err == nil {
+		t.Error("nested CLAUDE.md should not be captured as a claude-private overlay when promoted")
+	}
+	// Other helpers are still captured.
+	if _, err := os.Stat(filepath.Join(dir, ".agnostic-ai/overlays/claude/README.md")); err != nil {
+		t.Errorf("README.md helper should still be captured: %v", err)
+	}
+}
+
+// End-to-end: nested-only .claude/CLAUDE.md propagates to both the claude
+// (CLAUDE.md) and codex (AGENTS.md) entry-points after sync.
+func TestImportClaudeNestedThenSync_PropagatesToCodex(t *testing.T) {
+	dir := t.TempDir()
+	body := "# phel-doom\n\nNested instructions body for every tool.\n"
+	writeFile(t, filepath.Join(dir, ".claude/CLAUDE.md"), body)
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	writeMinimalConfig(t, dir, ".agnostic-ai")
+
+	prevDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevDir) })
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude,codex"})
+	silence(t)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"CLAUDE.md", "AGENTS.md"} {
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Errorf("%s entry-point missing: %v", name, err)
+			continue
+		}
+		if !strings.Contains(string(got), "Nested instructions body for every tool.") {
+			t.Errorf("%s missing shared body, got %q", name, got)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

A project whose Claude instructions live in the nested `.claude/CLAUDE.md` (a documented Claude Code project-memory location, equivalent to root `CLAUDE.md`) had that content captured only as a **claude-private helper overlay**. `sync` then fed every other target (codex, gemini, ...) the generic pointer template instead of the real instructions, so cross-target dedup was silently broken for these projects.

## Fix

- `import claude` now mirrors the project's main instructions to the shared `.agnostic-ai/AGNOSTIC_AI.md` from **either** root `CLAUDE.md` (preferred) **or** nested `.claude/CLAUDE.md` (fallback when root is absent).
- When the nested file is promoted to the shared body, it is no longer also captured as a claude-private overlay, so `sync` does not restore a duplicate copy under `.claude/`.
- Root `CLAUDE.md` still wins when both files exist (the legitimate dual-file case is preserved).

## Tests

- Added `TestImportClaude_NestedMainFilePromotedToSharedBody` and `TestImportClaudeNestedThenSync_PropagatesToCodex`.
- Full suite green (1078 tests).

## Verification

Validated end-to-end against a real nested-`.claude/CLAUDE.md` project: after the fix, the Claude entry-point and the Codex `AGENTS.md` carry the identical full instructions body, and `sync --check` is idempotent.