### PR TITLE
feat(adapters): pass arbitrary x-<target> keys to every target surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
-- Codex skills now emit arbitrary custom keys declared under `x-codex` into `SKILL.md` frontmatter (keys other than `interface`/`policy`/`dependencies`, which still route to `openai.yaml`). Custom keys stay scoped to their target and never leak across adapters. [#367](https://github.com/Chemaclass/agnostic-ai/issues/367)
+- Arbitrary custom keys declared under `x-<target>` now reach every target that has an output surface: Claude/Codex `SKILL.md`, Copilot `.instructions.md`, OpenCode and Amp command frontmatter, and Gemini command TOML (scalars and string arrays). Keys stay scoped to their target, emit in sorted order, and never leak across adapters. [#367](https://github.com/Chemaclass/agnostic-ai/issues/367)
 
 ### Changed
 

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -409,6 +409,17 @@ For Codex agents, `x-codex` fields (`model`, `model_reasoning_effort`, `sandbox_
 
 ### Arbitrary custom keys
 
-Any other key under `x-<target>` is emitted verbatim into that target's frontmatter when the target has one. Example: `x-claude.disable-model-invocation: true` reaches the Claude `SKILL.md`; `x-codex.some-key: manual` reaches the Codex `SKILL.md` (Codex routes only `interface`/`policy`/`dependencies` to `openai.yaml`, everything else lands in `SKILL.md`). The key is yours to validate against the target's schema.
+Any other key under `x-<target>` emits verbatim into that target's output surface. Declaring it under `x-<target>` is the opt-in: shared top-level keys stay stripped, so plain specs keep emitting valid files. Keys emit in sorted order and never leak across targets. Validate them against the target's schema yourself.
 
-Targets with no frontmatter surface for that spec kind (for example Gemini skills, emitted as TOML commands) drop arbitrary custom keys. The key never leaks across targets either way.
+Per surface:
+
+| Target | Surface | Custom key lands in |
+|--------|---------|---------------------|
+| `claude` | `SKILL.md` frontmatter | every `x-claude` key (e.g. `disable-model-invocation: true`) |
+| `codex` | `SKILL.md` frontmatter | every `x-codex` key except `interface`/`policy`/`dependencies` (those route to `openai.yaml`) |
+| `copilot` | `.instructions.md` frontmatter | every `x-copilot` key, alongside `applyTo` |
+| `opencode` | command `.md` frontmatter | every `x-opencode` key beyond `description`/`agent`/`model`/`subtask` (skills-as-commands) |
+| `amp` | command `.md` frontmatter | every `x-amp` key beyond `description` (skills-as-commands) |
+| `gemini` | command `.toml` | every `x-gemini` key (string, bool, number, or string array; skills-as-commands) |
+
+Targets that emit no surface for a spec kind drop arbitrary custom keys. Gemini TOML accepts scalars and string arrays only; nested tables are skipped.

--- a/internal/adapters/amp/amp.go
+++ b/internal/adapters/amp/amp.go
@@ -158,11 +158,16 @@ func buildMCPEntry(e spec.Entry) map[string]any {
 func commandFile(e spec.Entry) string {
 	meta := emit.ResolveMeta(e.Meta, target)
 	front := map[string]any{}
+	keys := []string{}
 	if d, _ := meta["description"].(string); d != "" {
 		front["description"] = d
+		keys = append(keys, "description")
 	}
+	// Pass through arbitrary x-amp keys beyond description so a target
+	// scoped custom key reaches the command frontmatter. See #367.
+	emit.MergeCustomTargetMeta(front, &keys, e.Meta, target, "description")
 	var sb strings.Builder
-	sb.WriteString(emit.Frontmatter(front))
+	sb.WriteString(emit.FrontmatterOrdered(front, keys))
 	sb.WriteString("\n")
 	sb.WriteString(e.Body)
 	return sb.String()

--- a/internal/adapters/amp/amp_test.go
+++ b/internal/adapters/amp/amp_test.go
@@ -125,6 +125,40 @@ func TestEmit_Skill_EmitsCommand_WhenOptIn(t *testing.T) {
 	}
 }
 
+// A custom key under x-amp reaches the command frontmatter; shared
+// top-level keys stay stripped. See #367.
+func TestEmit_Skill_CustomXAmpKeyReachesFrontmatter(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"amp": {EmitSkillsAsCommands: true},
+		},
+	}
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "yaml-validator",
+			Meta: map[string]any{
+				"description": "Validate YAML.",
+				"globs":       "src/**",
+				"x-amp":       map[string]any{"some-amp-key": "manual"},
+			},
+			Body: "Validate against schema.",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	cmd := readFile(t, filepath.Join(dir, ".agents/commands/skill-yaml-validator.md"))
+	if !strings.Contains(cmd, "some-amp-key: manual") {
+		t.Errorf("missing custom x-amp key in %s", cmd)
+	}
+	if strings.Contains(cmd, "globs:") {
+		t.Errorf("shared top-level key leaked into %s", cmd)
+	}
+}
+
 // A pre-existing AGENT.md with our provenance marker is renamed to
 // AGENT.md.bak and the user is warned.
 func TestEmit_MigratesLegacyAGENTMd_WhenAgnosticGenerated(t *testing.T) {

--- a/internal/adapters/codex/skill.go
+++ b/internal/adapters/codex/skill.go
@@ -2,7 +2,6 @@ package codex
 
 import (
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -85,40 +84,17 @@ func skillMarkdown(s spec.Entry) string {
 	// Pass through arbitrary x-codex keys the published schema does not
 	// cover. The spec author opts in by declaring them under x-codex, so
 	// SKILL.md stays valid for plain specs (shared top-level keys remain
-	// stripped) while custom keys still reach Codex. Keys routed to
-	// agents/openai.yaml (interface/policy/dependencies) are excluded
-	// here so they are not emitted twice. See #367.
-	if x, ok := s.Meta["x-codex"].(map[string]any); ok {
-		for _, k := range customSkillKeys(x) {
-			meta[k] = x[k]
-			keys = append(keys, k)
-		}
-	}
+	// stripped) while custom keys still reach Codex. The hand-emitted
+	// name/description and the keys routed to agents/openai.yaml are
+	// excluded so nothing is emitted twice. See #367.
+	exclude := append([]string{"name", "description"}, openaiYAMLKeys...)
+	emit.MergeCustomTargetMeta(meta, &keys, s.Meta, target, exclude...)
 	front := emit.FrontmatterOrdered(meta, keys)
 	body := strings.TrimSpace(s.Body)
 	if body == "" {
 		return front + "\n"
 	}
 	return front + "\n" + body + "\n"
-}
-
-// customSkillKeys returns the x-codex keys that belong in SKILL.md
-// frontmatter: everything except the fields already emitted by hand
-// (name/description) and the fields routed to agents/openai.yaml. The
-// result is sorted so emission stays deterministic across runs.
-func customSkillKeys(x map[string]any) []string {
-	skip := map[string]bool{"name": true, "description": true}
-	for _, k := range openaiYAMLKeys {
-		skip[k] = true
-	}
-	out := make([]string, 0, len(x))
-	for k := range x {
-		if !skip[k] {
-			out = append(out, k)
-		}
-	}
-	sort.Strings(out)
-	return out
 }
 
 // openaiYAML returns the YAML body for the optional agents/openai.yaml

--- a/internal/adapters/copilot/copilot.go
+++ b/internal/adapters/copilot/copilot.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
@@ -222,10 +224,16 @@ func applyToFor(e spec.Entry) string {
 // `applyTo:` frontmatter, an italic description (when present), and
 // the spec body.
 func renderInstruction(e spec.Entry, applyTo string) string {
+	front := map[string]any{"applyTo": applyTo}
+	keys := []string{"applyTo"}
+	// applyTo stays double-quoted (its glob can start with `*`, which a
+	// plain scalar cannot). Forcing the source style keeps existing files
+	// byte-identical while custom x-copilot keys append below it. See #367.
+	styles := map[string]yaml.Style{"applyTo": yaml.DoubleQuotedStyle}
+	emit.MergeCustomTargetMeta(front, &keys, e.Meta, target, "applyTo")
 	var b strings.Builder
-	b.WriteString("---\n")
-	b.WriteString("applyTo: \"" + applyTo + "\"\n")
-	b.WriteString("---\n\n")
+	b.WriteString(emit.FrontmatterStyled(front, keys, styles))
+	b.WriteString("\n")
 	if d := e.Description(); d != "" {
 		b.WriteString("_" + d + "_\n\n")
 	}

--- a/internal/adapters/copilot/copilot_test.go
+++ b/internal/adapters/copilot/copilot_test.go
@@ -152,6 +152,38 @@ func TestEmit_Skill_WritesSkillPrefixedInstruction(t *testing.T) {
 	}
 }
 
+// A custom key under x-copilot reaches the instruction frontmatter
+// alongside applyTo (which stays double-quoted). See #367.
+func TestEmit_Skill_CustomXCopilotKeyReachesFrontmatter(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "yaml-validator",
+			Path: "skills/yaml-validator.md",
+			Meta: map[string]any{
+				"globs":     "src/**",
+				"x-copilot": map[string]any{"some-copilot-key": "manual"},
+			},
+			Body: "Validate YAML with the schema.",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".github/instructions/skill-yaml-validator.instructions.md"))
+	if !strings.Contains(got, "applyTo: \"**\"") {
+		t.Errorf("instruction lost double-quoted applyTo: %s", got)
+	}
+	if !strings.Contains(got, "some-copilot-key: manual") {
+		t.Errorf("missing custom x-copilot key in %s", got)
+	}
+	if strings.Contains(got, "globs:") {
+		t.Errorf("shared top-level key leaked into %s", got)
+	}
+}
+
 // A rule with no globs but a scope from source layout derives applyTo
 // from the scope (so rules/backend/*.md auto-target backend/**).
 func TestEmit_RuleWithScope_DerivesApplyToFromScope(t *testing.T) {

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -237,13 +237,23 @@ func emitSkillCommands(skills []spec.Entry, dir string, dryRun bool) error {
 // commandTOML renders one slash-command TOML. Schema:
 //
 //	description = "<spec description>"
+//	<custom x-gemini scalar/array keys>
 //	prompt = """
 //	<spec body>
 //	"""
+//
+// Gemini commands have no other native frontmatter surface, so arbitrary
+// keys declared under `x-gemini` are emitted verbatim between description
+// and prompt (sorted, target-scoped). See #367.
 func commandTOML(e spec.Entry) string {
 	var sb strings.Builder
 	if d := e.Description(); d != "" {
 		emit.WriteTOMLString(&sb, "description", d)
+	}
+	if cm, keys := emit.CustomTargetMeta(e.Meta, target, "description", "prompt"); cm != nil {
+		for _, k := range keys {
+			emit.WriteTOMLValue(&sb, k, cm[k])
+		}
 	}
 	body := strings.TrimSpace(e.Body)
 	if body == "" {

--- a/internal/adapters/gemini/gemini_test.go
+++ b/internal/adapters/gemini/gemini_test.go
@@ -132,6 +132,51 @@ func TestEmit_Skill_EmitsAsCommand_WhenOptIn(t *testing.T) {
 	}
 }
 
+// Arbitrary x-gemini keys (string, bool, array) emit into the command
+// TOML with the right typed representation; shared top-level keys and
+// the hand-emitted description/prompt are not duplicated. See #367.
+func TestEmit_Skill_CustomXGeminiKeysReachTOML(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"gemini": {EmitSkillsAsCommands: true},
+		},
+	}
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "yaml-validator",
+			Meta: map[string]any{
+				"description": "Validate YAML.",
+				"globs":       "src/**",
+				"x-gemini": map[string]any{
+					"some-key": "manual",
+					"hidden":   true,
+					"tags":     []any{"a", "b"},
+				},
+			},
+			Body: "Validate against schema.",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	toml := readFile(t, filepath.Join(dir, ".gemini/commands/skill-yaml-validator.toml"))
+	for _, want := range []string{
+		`some-key = "manual"`,
+		"hidden = true",
+		`tags = ["a", "b"]`,
+	} {
+		if !strings.Contains(toml, want) {
+			t.Errorf("missing %q in %s", want, toml)
+		}
+	}
+	if strings.Contains(toml, "globs") {
+		t.Errorf("shared top-level key leaked into %s", toml)
+	}
+}
+
 // Gemini has no skill frontmatter surface: its command TOML carries only
 // description + prompt. Custom keys declared under x-codex (or any other
 // target) must not leak into Gemini output. Guards the #367 "absent from

--- a/internal/adapters/internal/emit/meta.go
+++ b/internal/adapters/internal/emit/meta.go
@@ -1,6 +1,9 @@
 package emit
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // XPrefix is the namespace for target-specific frontmatter extensions.
 // Keys named `x-<target>` carry fields that only the named adapter
@@ -54,6 +57,58 @@ func StringMap(v any) map[string]string {
 		}
 	}
 	return out
+}
+
+// CustomTargetMeta returns the entries under `x-<target>` that an adapter
+// should emit verbatim, minus the keys it already handles itself (passed
+// via exclude: fields it emits by hand or routes to another file). It
+// returns the value map plus a sorted key order so emission stays
+// deterministic across runs. Returns nil, nil when the `x-<target>` block
+// is absent or empty.
+//
+// Adapters whose output surface only accepts a fixed key set (Codex
+// SKILL.md, Gemini/OpenCode/Amp commands, Copilot instructions) use this
+// to honor arbitrary author-declared keys without leaking shared
+// top-level keys, so a plain spec stays valid while a target-scoped
+// custom key still reaches its target. See #367.
+func CustomTargetMeta(meta map[string]any, target string, exclude ...string) (map[string]any, []string) {
+	x, ok := meta[XPrefix+target].(map[string]any)
+	if !ok || len(x) == 0 {
+		return nil, nil
+	}
+	skip := make(map[string]bool, len(exclude))
+	for _, k := range exclude {
+		skip[k] = true
+	}
+	out := make(map[string]any, len(x))
+	keys := make([]string, 0, len(x))
+	for k, v := range x {
+		// nil mirrors the delete-marker convention (see ResolveMetaOrdered):
+		// there is nothing to emit, so drop it rather than write a null.
+		if skip[k] || v == nil {
+			continue
+		}
+		out[k] = v
+		keys = append(keys, k)
+	}
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	sort.Strings(keys)
+	return out, keys
+}
+
+// MergeCustomTargetMeta appends the custom `x-<target>` keys onto an
+// existing frontmatter map and its key-order slice, skipping `exclude`.
+// It is the YAML-frontmatter counterpart to CustomTargetMeta for adapters
+// that build a `map[string]any`; TOML adapters call CustomTargetMeta
+// directly. See #367.
+func MergeCustomTargetMeta(front map[string]any, keys *[]string, meta map[string]any, target string, exclude ...string) {
+	cm, ck := CustomTargetMeta(meta, target, exclude...)
+	for _, k := range ck {
+		front[k] = cm[k]
+		*keys = append(*keys, k)
+	}
 }
 
 // ResolveMeta returns a copy of meta with target-specific keys flattened

--- a/internal/adapters/internal/emit/meta_test.go
+++ b/internal/adapters/internal/emit/meta_test.go
@@ -21,6 +21,41 @@ func TestResolveMeta_DropsOtherTargets(t *testing.T) {
 	}
 }
 
+func TestCustomTargetMeta_ReturnsSortedNonExcludedKeys(t *testing.T) {
+	in := map[string]any{
+		"description": "top-level wins",
+		"x-codex": map[string]any{
+			"name":        "ignored",
+			"description": "ignored",
+			"interface":   map[string]any{"display_name": "X"},
+			"zebra":       "z",
+			"alpha":       "a",
+		},
+	}
+	got, keys := CustomTargetMeta(in, "codex", "name", "description", "interface")
+	wantKeys := []string{"alpha", "zebra"}
+	if !reflect.DeepEqual(keys, wantKeys) {
+		t.Fatalf("keys = %#v, want %#v", keys, wantKeys)
+	}
+	want := map[string]any{"alpha": "a", "zebra": "z"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestCustomTargetMeta_AbsentOrEmptyReturnsNil(t *testing.T) {
+	for _, in := range []map[string]any{
+		{"name": "r1"},
+		{"x-codex": map[string]any{}},
+		{"x-codex": map[string]any{"only": nil}}, // nil is a non-value
+	} {
+		got, keys := CustomTargetMeta(in, "codex", "name")
+		if got != nil || keys != nil {
+			t.Errorf("CustomTargetMeta(%#v) = %#v, %#v; want nil, nil", in, got, keys)
+		}
+	}
+}
+
 func TestResolveMeta_TargetOverridesTopLevel(t *testing.T) {
 	in := map[string]any{
 		"name":     "r1",

--- a/internal/adapters/internal/emit/toml.go
+++ b/internal/adapters/internal/emit/toml.go
@@ -3,6 +3,7 @@ package emit
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -62,6 +63,38 @@ func WriteTOMLInlineStringTable(sb *strings.Builder, key string, m map[string]st
 		sb.WriteString(k + " = \"" + EscapeTOMLBasic(m[k]) + "\"")
 	}
 	sb.WriteString(" }\n")
+}
+
+// WriteTOMLValue writes `key = <value>`, picking the TOML form from v's
+// dynamic type: string, bool, integers, float64, and string slices
+// ([]string or a []any whose elements are all strings). Unsupported
+// types (nested tables, mixed-type arrays) are skipped and the function
+// returns false, so a caller passing arbitrary author metadata never
+// emits malformed TOML.
+func WriteTOMLValue(sb *strings.Builder, key string, v any) bool {
+	switch t := v.(type) {
+	case string:
+		WriteTOMLString(sb, key, t)
+	case bool:
+		fmt.Fprintf(sb, "%s = %t\n", key, t)
+	case int:
+		fmt.Fprintf(sb, "%s = %d\n", key, t)
+	case int64:
+		fmt.Fprintf(sb, "%s = %d\n", key, t)
+	case float64:
+		fmt.Fprintf(sb, "%s = %s\n", key, strconv.FormatFloat(t, 'f', -1, 64))
+	case []string:
+		WriteTOMLStringArray(sb, key, t)
+	case []any:
+		ss := StringSlice(t)
+		if len(ss) != len(t) {
+			return false // a non-string element: skip the whole array
+		}
+		WriteTOMLStringArray(sb, key, ss)
+	default:
+		return false
+	}
+	return true
 }
 
 // EscapeTOMLBasic escapes the two characters that can break out of a

--- a/internal/adapters/internal/emit/toml_test.go
+++ b/internal/adapters/internal/emit/toml_test.go
@@ -50,6 +50,49 @@ func TestWriteTOMLStringArray(t *testing.T) {
 	}
 }
 
+func TestWriteTOMLValue_TypedScalarsAndArrays(t *testing.T) {
+	cases := []struct {
+		name string
+		v    any
+		want string
+	}{
+		{"string", "manual", `k = "manual"` + "\n"},
+		{"bool", true, "k = true\n"},
+		{"int", 7, "k = 7\n"},
+		{"int64", int64(9), "k = 9\n"},
+		{"float", 1.5, "k = 1.5\n"},
+		{"stringSlice", []string{"a", "b"}, `k = ["a", "b"]` + "\n"},
+		{"anySlice", []any{"a", "b"}, `k = ["a", "b"]` + "\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var sb strings.Builder
+			if !WriteTOMLValue(&sb, "k", c.v) {
+				t.Fatalf("WriteTOMLValue returned false for %#v", c.v)
+			}
+			if got := sb.String(); got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestWriteTOMLValue_SkipsUnsupported(t *testing.T) {
+	for _, v := range []any{
+		map[string]any{"nested": "table"},
+		[]any{"a", 1}, // mixed-type array
+		nil,
+	} {
+		var sb strings.Builder
+		if WriteTOMLValue(&sb, "k", v) {
+			t.Errorf("expected skip for %#v, wrote %q", v, sb.String())
+		}
+		if sb.Len() != 0 {
+			t.Errorf("wrote output for skipped %#v: %q", v, sb.String())
+		}
+	}
+}
+
 func TestEscapeTOMLBasic(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/internal/adapters/opencode/opencode.go
+++ b/internal/adapters/opencode/opencode.go
@@ -172,8 +172,14 @@ func emitSkillCommands(skills []spec.Entry, dir string, dryRun bool) error {
 func commandFile(e spec.Entry) string {
 	meta := emit.ResolveMeta(e.Meta, target)
 	front := pickKeys(meta, commandFrontmatterKeys)
+	keys := append([]string{}, commandFrontmatterKeys...)
+	// Pass through arbitrary x-opencode keys beyond the documented set so
+	// an author can declare command metadata OpenCode adds later without
+	// waiting on the allowlist. Excludes the allowlisted keys (handled by
+	// pickKeys) so nothing is emitted twice. See #367.
+	emit.MergeCustomTargetMeta(front, &keys, e.Meta, target, commandFrontmatterKeys...)
 	var sb strings.Builder
-	sb.WriteString(emit.FrontmatterOrdered(front, commandFrontmatterKeys))
+	sb.WriteString(emit.FrontmatterOrdered(front, keys))
 	sb.WriteString("\n")
 	sb.WriteString(e.Body)
 	return sb.String()

--- a/internal/adapters/opencode/opencode_test.go
+++ b/internal/adapters/opencode/opencode_test.go
@@ -197,6 +197,40 @@ func TestEmit_Skill_EmitsCommand_WhenOptIn(t *testing.T) {
 	}
 }
 
+// A custom key under x-opencode beyond the documented allowlist reaches
+// the command frontmatter; shared top-level keys stay stripped. See #367.
+func TestEmit_Skill_CustomXOpencodeKeyReachesFrontmatter(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{
+			"opencode": {EmitSkillsAsCommands: true},
+		},
+	}
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindSkill,
+			Name: "yaml-validator",
+			Meta: map[string]any{
+				"description": "Validate YAML.",
+				"globs":       "src/**",
+				"x-opencode":  map[string]any{"some-opencode-key": "manual"},
+			},
+			Body: "Validate against schema.",
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	cmd := readFile(t, filepath.Join(dir, ".opencode/commands/skill-yaml-validator.md"))
+	if !strings.Contains(cmd, "some-opencode-key: manual") {
+		t.Errorf("missing custom x-opencode key in %s", cmd)
+	}
+	if strings.Contains(cmd, "globs:") {
+		t.Errorf("shared top-level key leaked into %s", cmd)
+	}
+}
+
 func TestEmit_CommandsDirOverride(t *testing.T) {
 	dir := testutil.TempCwd(t)
 


### PR DESCRIPTION
## Summary
- Extends the `x-<target>` custom-key passthrough (started for Codex in #368) to **every** adapter that has an output surface: Claude/Codex `SKILL.md`, Copilot `.instructions.md`, OpenCode + Amp command frontmatter, and Gemini command TOML.
- Shared top-level keys stay stripped, so a plain spec keeps emitting schema-valid files. The author opts in by declaring the key under `x-<target>`. Keys emit sorted and never leak across targets.

## How
- `emit.CustomTargetMeta` — resolves the sorted, target-scoped custom keys for an adapter, excluding the ones it handles itself.
- `emit.MergeCustomTargetMeta` — folds those keys into a frontmatter map + key-order slice (used by Codex/Copilot/OpenCode/Amp; removes 4 copies of the same loop).
- `emit.WriteTOMLValue` — renders typed scalars (string/bool/int/float) and string arrays for Gemini's TOML surface; skips nested tables and mixed arrays.
- Copilot frontmatter moved to `FrontmatterStyled` with `applyTo` forced double-quoted, so existing files stay byte-identical.

## Tests
- Per target: custom key reaches the surface; shared top-level keys (`globs`) do not leak.
- Gemini: string/bool/array typed emission; foreign-target key dropped (non-frontmatter guard).
- Emit unit tests for `CustomTargetMeta` (sort, exclude, nil/empty) and `WriteTOMLValue` (typed forms + skip).

## Test plan
- [x] `go vet ./...`, `go test ./...` (1111 pass)
- [x] `golangci-lint run` (clean)
- [x] WASM playground build
- [x] schema drift check (no config change)
- [x] `agnostic-ai sync --check` (round-trip clean)

Closes #367