### PR TITLE
test: skip exec-bit restore test on Windows

### DIFF
--- a/internal/adapters/internal/emit/helper_files_test.go
+++ b/internal/adapters/internal/emit/helper_files_test.go
@@ -3,6 +3,7 @@ package emit
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -47,6 +48,9 @@ func TestRestoreHelperFiles_IsRecorded(t *testing.T) {
 // TestRestoreHelperFiles_PreservesMode keeps an executable overlay helper
 // (e.g. a hook script) executable after restore.
 func TestRestoreHelperFiles_PreservesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support the unix executable bit")
+	}
 	dir := t.TempDir()
 	chdirHelper(t, dir)
 


### PR DESCRIPTION
## Why

Main CI failed on `windows-latest`: `TestRestoreHelperFiles_PreservesMode` asserts the executable bit survives an overlay helper restore. Windows has no unix mode bits, so the restored file reports `-rw-rw-rw-` and the assertion fails.

## Change

Skip the test on Windows via `runtime.GOOS == "windows"`. Unix coverage is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)