### PR TITLE
docs: plain-english sweep (remove em-dashes, filler)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Same shape lands at `.claude/rules/`, `.windsurf/rules/`, `.clinerules/`, `.cont
 
 Legend: ✅ separate files · ◐ merged into single doc · `-` not supported. Hooks propagate to Claude, Codex, and Gemini. MCPs propagate to 10 targets in each tool's native schema.
 
-A ✅ means the file lands where the target documents. Not every cell is a path the upstream tool auto-loads — see [targets](docs/user/targets.md) for which paths are native vs. convention and how to wire conventions into each tool.
+A ✅ means the file lands where the target documents. Not every cell is a path the upstream tool auto-loads. See [targets](docs/user/targets.md) for which paths are native vs. convention and how to wire conventions into each tool.
 
 ## Install
 
@@ -110,7 +110,7 @@ agnostic-ai upgrade --run     # exec the detected upgrade command
 agnostic-ai upgrade --check   # diagnose install location + PATH shadowing
 ```
 
-Detects whether the running binary came from Homebrew, `go install`, or a raw download, then prints (or runs) the matching upgrade command. `--check` flags any other `agnostic-ai` on `PATH` that would shadow the resolved executable — the common reason `brew upgrade` reports "already up-to-date" but `agnostic-ai --version` keeps showing an older release.
+Detects whether the running binary came from Homebrew, `go install`, or a raw download, then prints (or runs) the matching upgrade command. `--check` flags any other `agnostic-ai` on `PATH` that would shadow the resolved executable. That is the common reason `brew upgrade` reports "already up-to-date" but `agnostic-ai --version` keeps showing an older release.
 
 Direct package-manager commands work too:
 
@@ -132,7 +132,7 @@ Edit specs under `.agnostic-ai/`, run `sync` again. Already have `.cursor/rules`
 agnostic-ai import cursor   # also: claude, codex, gemini, cline, windsurf, continue, ...
 ```
 
-CI gate — fail PRs that drift from source specs:
+CI gate to fail PRs that drift from source specs:
 
 ```yaml
 - uses: chemaclass/agnostic-ai-action@v1
@@ -144,27 +144,27 @@ CI gate — fail PRs that drift from source specs:
 ## Documentation
 
 **Get started**
-- [Getting started](docs/user/getting-started.md) — first rule, first sync, in 2 minutes
-- [Spec format](docs/user/spec-format.md) — frontmatter reference for every kind
-- [Examples](docs/examples/) — drop-in templates
+- [Getting started](docs/user/getting-started.md): first rule, first sync, in 2 minutes
+- [Spec format](docs/user/spec-format.md): frontmatter reference for every kind
+- [Examples](docs/examples/): drop-in templates
 
 **Reference**
-- [Targets](docs/user/targets.md) — what each adapter emits and where
-- [Configuration](docs/user/configuration.md) — `agnostic-ai.yaml` reference
-- [CLI reference](docs/user/cli-reference.md) — every flag, every command
-- [Errors](docs/user/errors.md) — error code lookup
+- [Targets](docs/user/targets.md): what each adapter emits and where
+- [Configuration](docs/user/configuration.md): `agnostic-ai.yaml` reference
+- [CLI reference](docs/user/cli-reference.md): every flag, every command
+- [Errors](docs/user/errors.md): error code lookup
 
 **Workflows**
-- [CI gate](docs/user/ci.md) — drift checks on every PR
-- [Git hooks](docs/user/git-hooks.md) — pre-commit, lefthook, husky recipes
-- [Packs](docs/user/packs.md) — share spec bundles across repos
+- [CI gate](docs/user/ci.md): drift checks on every PR
+- [Git hooks](docs/user/git-hooks.md): pre-commit, lefthook, husky recipes
+- [Packs](docs/user/packs.md): share spec bundles across repos
 
 **Tools**
