### PR TITLE
docs: simplify changelog and fix default target count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
-- Docs: README and getting-started explain whether to commit or gitignore generated outputs (recommends ignore via `gitignore.enabled`); CONTRIBUTING documents that this repo's AI config is generated, regenerated via `agnostic-ai sync`, and why its `.gitignore` block is hand-maintained rather than tool-managed.
+- Docs explain whether to commit or gitignore generated outputs, and recommend ignoring them via `gitignore.enabled`.
 
 ### Changed
 
+- Docs: `configuration.md` states the correct default target set (12 of 14, omitting `amp` and `warp`), drops the duplicated entry-point list in favor of a link to `targets.md`.
+
 ### Fixed
 
-- Managed `.gitignore` block (`gitignore.enabled`) now root-anchors every entry (`/AGENTS.md`, not `AGENTS.md`). Unanchored basenames matched at any depth, so a generated `.rules`, `CONVENTIONS.md`, or `AGENTS.md` silently ignored same-named files nested elsewhere (e.g. golden fixtures under `internal/adapters/*/testdata/`). (#362)
-- `import claude` now propagates a project's instructions to every target when they live in the nested `.claude/CLAUDE.md` (a documented Claude Code project-memory location) rather than the root `CLAUDE.md`. Previously the nested file was captured only as a claude-private helper overlay, so `sync` fed codex, gemini, and the rest the generic pointer template instead of the real instructions. The nested file is now promoted to the shared `.agnostic-ai/AGNOSTIC_AI.md` body (root `CLAUDE.md` still wins when both exist), and is no longer double-captured as an overlay.
-- Playground rendered nothing for any target whose adapter reads a captured overlay or helper file (claude, codex, and others): the in-browser `js/wasm` runtime has no filesystem, so those reads failed with `ENOSYS` (and other wasm-specific errors) instead of "file not found", aborting the emit. Optional source reads now treat a missing filesystem as "absent" and proceed.
-- Playground now renders each target's root entry-point file (CLAUDE.md, AGENTS.md, GEMINI.md, ...) alongside the per-spec artifacts, mirroring a real `sync`. Previously codex showed nothing for a `rule` spec (codex emits no per-rule file; rules surface only through AGENTS.md), and claude never showed CLAUDE.md.
+- Managed `.gitignore` block now root-anchors every entry (`/AGENTS.md`, not `AGENTS.md`), so a generated path no longer ignores a same-named file nested elsewhere (e.g. golden fixtures under `internal/adapters/*/testdata/`). (#362)
+- `import claude` propagates instructions from a nested `.claude/CLAUDE.md` to every target. They were captured only as a claude-private overlay, so other targets got the generic pointer template instead. (#361)
+- Playground renders targets whose adapter reads an overlay or helper file (claude, codex). The `js/wasm` runtime has no filesystem, so optional source reads now treat a missing filesystem as "absent" instead of failing with `ENOSYS`.
+- Playground renders each target's root entry-point file (CLAUDE.md, AGENTS.md, ...) alongside the per-spec artifacts, mirroring a real `sync`.
 
 ### Removed
 

--- a/docs/internal/roadmap.md
+++ b/docs/internal/roadmap.md
@@ -20,7 +20,7 @@ Higher layer wins on `(Kind, Name)` collision. Merge in `spec.LoadLayered`. See 
 - Codex subagents + skills (`.codex/agents/<name>.toml`, `.codex/skills/<name>/SKILL.md`).
 - Top-level `import <source>` (and multi-source: `import claude codex`).
 - `doctor --fix [--backup]`.
-- MCP for 10/13 targets. Aider/Cline/Windsurf lack project-scoped MCP.
+- MCP for 10/14 targets. Aider/Cline/Windsurf lack project-scoped MCP.
 - Hooks beyond Claude: Codex `.codex/config.toml`, Gemini `.gemini/settings.json`.
 
 ## Open

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -40,7 +40,10 @@ sources:
   mcps: mcps
   commands: commands
 
-# AI CLIs to emit configs for.
+# AI CLIs to emit configs for. These 12 are the default set (used when
+# `targets` is omitted). Two more adapters exist, `amp` and `warp`, but
+# both emit the root `AGENTS.md` like `codex`, so enabling them together
+# collides. Add one and give it an `outputs.<target>.file` override.
 targets:
   - claude
   - codex
@@ -51,18 +54,14 @@ targets:
   - cline
   - windsurf
   - continue
-  - amp
   - zed
-  - warp
   - opencode
   - antigravity
 
 # Per-target output overrides. Each target accepts only the fields
-# relevant to it. Defaults shown in comments. The project-root
-# entry-point file (CLAUDE.md, AGENTS.md, GEMINI.md, CONVENTIONS.md,
-# .github/copilot-instructions.md, .opencode/AGENTS.md,
-# .agent/AGENTS.md) is written centrally by `sync` and is not
-# adapter-configurable.
+# relevant to it. Defaults shown in comments. The root entry-point file
+# is written centrally by `sync` and is not adapter-configurable (see
+# the Entry-point files section below).
 #
 # Set `outputs.<target>.rules-file: <path>` on any target to opt back
 # into the legacy concatenated rules layout at that path; `sync` then
@@ -146,7 +145,7 @@ gitignore:
 |-------|------|---------|-------------|
 | `version` | int | `1` | Schema version. Reserved for future migrations. |
 | `sources` | map | see below | Per-kind source directories (relative to config file). |
-| `targets` | list | all 14 adapters | Adapter names to emit. Unknown targets log a warning and skip. |
+| `targets` | list | 12 default adapters | Adapter names to emit. Defaults to every adapter except `amp` and `warp`. Unknown targets log a warning and skip. |
 | `outputs` | map | see below | Per-target output path overrides. |
 | `on-unsupported` | string | `warn` | How to react when a kind is unsupported by a target. One of `warn`, `error`, `silent`. |
 | `gitignore` | map | `enabled: false` | Auto-manage a block in `.gitignore` listing generated paths. See [`gitignore`](#gitignore). |
@@ -217,7 +216,7 @@ Per-target paths. Each target reads only the fields it understands; irrelevant f
 
 ## `targets`
 
-When omitted: all 13 adapters above. Comment out entries to disable targets. CLI flag `-t/--target` overrides for a single run.
+When omitted: the 12 default adapters above (every adapter except `amp` and `warp`, which collide with `codex` on the root `AGENTS.md`). Comment out entries to disable targets. CLI flag `-t/--target` overrides for a single run.
 
 ### Interactive target selection
 
@@ -454,13 +453,10 @@ See [`sync --watch`](cli-reference.md#sync) for the polling fallback and debounc
 
 ## Entry-point files
 
-`sync` writes `.agnostic-ai/AGNOSTIC_AI.md` plus a conventional root
-entry-point file for every enabled target (`CLAUDE.md`, `AGENTS.md`,
-`GEMINI.md`, `CONVENTIONS.md`, `.github/copilot-instructions.md`,
-`.opencode/AGENTS.md`, `.agent/AGENTS.md`). All files share the same
-canonical pointer body. Targets that share an entry-point path (codex,
-amp, and warp all at `AGENTS.md`) write the file once; the dedup is
-automatic.
+`sync` writes `.agnostic-ai/AGNOSTIC_AI.md` plus one root entry-point
+file per enabled target, all sharing the canonical pointer body. See the
+[per-target table](targets.md#entry-point-files) for which file each
+target uses.
 
 To opt back into the legacy concatenated layout for a target, set
 `outputs.<target>.rules-file: <path>`. The adapter then writes a


### PR DESCRIPTION
Follow-up doc cleanup.

## Changes

- **Simplify** the `[Unreleased]` changelog notes: one idea per line, drop filler.
- **Fix drift** in `docs/user/configuration.md`: the default target set is 12 of 14, not "13" / "14". `amp` and `warp` are excluded because they emit the root `AGENTS.md` like `codex` and would collide. Corrected the `## Top-level fields` table, the `## targets` section, and the schema example (which previously listed a colliding `codex`+`amp`+`warp` set).
- **De-duplicate**: the entry-point file list was repeated verbatim in `configuration.md` and `targets.md`. `configuration.md` now links the [per-target table](../user/targets.md#entry-point-files).
- **Stale count**: `roadmap.md` 10/13 -> 10/14.

Ground truth checked against `config.DefaultTargets()` (12) and the adapter registry in `internal/adapters/adapter.go` (14).