### PR TITLE
feat(codex): emit arbitrary x-codex keys into SKILL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ## [Unreleased]
 
+### Added
+
+- Codex skills now emit arbitrary custom keys declared under `x-codex` into `SKILL.md` frontmatter (keys other than `interface`/`policy`/`dependencies`, which still route to `openai.yaml`). Custom keys stay scoped to their target and never leak across adapters. [#367](https://github.com/Chemaclass/agnostic-ai/issues/367)
+
 ### Changed
 
 - Docs: simplified `README.md` and every `docs/user/` and `docs/internal/` page. Same facts, fewer words, plain English. Added a one-line entry-style convention to `CHANGELOG.md`.

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -406,3 +406,9 @@ Resolution per target:
 | `gemini` | `name`, `description`, `model` |
 
 For Codex agents, `x-codex` fields (`model`, `model_reasoning_effort`, `sandbox_mode`, `nickname_candidates`) pass through to the generated `.agents/agents/<name>.toml`. For Codex skills, `x-codex.interface`, `x-codex.policy`, and `x-codex.dependencies` trigger an additional `.agents/skills/<name>/agents/openai.yaml` for UI customization, policy, and tool dependencies.
+
+### Arbitrary custom keys
+
+Any other key under `x-<target>` is emitted verbatim into that target's frontmatter when the target has one. Example: `x-claude.disable-model-invocation: true` reaches the Claude `SKILL.md`; `x-codex.some-key: manual` reaches the Codex `SKILL.md` (Codex routes only `interface`/`policy`/`dependencies` to `openai.yaml`, everything else lands in `SKILL.md`). The key is yours to validate against the target's schema.
+
+Targets with no frontmatter surface for that spec kind (for example Gemini skills, emitted as TOML commands) drop arbitrary custom keys. The key never leaks across targets either way.

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -130,6 +130,37 @@ func TestEmit_PreservesArbitrarySkillFrontmatter(t *testing.T) {
 	}
 }
 
+// A custom key declared under x-claude reaches the emitted SKILL.md and
+// stays scoped to Claude (other targets drop it). Guards the #367
+// passthrough contract on the Claude side, where it already works via
+// ResolveMetaOrdered flattening.
+func TestEmit_CustomXClaudeKeyReachesSkillFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{{
+		Kind: spec.KindSkill,
+		Name: "validator",
+		Body: "skill body",
+		Meta: map[string]any{
+			"description": "validate stuff",
+			"x-claude": map[string]any{
+				"disable-model-invocation": true,
+			},
+		},
+	}}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".claude/skills/validator/SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); !strings.Contains(got, "disable-model-invocation: true") {
+		t.Errorf("SKILL.md missing x-claude custom key in:\n%s", got)
+	}
+}
+
 func TestEmit_PropagatesSkillAssets(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/adapters/codex/codex_test.go
+++ b/internal/adapters/codex/codex_test.go
@@ -347,6 +347,45 @@ func TestEmit_SkillFolder_OpenAIYAMLFromXCodex(t *testing.T) {
 	}
 }
 