-- [Playground](https://chemaclass.github.io/agnostic-ai/) — paste a spec, see what every adapter emits (WASM, runs offline)
-- [Editor extensions](editors/) — VS Code (shipped), JetBrains (planned)
+- [Playground](https://chemaclass.github.io/agnostic-ai/): paste a spec, see what every adapter emits (WASM, runs offline)
+- [Editor extensions](editors/): VS Code (shipped), JetBrains (planned)
 
 **Contributing**
-- [Architecture & roadmap](docs/internal/) — adapter pattern, adding targets, release process
+- [Architecture & roadmap](docs/internal/): adapter pattern, adding targets, release process
 
 ---
 

--- a/docs/examples/agnostic-ai.yaml
+++ b/docs/examples/agnostic-ai.yaml
@@ -1,5 +1,5 @@
 # Full reference config showing every available knob with its default value.
-# Trim down to what you actually need. Every section is optional.
+# Trim down to what you need. Every section is optional.
 
 version: 1
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -1,13 +1,13 @@
 # Contributor docs
 
-1. [Architecture](architecture.md) — code layout, data flow, core types.
-2. [Adding an adapter](adding-adapters.md) — concrete walkthrough.
-3. [Plugin protocol](plugin-protocol.md) — JSON-over-stdio contract for out-of-tree adapter binaries.
-4. [Contributing](contributing.md) — dev setup, branch flow, test expectations.
-5. [Release process](release-process.md) — how a tag becomes a release.
-6. [Contributing a preset](contributing-presets.md) — adding an `init --preset <name>` pack.
-7. [Decision log](decisions.md) — historical design choices.
-8. [Roadmap](roadmap.md) — planned directions.
+1. [Architecture](architecture.md): code layout, data flow, core types.
+2. [Adding an adapter](adding-adapters.md): concrete walkthrough.
+3. [Plugin protocol](plugin-protocol.md): JSON-over-stdio contract for out-of-tree adapter binaries.
+4. [Contributing](contributing.md): dev setup, branch flow, test expectations.
+5. [Release process](release-process.md): how a tag becomes a release.
+6. [Contributing a preset](contributing-presets.md): adding an `init --preset <name>` pack.
+7. [Decision log](decisions.md): historical design choices.
+8. [Roadmap](roadmap.md): planned directions.
 
 ## House rules
 

--- a/docs/internal/adding-adapters.md
+++ b/docs/internal/adding-adapters.md
@@ -69,28 +69,28 @@ Add to default targets in `internal/config/config.go` and `internal/cli/init.go`
 
 Use shared resolvers; never hand-roll output paths:
 
-- `emit.OutputFile(cfg, target, fallback)` — single-document outputs
-- `emit.OutputDir(cfg, target, fallback)` — parent dir
-- `emit.OutputRulesDir(cfg, target, fallback)` — per-rule dir adapter
-- `emit.OutputRulesFile(cfg, target, fallback)` — merged rules file
-- `emit.OutputMCPFile(cfg, target, fallback)` — MCP propagation
-- `emit.OutputAgentsDir(cfg, target, fallback)` — per-agent files
-- `emit.OutputSkillsDir(cfg, target, fallback)` — per-skill files/folders
-- `emit.OutputCommandsDir(cfg, target, fallback)` — slash-command dirs
-- `emit.OutputInstructionsDir(cfg, target, fallback)` — Copilot-style scoped rules
-- `emit.EmitSkillsAsCommands(cfg, target)` — opt-in flag for skills-as-commands
+- `emit.OutputFile(cfg, target, fallback)`: single-document outputs
+- `emit.OutputDir(cfg, target, fallback)`: parent dir
+- `emit.OutputRulesDir(cfg, target, fallback)`: per-rule dir adapter
+- `emit.OutputRulesFile(cfg, target, fallback)`: merged rules file
+- `emit.OutputMCPFile(cfg, target, fallback)`: MCP propagation
+- `emit.OutputAgentsDir(cfg, target, fallback)`: per-agent files
+- `emit.OutputSkillsDir(cfg, target, fallback)`: per-skill files/folders
+- `emit.OutputCommandsDir(cfg, target, fallback)`: slash-command dirs
+- `emit.OutputInstructionsDir(cfg, target, fallback)`: Copilot-style scoped rules
+- `emit.EmitSkillsAsCommands(cfg, target)`: opt-in flag for skills-as-commands
 
 New field on `config.Output`? Add once, reuse.
 
 ## 5. Shared helpers
 
-- `emit.GroupRulesByScope(rules)` + `emit.RouteScope(r)` — route rules to `<scope>/AGENTS.md` / `<scope>/GEMINI.md` hierarchies.
-- `emit.WriteSection(sb, heading, e)` — inlined `### heading`. `emit.WriteReference(sb, e, sourcePath)` — pointer when the definition lives elsewhere.
-- `emit.WriteTOMLString` / `WriteTOMLMultiline` / `WriteTOMLStringArray` / `EscapeTOMLBasic` — TOML emit.
-- `emit.Frontmatter(meta)` — render YAML frontmatter.
-- `emit.ResolveMeta(meta, target)` — flatten `x-<target>` overrides as top-level keys.
-- `emit.MigrateLegacyFile(cfg, target, legacyName, defaultNewPath, dryRun)` — rename old outputs across releases.
-- `emit.IsCapturing()` — check capture mode before any non-`WriteFile` side effect.
+- `emit.GroupRulesByScope(rules)` + `emit.RouteScope(r)`: route rules to `<scope>/AGENTS.md` / `<scope>/GEMINI.md` hierarchies.
+- `emit.WriteSection(sb, heading, e)`: inlined `### heading`. `emit.WriteReference(sb, e, sourcePath)` points when the definition lives elsewhere.
+- `emit.WriteTOMLString` / `WriteTOMLMultiline` / `WriteTOMLStringArray` / `EscapeTOMLBasic`: TOML emit.
+- `emit.Frontmatter(meta)`: render YAML frontmatter.
+- `emit.ResolveMeta(meta, target)`: flatten `x-<target>` overrides as top-level keys.
+- `emit.MigrateLegacyFile(cfg, target, legacyName, defaultNewPath, dryRun)`: rename old outputs across releases.
+- `emit.IsCapturing()`: check capture mode before any non-`WriteFile` side effect.
 
 ## 6. Tests
 
@@ -136,10 +136,10 @@ return emit.WriteMCPFile(b.MCPs, emit.MCPSchemaServersMap,
 
 Built-in schemas:
 
-- `MCPSchemaServersMap` — `{"mcpServers": {...}}` (Claude, Cursor, Warp)
-- `MCPSchemaVSCodeServers` — `{"servers": {...}}` with `type` per server (Copilot / VS Code)
+- `MCPSchemaServersMap`: `{"mcpServers": {...}}` (Claude, Cursor, Warp)
+- `MCPSchemaVSCodeServers`: `{"servers": {...}}` with `type` per server (Copilot / VS Code)
 
-Non-trivial shapes (Codex TOML, Gemini `httpUrl`, Amp `amp.mcpServers` dotted key, Zed `context_servers`, OpenCode `mcp`, Continue one-YAML-per-server) emit custom — see each adapter. Use `emit.MergeJSONFile` to preserve unrelated user keys. Use `emit.OutputMCPDir` for one-file-per-server.
+Non-trivial shapes (Codex TOML, Gemini `httpUrl`, Amp `amp.mcpServers` dotted key, Zed `context_servers`, OpenCode `mcp`, Continue one-YAML-per-server) emit custom. See each adapter. Use `emit.MergeJSONFile` to preserve unrelated user keys. Use `emit.OutputMCPDir` for one-file-per-server.
 
 ## 9. Hooks (optional)
 

--- a/docs/internal/contributing-presets.md
+++ b/docs/internal/contributing-presets.md
@@ -28,7 +28,7 @@ The `presetFS` `embed.FS` uses `all:initdata/presets`, so new dirs are picked up
 ## Style
 
 - Stack-shaped, not project-shaped. `python` says "use type hints", not "use this team's mypy config".
-- One topic per spec. `python-style.md`, `pytest.md`, `typing.md` — not a giant `python.md`.
+- One topic per spec. `python-style.md`, `pytest.md`, `typing.md`, not a giant `python.md`.
 - Scope rules with `globs:` so they fire only on relevant files.
 - `alwaysApply: true` for style/testing rules; `false` for narrow scopes.
 

--- a/docs/internal/contributing.md
+++ b/docs/internal/contributing.md
@@ -15,7 +15,7 @@ make build      # builds ./agnostic-ai
 make test
 ```
 
-`make tools` puts binaries in `$(go env GOPATH)/bin` — ensure it is on `$PATH`.
+`make tools` puts binaries in `$(go env GOPATH)/bin`. Ensure it is on `$PATH`.
 
 ## Dev loop
 
@@ -72,5 +72,5 @@ Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`. 
 ## See also
 
 - [Release process](release-process.md)
-- [Decision log](decisions.md) — add non-obvious architectural calls.
+- [Decision log](decisions.md): add non-obvious architectural calls.
 - Questions: open a Discussion.

--- a/docs/internal/plugin-protocol.md
+++ b/docs/internal/plugin-protocol.md
@@ -80,7 +80,7 @@ Host writes one JSON document to stdin and reads one JSON document from stdout. 
 
 - Adapter runs as subprocess, not in-process. Sandboxed by whatever the host OS enforces for children.
 - Host pipes stdin once, reads stdout to EOF, waits for exit. No interactive terminal.
-- Adapter must not write to disk — host owns all on-disk state so capture/backup/dry-run stays consistent.
+- Adapter must not write to disk. Host owns all on-disk state so capture/backup/dry-run stays consistent.
 
 ## Versioning
 

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -17,7 +17,7 @@ make playground-build       # compiles the WASM and copies wasm_exec.js
 make playground-serve       # builds, then serves on http://127.0.0.1:8080
 ```
 
-`file://` protocol does **not** work — browsers refuse to fetch the
+`file://` protocol does **not** work. Browsers refuse to fetch the
 `.wasm` from a `file://` page. Use the `playground-serve` target or any
 static HTTP server pointed at `docs/playground/`.
 
@@ -41,7 +41,7 @@ static HTTP server pointed at `docs/playground/`.
   the binary, so the UI can build the target picker dynamically.
 
 Adapters run under capture mode (`adapters.StartCapture()`), so no
-filesystem operations occur — perfect for the WASM sandbox.
+filesystem operations occur, perfect for the WASM sandbox.
 
 ## Build size
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -70,8 +70,8 @@ CLI present in the project.
 | Source | Becomes |
 |--------|---------|
 | `.claude/rules/*.md` (preferred) | `<rules>/<name>.md` (byte-identical copy) |
-| `CLAUDE.md` (split on `## headings`) | `<rules>/<slug>.md` per section — only when `.claude/rules/` is absent |
-| `CLAUDE.md` (no headings) | single `<rules>/<projectname>.md` — only when `.claude/rules/` is absent |
+| `CLAUDE.md` (split on `## headings`) | `<rules>/<slug>.md` per section (only when `.claude/rules/` is absent) |
+| `CLAUDE.md` (no headings) | single `<rules>/<projectname>.md` (only when `.claude/rules/` is absent) |
 | `CLAUDE.md` (any form) | `.agnostic-ai/AGNOSTIC_AI.md` (byte-identical copy) |
 | `.claude/agents/*.md` | `<agents>/<name>.md` (byte-identical copy) |
 | `.claude/skills/<name>/SKILL.md` | `<skills>/<name>/SKILL.md` |
@@ -276,7 +276,7 @@ to `agnostic-ai.yaml` so future syncs skip the prompt.
 
 - **TTY:** multi-select widget (same UI as `init`'s default prompt).
 - **Piped stdin:** `echo "claude,codex" | agnostic-ai sync` selects + persists without a prompt.
-- **Non-TTY with no piped data (CI):** silent fallback — emits every configured target. CI runs keep working without changes.
+- **Non-TTY with no piped data (CI):** silent fallback. Emits every configured target. CI runs keep working without changes.
 - **Bypass:** pass `--all`, `-t`, `--only`, or `--except` to skip the picker for one run.
 
 ```bash
@@ -360,7 +360,7 @@ The `--json` output uses the same schema as `sync --json`. Actions are
 set), or `"skip"` (file was already absent).
 
 Without a prior `--backup`, `revert` becomes a no-op unless `--force`
-is also passed — protecting helper files from accidental deletion.
+is also passed. This protects helper files from accidental deletion.
 
 ## doctor
 
@@ -449,10 +449,10 @@ generated files. When no files exist yet, the timestamp is reported as `unknown`
 Generate a shell completion script and install it for your shell.
 
 ```bash
-# Bash — system-wide (may need sudo)
+# Bash, system-wide (may need sudo)
 agnostic-ai completion bash > /etc/bash_completion.d/agnostic-ai
 
-# Bash — current user only
+# Bash, current user only
 agnostic-ai completion bash > ~/.local/share/bash-completion/completions/agnostic-ai
 
 # Zsh

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -9,7 +9,7 @@
 Drop an `agnostic-ai.local.yaml` next to the base config to layer per-machine tweaks without touching the shared file. Loaded after the base and deep-merged: scalars and lists in the local file replace the base, maps merge recursively. `agnostic-ai init` adds the local filename to `.gitignore` automatically.
 
 ```yaml
-# agnostic-ai.local.yaml — never committed
+# agnostic-ai.local.yaml (never committed)
 on-unsupported: error
 outputs:
   claude:
@@ -230,7 +230,7 @@ For scripted use (CI, integration tests), pipe a comma-separated line of target 
 
     echo "claude,codex" | agnostic-ai init
 
-Unknown names produce a clear error and leave the working tree untouched. To skip the picker entirely and enable every supported target, pass `--all` (`-a`). A non-TTY stdin with no piped data falls back to the full target list silently — CI invocations keep working without flags.
+Unknown names produce a clear error and leave the working tree untouched. To skip the picker entirely and enable every supported target, pass `--all` (`-a`). A non-TTY stdin with no piped data falls back to the full target list silently. CI invocations keep working without flags.
 
 ## `sync`
 
@@ -297,7 +297,7 @@ Override per-run with `--gitignore on|off` on `sync`.
 
 ### Picking the default at `init`
 
-`agnostic-ai init` asks whether to enable the managed block when stdin is a TTY. Pick "No" (default) to commit emitted target files; pick "Yes" to treat them as build artifacts. Non-interactive runs (CI, piped stdin) skip the prompt — pass `--gitignore` to opt in:
+`agnostic-ai init` asks whether to enable the managed block when stdin is a TTY. Pick "No" (default) to commit emitted target files; pick "Yes" to treat them as build artifacts. Non-interactive runs (CI, piped stdin) skip the prompt. Pass `--gitignore` to opt in:
 
     agnostic-ai init --all --gitignore
 
@@ -418,7 +418,7 @@ outputs:
 | `justification` | no | Free-form comment emitted above the rule as a `#` line. |
 | `match` | no | Example matches rendered as commented `# match: ...` lines below the rule. Documentation only; Codex CLI ignores them. |
 
-For projects with many policies, keep them in a separate YAML file and point `exec-policies-file: ./.agnostic-ai/codex.exec-policies.yaml`. Inline entries render first, then file entries — order matters because Codex evaluates rules top-down.
+For projects with many policies, keep them in a separate YAML file and point `exec-policies-file: ./.agnostic-ai/codex.exec-policies.yaml`. Inline entries render first, then file entries. Order matters because Codex evaluates rules top-down.
 
 When you run `agnostic-ai import codex` against a project that already ships `.codex/rules/default.rules`, the import captures every `prefix_rule(...)` call into `.agnostic-ai/overlays/codex.exec-policies.yaml`. The codex emitter auto-loads that overlay when no inline list and no explicit `exec-policies-file` is set, so the round-trip is byte-content-preserving without any extra config.
 
@@ -441,7 +441,7 @@ first-class key is dropped to keep the TOML valid.
 - `agnostic-ai.yaml` (and `agnostic-ai.local.yaml` when present)
 - every directory listed under `sources` (agents, skills, rules, hooks, mcps, commands)
 - `.agnostic-ai.local/` (the project-user spec layer)
-- `.agnostic-ai/overlays/` — captured per-target settings (`claude.settings.json`, `codex.config.toml`). Hand-edit the overlay to change something the spec layer does not own (Claude `statusLine`, Codex `[profiles.*]`, …) and watch re-runs `sync` within the 50 ms debounce window.
+- `.agnostic-ai/overlays/`: captured per-target settings (`claude.settings.json`, `codex.config.toml`). Hand-edit the overlay to change something the spec layer does not own (Claude `statusLine`, Codex `[profiles.*]`, …) and watch re-runs `sync` within the 50 ms debounce window.
 
 See [`sync --watch`](cli-reference.md#sync) for the polling fallback and debounce details.
 

--- a/docs/user/errors.md
+++ b/docs/user/errors.md
@@ -34,49 +34,49 @@ Codes are stable across releases. New codes append; existing codes are never ren
 
 ## Codes
 
-### AAI-001 — Spec parse failed
+### AAI-001: Spec parse failed
 
 A spec file could not be parsed. Markdown specs use YAML frontmatter; hooks and MCPs are pure YAML. The error includes the path and (when available) line:col of the offending byte.
 
 **Fix:** open the file at the reported position. Confirm the frontmatter delimiters (`---`) wrap the metadata and that the YAML is well-formed (correct indentation, no tabs, quoted strings where needed).
 
-### AAI-002 — Spec kind not supported by target
+### AAI-002: Spec kind not supported by target
 
 A spec kind (hook, mcp, command, ...) is present in the bundle but the target adapter does not emit it. Default policy logs a warning; `on-unsupported: error` upgrades it to a hard failure.
 
 **Fix:** drop the spec, switch the target to one that supports the kind, or set `on-unsupported: warn` (or `silent`) in `agnostic-ai.yaml`.
 
-### AAI-003 — Config file missing
+### AAI-003: Config file missing
 
 Neither `agnostic-ai.yaml` nor the legacy `agnostic.config.yaml` exists in the project root.
 
 **Fix:** run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one.
 
-### AAI-004 — Config decode failed
+### AAI-004: Config decode failed
 
 The config file was found but could not be parsed as YAML, or its keys do not match the expected schema.
 
 **Fix:** validate against `docs/schemas/config.schema.json`. Check indentation and that list keys (e.g. `targets:`) hold a YAML sequence.
 
-### AAI-102 — Targets emit to the same output path
+### AAI-102: Targets emit to the same output path
 
 Two or more enabled targets would write to the same path (commonly `AGENTS.md`, shared by codex, amp, warp, opencode and zed). Last-writer-wins would mask drift.
 
 **Fix:** drop one of the colliding targets from `targets:` in `agnostic-ai.yaml`, or override the colliding path via `outputs.<target>.file`.
 
-### AAI-202 — Import source name unknown
+### AAI-202: Import source name unknown
 
 The argument passed to `agnostic-ai import` does not match any registered source.
 
 **Fix:** run `agnostic-ai import --help` for the supported list. Spelling counts.
 
-### AAI-301 — Unknown sync target
+### AAI-301: Unknown sync target
 
 A target requested via `--target`, `--only`, or the config is not a built-in adapter and no `agnostic-ai-adapter-<name>` binary is on PATH.
 
 **Fix:** check the target name spelling. Built-ins: `claude`, `codex`, `gemini`, `cursor`, `copilot`, `aider`, `cline`, `windsurf`, `continue`, `amp`, `zed`, `warp`, `opencode`, `antigravity`. External adapters live on PATH as `agnostic-ai-adapter-<name>`.
 
-### AAI-302 — Mutually exclusive flags
+### AAI-302: Mutually exclusive flags
 
 Two flags whose effects conflict were passed together (e.g. `--only` with `--except`, or `--watch` with `--check`).
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -123,8 +123,8 @@ Clear them once you are happy with `agnostic-ai cleanup`.
 `import <cli>` translates rules, agents, skills, hooks, commands, and a
 target-specific `settings.json`-style overlay into agnostic specs. Anything
 else under the target's directory (`.claude/statusline.sh`, helper scripts
-referenced from `settings.json`, ad-hoc config files) is **out of scope** —
-keep those files in git alongside `.agnostic-ai/` so they survive a fresh
+referenced from `settings.json`, ad-hoc config files) is **out of scope**.
+Keep those files in git alongside `.agnostic-ai/` so they survive a fresh
 checkout. Helper files inside a skill directory (e.g. `.claude/skills/
 yaml-validator/check.mjs`) are the exception: they round-trip via the
 nested skill layout described in [Skills](spec-format.md#skills).
@@ -136,7 +136,7 @@ JSON document recording the last sync timestamp and number of files
 changed. It is consumed by `agnostic-ai status` to surface "last sync at
 …" and by `doctor` to tell the never-synced state apart from
 post-sync-edits. The file is auto-added to the managed `.gitignore`
-block, so do not commit it. Deleting it is safe — the next `sync`
+block, so do not commit it. Deleting it is safe: the next `sync`
 regenerates it; the only effect is `status` reports "never synced" until
 that next run.
 

--- a/docs/user/graph.md
+++ b/docs/user/graph.md
@@ -81,10 +81,10 @@ One record per edge, suitable for editor extensions and scripts.
 # Default matrix view
 agnostic-ai graph
 
-# Just the claude column
+# Only the claude column
 agnostic-ai graph --target claude
 
-# Just one spec across every target
+# One spec across every target
 agnostic-ai graph --spec no-console-log
 
 # Only rule-kind edges, as JSON

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -119,7 +119,7 @@ skills/yaml-validator/SKILL.md
 skills/yaml-validator/schema.yaml
 ```
 
-Only `SKILL.md` and flat `*.md` are parsed. Other files in nested skill directories (scripts, templates, fixtures, nested subdirectories) are copied verbatim to the same relative location under each target's skills dir — useful for shipping a `check.mjs`, `templates/*.tpl`, or `fixtures/*.json` that the skill body references. Executable bits are preserved both directions through import + sync.
+Only `SKILL.md` and flat `*.md` are parsed. Other files in nested skill directories (scripts, templates, fixtures, nested subdirectories) are copied verbatim to the same relative location under each target's skills dir. This is useful for shipping a `check.mjs`, `templates/*.tpl`, or `fixtures/*.json` that the skill body references. Executable bits are preserved both directions through import + sync.
 
 ```markdown
 ---
@@ -195,7 +195,7 @@ command: "npx prettier --write \"$CLAUDE_FILE_PATHS\""
 
 When none of these fields is set the hook emits to every target that supports hooks (legacy behavior). `target` and `targets` are mutually informative; `target` takes precedence when both appear. Exclude wins: a target in both an include AND an exclude list is excluded.
 
-The same four scoping fields work on every spec kind (agents, skills, rules, commands, mcps), not just hooks. A `target: codex` agent emits only into `.codex/agents/`; a `targets-exclude: [gemini]` skill emits to every configured target except gemini.
+The same four scoping fields work on every spec kind (agents, skills, rules, commands, mcps), not only hooks. A `target: codex` agent emits only into `.codex/agents/`; a `targets-exclude: [gemini]` skill emits to every configured target except gemini.
 
 ### Per-target body fences
 
@@ -256,7 +256,7 @@ Hooks imported from a tool-native source auto-set `target` to that tool (codex i
 | `Stop` | When the model stops generating. |
 | `Notification` | When Claude Code surfaces a system notification. |
 
-Emitted natively by Claude Code (`.claude/settings.json`), Codex (`.codex/config.toml` `[[hooks.<event>]]`), and Gemini (`.gemini/settings.json` `hooks` — uses event names like `BeforeTool`/`AfterTool`). Other targets log a warning and skip. See each tool's docs for its full event list and matcher semantics.
+Emitted natively by Claude Code (`.claude/settings.json`), Codex (`.codex/config.toml` `[[hooks.<event>]]`), and Gemini (`.gemini/settings.json` `hooks`, uses event names like `BeforeTool`/`AfterTool`). Other targets log a warning and skip. See each tool's docs for its full event list and matcher semantics.
 
 ### How agnostic-ai frontmatter renders per target
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -1,6 +1,6 @@
 # Targets
 
-Each adapter emits in its tool's native format — separate files where the tool supports them, a merged document otherwise. Unsupported features (e.g. hooks for a non-hook-aware target) skip with a warning by default. Override via `on-unsupported` in [configuration](configuration.md).
+Each adapter emits in its tool's native format: separate files where the tool supports them, a merged document otherwise. Unsupported features (e.g. hooks for a non-hook-aware target) skip with a warning by default. Override via `on-unsupported` in [configuration](configuration.md).
 
 ## Entry-point files
 
@@ -53,7 +53,7 @@ event-triggered hooks. Other targets have no equivalent concept and
 skip with a warning.
 
 MCP servers propagate to every target that has a project-scoped MCP file
-(10 of 14 — see the matrix above). Aider, Cline, Windsurf, and Antigravity
+(10 of 14, see the matrix above). Aider, Cline, Windsurf, and Antigravity
 have no project-scoped MCP surface and skip with a warning.
 
 Commands are slash-prompt files authored under `commands/` and emitted to the
@@ -76,7 +76,7 @@ CLAUDE.md                # canonical entry-point pointer body (written by sync)
 .mcp.json
 ```
 
-Rules emit one file per spec under `.claude/rules/`. `CLAUDE.md` is owned by `sync` and overwritten on every run with the canonical pointer body. Reference per-rule files from `CLAUDE.md` with `@.claude/rules/<name>.md` imports — those imports survive across syncs because the pointer body lists `.claude/rules/` as the rules directory. Set `outputs.claude.rules-file: CLAUDE.md` to fall back to the legacy concatenated layout; `sync` then skips the pointer-body write for `claude`.
+Rules emit one file per spec under `.claude/rules/`. `CLAUDE.md` is owned by `sync` and overwritten on every run with the canonical pointer body. Reference per-rule files from `CLAUDE.md` with `@.claude/rules/<name>.md` imports. Those imports survive across syncs because the pointer body lists `.claude/rules/` as the rules directory. Set `outputs.claude.rules-file: CLAUDE.md` to fall back to the legacy concatenated layout; `sync` then skips the pointer-body write for `claude`.
 
 Commands emit one file per spec under `.claude/commands/`. Each command becomes a Claude Code slash command (e.g. a spec named `deploy` is invoked as `/deploy`). Frontmatter passes through; the body is the prompt template.
 
@@ -90,7 +90,7 @@ Config keys: `outputs.claude.dir` (default `.claude`), `outputs.claude.rules-dir
 
 #### Verifying with the real Claude Code CLI
 
-1. Install Claude Code: `npm install -g @anthropic-ai/claude-code` (or download the desktop app — both read the same project files).
+1. Install Claude Code: `npm install -g @anthropic-ai/claude-code` (or download the desktop app, both read the same project files).
 2. Sanity-check the emitted tree:
 
    ```bash
@@ -118,13 +118,13 @@ AGENTS.md                                    # canonical entry-point pointer bod
 .codex/config.toml                           # when hook and/or MCP entries exist
 ```
 
-Config keys: `outputs.codex.agents-dir` (default `.codex/agents` — Codex CLI's native lookup path; override to `.agents/agents` for the community shared layout), `outputs.codex.skills-dir` (default `.codex/skills` — Codex CLI's native lookup path; override to `.agents/skills` for the community shared layout), `outputs.codex.shared-subagents` (default `false` when `claude` is also in `targets` to avoid duplicating `.claude/skills/<name>/`, `true` when codex is alone; set explicitly to override), `outputs.codex.commands-dir` (default `.codex/prompts`), `outputs.codex.mcp-file` (default `.codex/config.toml` — also holds hooks), `outputs.codex.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `codex`).
+Config keys: `outputs.codex.agents-dir` (default `.codex/agents`, Codex CLI's native lookup path; override to `.agents/agents` for the community shared layout), `outputs.codex.skills-dir` (default `.codex/skills`, Codex CLI's native lookup path; override to `.agents/skills` for the community shared layout), `outputs.codex.shared-subagents` (default `false` when `claude` is also in `targets` to avoid duplicating `.claude/skills/<name>/`, `true` when codex is alone; set explicitly to override), `outputs.codex.commands-dir` (default `.codex/prompts`), `outputs.codex.mcp-file` (default `.codex/config.toml`, also holds hooks), `outputs.codex.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `codex`).
 
 The project-root `AGENTS.md` is written by `sync` with the canonical pointer body. Codex still loads rules from the spec source directory referenced in that pointer; per-directory `AGENTS.md` scoping (e.g. `src/AGENTS.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.codex.rules-file: AGENTS.md` if you need the legacy concatenated single-file layout back.
 
 Skills follow the [Codex skills layout](https://developers.openai.com/codex/skills): one folder per skill under `.agents/skills/<name>/` with a required `SKILL.md` (frontmatter `name` + `description`, plus the body). When the spec carries `x-codex.interface`, `x-codex.policy`, or `x-codex.dependencies`, an additional `agents/openai.yaml` is written in the skill folder for UI customization and policy declarations.
 
-Hooks and MCP servers both land in `.codex/config.toml`. Hook specs route by their `event` frontmatter (e.g. `SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact`, `PostCompact`) into `[[hooks.<event>]]` array-of-tables entries with `matcher` and `command`. MCP servers emit as `[mcp_servers.<name>]` tables — stdio uses `command`/`args`/`env`; HTTP/SSE uses `url`/`bearer_token_env_var`/`http_headers`. The project-tier config.toml is agnostic-ai-managed (overwritten on each sync); add unmanaged Codex config to `~/.codex/config.toml` user-global instead.
+Hooks and MCP servers both land in `.codex/config.toml`. Hook specs route by their `event` frontmatter (e.g. `SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact`, `PostCompact`) into `[[hooks.<event>]]` array-of-tables entries with `matcher` and `command`. MCP servers emit as `[mcp_servers.<name>]` tables. Stdio uses `command`/`args`/`env`; HTTP/SSE uses `url`/`bearer_token_env_var`/`http_headers`. The project-tier config.toml is agnostic-ai-managed (overwritten on each sync); add unmanaged Codex config to `~/.codex/config.toml` user-global instead.
 
 Commands emit one file per spec under `.codex/prompts/` (project-tier mirror of `~/.codex/prompts/`). Each becomes a Codex slash prompt. Frontmatter passes through; the body is the prompt template.
 
@@ -162,13 +162,13 @@ GEMINI.md                              # canonical entry-point pointer body (wri
 .gemini/settings.json                  # when MCP and/or hook entries exist (merged with any existing user config)
 ```
 
-Config keys: `outputs.gemini.commands-dir` (default `.gemini/commands`), `outputs.gemini.mcp-file` (default `.gemini/settings.json` — also holds hooks), `outputs.gemini.emit-skills-as-commands` (default `false`), `outputs.gemini.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `gemini`).
+Config keys: `outputs.gemini.commands-dir` (default `.gemini/commands`), `outputs.gemini.mcp-file` (default `.gemini/settings.json`, also holds hooks), `outputs.gemini.emit-skills-as-commands` (default `false`), `outputs.gemini.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `gemini`).
 
 The project-root `GEMINI.md` is written by `sync` with the canonical pointer body. Per-directory scoping (e.g. `src/GEMINI.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.gemini.rules-file: GEMINI.md` for the legacy concatenated single-file layout.
 
 Agents emit as TOML slash commands under `.gemini/commands/` per [Gemini CLI custom commands](https://geminicli.com/docs/cli/custom-commands/). Skills default to source-only; flip `outputs.gemini.emit-skills-as-commands: true` to emit one `.gemini/commands/skill-<name>.toml` per skill.
 
-When MCP and/or hook entries are present, the adapter writes (or updates) `.gemini/settings.json` with the `mcpServers` map and the `hooks` map. Gemini uses `httpUrl` (not `url`) for HTTP MCP servers — the adapter handles the rename automatically. Hook specs route by their `event` frontmatter (e.g. `BeforeTool`, `AfterTool`, `SessionStart`); each event entry is `{matcher, command}`. Pre-existing user-managed keys in `.gemini/settings.json` survive across syncs.
+When MCP and/or hook entries are present, the adapter writes (or updates) `.gemini/settings.json` with the `mcpServers` map and the `hooks` map. Gemini uses `httpUrl` (not `url`) for HTTP MCP servers. The adapter handles the rename automatically. Hook specs route by their `event` frontmatter (e.g. `BeforeTool`, `AfterTool`, `SessionStart`); each event entry is `{matcher, command}`. Pre-existing user-managed keys in `.gemini/settings.json` survive across syncs.
 
 #### Verifying with the real Gemini CLI
 
@@ -192,7 +192,7 @@ When MCP and/or hook entries are present, the adapter writes (or updates) `.gemi
 .cursor/commands/<name>.md           # one per agent, only when commands-dir is set
 ```
 
-Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.cursor.commands-dir` (default empty — opt-in), `outputs.cursor.mcp-file` (default `.cursor/mcp.json`).
+Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.cursor.commands-dir` (default empty, opt-in), `outputs.cursor.mcp-file` (default `.cursor/mcp.json`).
 
 Rules emit with `alwaysApply: true`; agents as rules with `alwaysApply: false`. Override in spec frontmatter.
 
@@ -227,7 +227,7 @@ When `outputs.cursor.commands-dir` is set, each agent additionally emits as a [C
 
 Config keys: `outputs.copilot.instructions-dir` (default `.github/instructions`), `outputs.copilot.mcp-file` (default `.vscode/mcp.json`), `outputs.copilot.rules-file` (unset; setting it writes the always-on rules concatenated at that path and `sync` skips the pointer-body write for `copilot`).
 
-Copilot natively supports path-scoped instructions via `applyTo:` frontmatter. Rules with a `globs` field (or a source-layout scope like `rules/backend/auth.md`) emit as a separate `.instructions.md` file with `applyTo` derived from the globs (explicit `globs` wins, else `<scope>/**`). Always-on rules (no globs, no scope, or `alwaysApply: true`) skip per-file emission — they are reachable via the canonical pointer body at `.github/copilot-instructions.md` plus the source spec dir. Agents and skills always emit as catch-all (`applyTo: "**"`) so they remain discoverable across the repo.
+Copilot natively supports path-scoped instructions via `applyTo:` frontmatter. Rules with a `globs` field (or a source-layout scope like `rules/backend/auth.md`) emit as a separate `.instructions.md` file with `applyTo` derived from the globs (explicit `globs` wins, else `<scope>/**`). Always-on rules (no globs, no scope, or `alwaysApply: true`) skip per-file emission. They are reachable via the canonical pointer body at `.github/copilot-instructions.md` plus the source spec dir. Agents and skills always emit as catch-all (`applyTo: "**"`) so they remain discoverable across the repo.
 
 The Copilot MCP file uses the VS Code schema: a top-level `servers` key with each entry carrying a `type` field (`stdio`, `http`, or `sse`).
 
@@ -253,7 +253,7 @@ CONVENTIONS.md           # canonical entry-point pointer body (written by sync)
 .aider.conf.yml          # only when conf-file is set
 ```
 
-Config keys: `outputs.aider.conf-file` (default empty — opt-in), `outputs.aider.model`, `outputs.aider.weak-model`, `outputs.aider.rules-file` (unset; setting it writes a legacy merged document at that path and `sync` skips the pointer-body write for `aider`).
+Config keys: `outputs.aider.conf-file` (default empty, opt-in), `outputs.aider.model`, `outputs.aider.weak-model`, `outputs.aider.rules-file` (unset; setting it writes a legacy merged document at that path and `sync` skips the pointer-body write for `aider`).
 
 By default the adapter only emits the conventions document and you wire it in yourself via `aider --read CONVENTIONS.md`. Set `outputs.aider.conf-file: .aider.conf.yml` to have `sync` also merge a `read:` entry into Aider's [project config](https://aider.chat/docs/config/aider_conf.html) so the file auto-loads. `model` and `weak-model` propagate into the same file when set. Pre-existing keys in the conf file are preserved; the `read:` list de-duplicates.
 
@@ -284,7 +284,7 @@ By default the adapter only emits the conventions document and you wire it in yo
 .clinerules/workflows/<name>.md      # one per agent, only when workflows-dir is set
 ```
 
-Config keys: `outputs.cline.rules-dir` (default `.clinerules`), `outputs.cline.workflows-dir` (default empty — opt-in).
+Config keys: `outputs.cline.rules-dir` (default `.clinerules`), `outputs.cline.workflows-dir` (default empty, opt-in).
 
 When `outputs.cline.workflows-dir` is set, each agent additionally emits as a [Cline Workflow](https://docs.cline.bot/features/workflows): a Markdown file invokable from chat as `/<name>.md`. The italic description prefixes the body when present. The rule-form emission (`.clinerules/agent-<name>.md`) still happens, so existing setups keep working.
 
@@ -308,7 +308,7 @@ When `outputs.cline.workflows-dir` is set, each agent additionally emits as a [C
 .windsurf/workflows/<name>.md        # one per agent, only when workflows-dir is set
 ```
 
-Config keys: `outputs.windsurf.rules-dir` (default `.windsurf/rules`), `outputs.windsurf.workflows-dir` (default empty — opt-in).
+Config keys: `outputs.windsurf.rules-dir` (default `.windsurf/rules`), `outputs.windsurf.workflows-dir` (default empty, opt-in).
 
 When `outputs.windsurf.workflows-dir` is set, each agent additionally emits as a [Windsurf Workflow](https://docs.windsurf.com/windsurf/cascade/workflows): a Markdown file with `description` frontmatter, invokable in Cascade as `/<name>`. The rule-form emission (`.windsurf/rules/agent-<name>.md`) still happens, so existing setups keep working.
 
@@ -333,7 +333,7 @@ When `outputs.windsurf.workflows-dir` is set, each agent additionally emits as a
 .continue/assistants/<name>.yaml       # one per agent, only when assistants-dir is set
 ```
 
-Config keys: `outputs.continue.rules-dir` (default `.continue/rules`), `outputs.continue.mcp-dir` (default `.continue/mcpServers`), `outputs.continue.assistants-dir` (default empty — opt-in).
+Config keys: `outputs.continue.rules-dir` (default `.continue/rules`), `outputs.continue.mcp-dir` (default `.continue/mcpServers`), `outputs.continue.assistants-dir` (default empty, opt-in).
 
 Continue picks up each YAML under `.continue/mcpServers/` as a single MCP server config. Stdio servers emit `command`/`args`/`env`; HTTP / SSE / streamable-http variants emit `type`/`url`/`headers`.
 
@@ -365,9 +365,9 @@ AGENTS.md                              # canonical entry-point pointer body (wri
 
 Config keys: `outputs.amp.commands-dir` (default `.agents/commands`), `outputs.amp.mcp-file` (default `.amp/settings.json`), `outputs.amp.emit-skills-as-commands` (default `false`), `outputs.amp.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `amp`).
 
-The project-root `AGENTS.md` is written by `sync` with the canonical pointer body — shared byte-for-byte with codex and warp so the three targets coexist at the same path with no collision.
+The project-root `AGENTS.md` is written by `sync` with the canonical pointer body, shared byte-for-byte with codex and warp so the three targets coexist at the same path with no collision.
 
-When MCP entries are present, the adapter writes (or updates) `.amp/settings.json` with the `amp.mcpServers` map (note: a single dotted key, not a nested object). Stdio servers emit `command`/`args`/`env`; HTTP/SSE emit `url`/`headers`. Pre-existing non-managed keys in `.amp/settings.json` (theme, editor settings, etc.) are preserved across syncs; only `amp.mcpServers` is overwritten. Workspace MCPs require explicit approval inside Amp the first time the project is opened — Amp's safety model is intentional.
+When MCP entries are present, the adapter writes (or updates) `.amp/settings.json` with the `amp.mcpServers` map (note: a single dotted key, not a nested object). Stdio servers emit `command`/`args`/`env`; HTTP/SSE emit `url`/`headers`. Pre-existing non-managed keys in `.amp/settings.json` (theme, editor settings, etc.) are preserved across syncs; only `amp.mcpServers` is overwritten. Workspace MCPs require explicit approval inside Amp the first time the project is opened. Amp's safety model is intentional.
 
 The adapter previously wrote `AGENT.md` (singular). Amp's owner's manual specifies `AGENTS.md` (plural); the misnamed file is retired. On first sync after upgrading, any agnostic-generated `AGENT.md` at the configured root is renamed to `AGENT.md.bak`. A user-authored `AGENT.md` (no `Generated by agnostic-ai` marker) is left untouched.
 
@@ -383,8 +383,8 @@ The adapter previously wrote `AGENT.md` (singular). Amp's owner's manual specifi
 
 3. Validate the JSON syntactically: `python -m json.tool .amp/settings.json > /dev/null`.
 4. Open the project in Amp and confirm it indexes `AGENTS.md` (Amp's left sidebar surfaces it under "Project rules"). There should be no warning about `AGENT.md.bak`.
-5. List the available slash commands inside Amp — each `.agents/commands/<name>.md` file should appear as `/<name>` with the rendered description.
-6. List configured MCP servers via Amp's MCP picker — every entry under `amp.mcpServers` in `.amp/settings.json` should appear with a green status. Workspace MCPs prompt for approval the first time; that prompt is expected, not an error.
+5. List the available slash commands inside Amp. Each `.agents/commands/<name>.md` file should appear as `/<name>` with the rendered description.
+6. List configured MCP servers via Amp's MCP picker. Every entry under `amp.mcpServers` in `.amp/settings.json` should appear with a green status. Workspace MCPs prompt for approval the first time; that prompt is expected, not an error.
 
 ### Zed (`zed`)
 
@@ -394,11 +394,11 @@ The adapter previously wrote `AGENT.md` (singular). Amp's owner's manual specifi
 .zed/tasks.json                        # one task per hook, only when tasks-file is set
 ```
 
-Config keys: `outputs.zed.file` (default `.rules`), `outputs.zed.mcp-file` (default `.zed/settings.json`), `outputs.zed.tasks-file` (default empty — opt-in).
+Config keys: `outputs.zed.file` (default `.rules`), `outputs.zed.mcp-file` (default `.zed/settings.json`), `outputs.zed.tasks-file` (default empty, opt-in).
 
-When MCP entries are present, the adapter writes (or updates) `.zed/settings.json` with the `context_servers` map (Zed's key — not `mcpServers`). Each server emits with Zed's nested `command: {path, args, env}` shape plus an empty `settings: {}`. User-managed keys (theme, buffer_font_size, etc.) are preserved across syncs.
+When MCP entries are present, the adapter writes (or updates) `.zed/settings.json` with the `context_servers` map (Zed's key, not `mcpServers`). Each server emits with Zed's nested `command: {path, args, env}` shape plus an empty `settings: {}`. User-managed keys (theme, buffer_font_size, etc.) are preserved across syncs.
 
-Zed only supports stdio transport natively. HTTP / SSE MCP entries auto-bridge through `npx mcp-remote <url>` so they still work — a one-line stderr warning fires when this fallback is taken.
+Zed only supports stdio transport natively. HTTP / SSE MCP entries auto-bridge through `npx mcp-remote <url>` so they still work. A one-line stderr warning fires when this fallback is taken.
 
 When `outputs.zed.tasks-file` is set, every hook spec emits as a [Zed Task](https://zed.dev/docs/tasks) into that JSON file. Each task uses `sh -c "<hook command>"` so arbitrary one-liners work; the hook's name is the label (with the description appended after an em-dash when present). Zed has no lifecycle-hook surface, so these tasks run on demand from the command palette rather than firing on `PreToolUse` / `PostToolUse` events.
 
@@ -414,7 +414,7 @@ When `outputs.zed.tasks-file` is set, every hook spec emits as a [Zed Task](http
    python -m json.tool .zed/tasks.json > /dev/null
    ```
 
-3. Open the project in Zed. The inline assistant reads `.rules` as additional system context — confirm a prompt sees the rule content.
+3. Open the project in Zed. The inline assistant reads `.rules` as additional system context. Confirm a prompt sees the rule content.
 4. Open the MCP picker. Each `context_servers.<name>` entry from `.zed/settings.json` should appear ready.
 5. Open the command palette and confirm every entry from `.zed/tasks.json` is runnable as a Zed Task.
 
@@ -426,13 +426,13 @@ AGENTS.md                              # canonical entry-point pointer body (wri
 .warp/.mcp.json                        # when MCP entries exist
 ```
 
-Config keys: `outputs.warp.workflows-dir` (default empty — opt-in), `outputs.warp.mcp-file` (default `.warp/.mcp.json`), `outputs.warp.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `warp`).
+Config keys: `outputs.warp.workflows-dir` (default empty, opt-in), `outputs.warp.mcp-file` (default `.warp/.mcp.json`), `outputs.warp.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `warp`).
 
-The project-root `AGENTS.md` is written by `sync` with the canonical pointer body — shared byte-for-byte with codex and amp so the three targets coexist at the same path with no collision.
+The project-root `AGENTS.md` is written by `sync` with the canonical pointer body, shared byte-for-byte with codex and amp so the three targets coexist at the same path with no collision.
 
 The adapter previously wrote `WARP.md`. Warp's current Rules docs specify `AGENTS.md` per the open AGENTS.md standard; the legacy name is retired. On first sync after upgrading, any agnostic-generated `WARP.md` at the configured root is renamed to `WARP.md.bak`. A user-authored `WARP.md` (no `Generated by agnostic-ai` marker) is left untouched.
 
-When `outputs.warp.workflows-dir` is set, each agent emits as a [Warp Workflow](https://docs.warp.dev/features/warp-drive/workflows) YAML at `<dir>/<name>.yaml` (`name`/`command`/`description`/`tags`). The workflow `command:` is the agent body verbatim — tailor it to a Warp-friendly shell snippet from there.
+When `outputs.warp.workflows-dir` is set, each agent emits as a [Warp Workflow](https://docs.warp.dev/features/warp-drive/workflows) YAML at `<dir>/<name>.yaml` (`name`/`command`/`description`/`tags`). The workflow `command:` is the agent body verbatim. Tailor it to a Warp-friendly shell snippet from there.
 
 #### Verifying with the real Warp terminal
 
@@ -461,9 +461,9 @@ opencode.json                             # when MCP entries exist (merged with 
 
 Config keys: `outputs.opencode.commands-dir` (default `.opencode/commands`), `outputs.opencode.mcp-file` (default `opencode.json`), `outputs.opencode.emit-skills-as-commands` (default `false`), `outputs.opencode.rules-file` (unset; setting it writes a legacy concatenated rules document at that path and `sync` skips the pointer-body write for `opencode`).
 
-When MCP entries are present, the adapter writes (or updates) `opencode.json` at the project root with a `$schema` link and the `mcp` map. Stdio servers map to `{type: "local", command: [...]}`; HTTP/SSE/remote servers map to `{type: "remote", url, headers}`. Any pre-existing non-managed keys (`theme`, `model`, etc.) are preserved across syncs; only `$schema` and `mcp` are overwritten. Note: drift checks (`sync --check`) read in capture mode and skip the read step, so unrelated user keys may be reported as drift until the next non-check sync — this is by design.
+When MCP entries are present, the adapter writes (or updates) `opencode.json` at the project root with a `$schema` link and the `mcp` map. Stdio servers map to `{type: "local", command: [...]}`; HTTP/SSE/remote servers map to `{type: "remote", url, headers}`. Any pre-existing non-managed keys (`theme`, `model`, etc.) are preserved across syncs; only `$schema` and `mcp` are overwritten. Note: drift checks (`sync --check`) read in capture mode and skip the read step, so unrelated user keys may be reported as drift until the next non-check sync. This is by design.
 
-Routed under `.opencode/` rather than the repo root to avoid clashing with Codex's `AGENTS.md`. Each command file carries frontmatter filtered to the OpenCode-supported keys (`description`, `agent`, `model`, `subtask`) — pass `agent`, `model`, or `subtask` through the `x-opencode` namespace in your spec frontmatter to route them into the command file without polluting other targets.
+Routed under `.opencode/` rather than the repo root to avoid clashing with Codex's `AGENTS.md`. Each command file carries frontmatter filtered to the OpenCode-supported keys (`description`, `agent`, `model`, `subtask`). Pass `agent`, `model`, or `subtask` through the `x-opencode` namespace in your spec frontmatter to route them into the command file without polluting other targets.
 
 #### Verifying with the real OpenCode CLI
 
@@ -477,7 +477,7 @@ Routed under `.opencode/` rather than the repo root to avoid clashing with Codex
    ```
 
 3. Launch OpenCode in the project (`opencode`). Confirm every `.opencode/commands/<name>.md` appears in the slash-command picker with the rendered description.
-4. Confirm `opencode.json` MCP servers load by inspecting OpenCode's MCP panel — each `mcp.<name>` entry should show ready.
+4. Confirm `opencode.json` MCP servers load by inspecting OpenCode's MCP panel. Each `mcp.<name>` entry should show ready.
 
 ### Google Antigravity (`antigravity`)
 
@@ -503,7 +503,7 @@ Skills, hooks, MCPs, and commands are not yet confirmed in the Antigravity publi
    head -1 .agent/rules/*.md  # every rule + agent file must start with the provenance header
    ```
 
-3. Open the project in Antigravity and confirm it surfaces `.agent/AGENTS.md` in the project-instructions panel — the canonical pointer body should appear without "unrecognized file" warnings.
+3. Open the project in Antigravity and confirm it surfaces `.agent/AGENTS.md` in the project-instructions panel. The canonical pointer body should appear without "unrecognized file" warnings.
 4. Open one of `.agent/rules/<name>.md` from inside Antigravity and verify the per-rule file is also picked up.
 5. Trigger an agent action (e.g. ask for a refactor) and confirm the rules apply in the response. There should be no schema-validation log entries referencing `.agent/`.
 


### PR DESCRIPTION
Brings docs into compliance with the project plain-english style rule.

## Changes

- Replaced **105 prose em-dashes** across 15 files with period / comma / colon / parentheses, whichever reads best.
- Split run-on sentences (one idea per sentence).
- Dropped filler words (`just`, `actually`) from example comments.

## Preserved

- Code blocks, inline `code`, YAML/TOML/JSON, tables, links, command output untouched.
- One em-dash kept at `docs/user/cli-reference.md:243`: it documents the literal `sync --dry-run` output format `# target: <name> — <output path>`, which the tool prints with an em-dash (`internal/cli/render.go:66`).

Punctuation and wording only. No technical meaning, paths, flag names, target names, or defaults changed. Balanced diff (107/107) confirms substitution-level edits.

Done as a fan-out: one agent per file group, each with strict preserve-meaning constraints, then a manual final gate (`grep` for em-dashes + filler).