+// A custom key under x-codex that is not routed to agents/openai.yaml
+// (interface/policy/dependencies) lands in SKILL.md frontmatter so a
+// spec can declare Codex-specific metadata the published schema does not
+// cover. Keys routed to openai.yaml and shared top-level keys stay out of
+// SKILL.md. See #367.
+func TestEmit_SkillFolder_CustomXCodexKeyReachesFrontmatter(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindSkill, Name: "yaml-validator",
+			Path: "skills/yaml-validator.md",
+			Body: "Validate YAML files.",
+			Meta: map[string]any{
+				"description": "Validate YAML.",
+				"globs":       "src/**",
+				"x-codex": map[string]any{
+					"some-codex-key": "manual",
+					"interface": map[string]any{
+						"display_name": "YAML Validator",
+					},
+				},
+			}},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".codex/skills/yaml-validator/SKILL.md"))
+	if !strings.Contains(got, "some-codex-key: manual") {
+		t.Errorf("SKILL.md missing custom x-codex key in:\n%s", got)
+	}
+	// interface routes to openai.yaml; shared top-level globs stays stripped.
+	if strings.Contains(got, "interface:") {
+		t.Errorf("SKILL.md must not carry openai.yaml-routed key:\n%s", got)
+	}
+	if strings.Contains(got, "globs:") {
+		t.Errorf("SKILL.md must not leak shared top-level key:\n%s", got)
+	}
+}
+
 func TestEmit_SkillFolder_NoOpenAIYAMLWithoutExtras(t *testing.T) {
 	dir := testutil.TempCwd(t)
 

--- a/internal/adapters/codex/skill.go
+++ b/internal/adapters/codex/skill.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -76,15 +77,48 @@ func skillMarkdown(s spec.Entry) string {
 	if desc == "" {
 		desc = s.Name
 	}
-	front := emit.FrontmatterOrdered(map[string]any{
+	meta := map[string]any{
 		"name":        s.Name,
 		"description": desc,
-	}, []string{"name", "description"})
+	}
+	keys := []string{"name", "description"}
+	// Pass through arbitrary x-codex keys the published schema does not
+	// cover. The spec author opts in by declaring them under x-codex, so
+	// SKILL.md stays valid for plain specs (shared top-level keys remain
+	// stripped) while custom keys still reach Codex. Keys routed to
+	// agents/openai.yaml (interface/policy/dependencies) are excluded
+	// here so they are not emitted twice. See #367.
+	if x, ok := s.Meta["x-codex"].(map[string]any); ok {
+		for _, k := range customSkillKeys(x) {
+			meta[k] = x[k]
+			keys = append(keys, k)
+		}
+	}
+	front := emit.FrontmatterOrdered(meta, keys)
 	body := strings.TrimSpace(s.Body)
 	if body == "" {
 		return front + "\n"
 	}
 	return front + "\n" + body + "\n"
+}
+
+// customSkillKeys returns the x-codex keys that belong in SKILL.md
+// frontmatter: everything except the fields already emitted by hand
+// (name/description) and the fields routed to agents/openai.yaml. The
+// result is sorted so emission stays deterministic across runs.
+func customSkillKeys(x map[string]any) []string {
+	skip := map[string]bool{"name": true, "description": true}
+	for _, k := range openaiYAMLKeys {
+		skip[k] = true
+	}
+	out := make([]string, 0, len(x))
+	for k := range x {
+		if !skip[k] {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // openaiYAML returns the YAML body for the optional agents/openai.yaml

--- a/internal/adapters/gemini/gemini_test.go
+++ b/internal/adapters/gemini/gemini_test.go
@@ -132,6 +132,38 @@ func TestEmit_Skill_EmitsAsCommand_WhenOptIn(t *testing.T) {
 	}
 }
 
+// Gemini has no skill frontmatter surface: its command TOML carries only
+// description + prompt. Custom keys declared under x-codex (or any other
+// target) must not leak into Gemini output. Guards the #367 "absent from
+// all others" contract on a non-frontmatter target.
+func TestEmit_Skill_DropsForeignCustomKeys(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"gemini": {EmitSkillsAsCommands: true},
+		},
+	}
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "yaml-validator",
+			Meta: map[string]any{
+				"description": "Validate YAML.",
+				"x-codex":     map[string]any{"some-codex-key": "manual"},
+			},
+			Body: "Validate against schema.",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	toml := readFile(t, filepath.Join(dir, ".gemini/commands/skill-yaml-validator.toml"))
+	if strings.Contains(toml, "some-codex-key") || strings.Contains(toml, "x-codex") {
+		t.Errorf("gemini output leaked foreign custom key:\n%s", toml)
+	}
+}
+
 func TestEmit_CommandsDirOverride(t *testing.T) {
 	dir := testutil.TempCwd(t)
 


### PR DESCRIPTION
## Summary
- Codex `SKILL.md` frontmatter was hardcoded to `name`+`description`, silently dropping any custom key under `x-codex`. Now passes through arbitrary `x-codex` keys (those not routed to `agents/openai.yaml`) into `SKILL.md`, scoped to the target.
- Closes the cross-adapter inconsistency: only Claude honored arbitrary `x-<target>` keys (via `ResolveMetaOrdered` flatten); Codex now does too.
- Targets with no frontmatter surface for a spec kind (e.g. Gemini skills as TOML commands) drop the keys; nothing leaks across targets.

## Behavior
- `x-codex.some-key: manual` → emitted in `SKILL.md`.
- `x-codex.interface/policy/dependencies` → still route to `agents/openai.yaml` only (unchanged).
- Shared top-level keys (e.g. `globs`) stay stripped from Codex output, so plain specs remain schema-valid. The author opts in by declaring under `x-codex`.

## Tests
- Codex: custom `x-codex` key reaches `SKILL.md`; routed keys and shared top-level keys stay out.
- Claude: `x-claude` custom key reaches `SKILL.md` (regression guard).
- Gemini (non-frontmatter target): foreign custom key absent from output.

## Notes
- Final `ref(...)` review surfaced zero changes: the new code has no duplication, deterministic sorted emission, and honors adapter-pattern / no-cross-adapter-imports / error-wrapping / go-style rules. No polish commit needed.

## Test plan
- [x] `go test ./...` (1096 passed)
- [x] `agnostic-ai sync --check` (round-trip clean, exit 0)

Closes #367