### PR TITLE
fix(zed): emit current context_servers MCP schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Fixed
 
 - Antigravity no longer reports skills as unsupported while silently writing a `skill-<name>.md` rule file; skills are a declared, native kind now. [#371](https://github.com/Chemaclass/agnostic-ai/issues/371).
+- Zed MCP servers now emit Zed's current `context_servers` schema: flat `command`/`args`/`env` for stdio and native `url`/`headers` for remote (HTTP/SSE). Drops the stale nested `command:{path,...}` + `settings:{}` shape and the `npx mcp-remote` bridge. Closes [#373](https://github.com/Chemaclass/agnostic-ai/issues/373).
 
 ### Removed
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -285,7 +285,7 @@ Verify with the real CLI:
 .zed/tasks.json                        # one task per hook, only when tasks-file is set
 ```
 
-- **MCP**: written into `.zed/settings.json` under `context_servers` (Zed's key, not `mcpServers`). Each server uses Zed's nested `command: {path, args, env}` plus an empty `settings: {}`. User-managed keys (theme, buffer_font_size) are preserved. Zed supports only stdio natively; HTTP / SSE entries auto-bridge through `npx mcp-remote <url>` with a one-line stderr warning.
+- **MCP**: written into `.zed/settings.json` under `context_servers` (Zed's key, not `mcpServers`). Stdio servers use a flat `command`/`args`/`env` shape; remote (HTTP / SSE) servers use a native `url`/`headers` shape. User-managed keys (theme, buffer_font_size) are preserved.
 - **Hooks**: when `outputs.zed.tasks-file` is set, every hook spec emits as a [Zed Task](https://zed.dev/docs/tasks) using `sh -c "<hook command>"`. The hook name is the label (description appended after an em-dash when present). Zed has no lifecycle-hook surface, so tasks run on demand from the command palette.
 
 Config keys: `outputs.zed.file` (default `.rules`), `outputs.zed.mcp-file` (default `.zed/settings.json`), `outputs.zed.tasks-file` (default empty, opt-in).

--- a/internal/adapters/zed/testdata/kitsink/.zed/settings.json
+++ b/internal/adapters/zed/testdata/kitsink/.zed/settings.json
@@ -1,34 +1,17 @@
 {
   "context_servers": {
     "disabled-server": {
-      "command": {
-        "env": {},
-        "path": "x"
-      },
-      "settings": {}
+      "command": "x"
     },
     "http-server": {
-      "command": {
-        "args": [
-          "-y",
-          "mcp-remote",
-          "https://example.test/mcp"
-        ],
-        "env": {},
-        "path": "npx"
-      },
-      "settings": {}
+      "url": "https://example.test/mcp"
     },
     "stdio-server": {
-      "command": {
-        "args": [
-          "-y",
-          "@modelcontextprotocol/server-filesystem"
-        ],
-        "env": {},
-        "path": "npx"
-      },
-      "settings": {}
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem"
+      ],
+      "command": "npx"
     }
   }
 }

--- a/internal/adapters/zed/zed.go
+++ b/internal/adapters/zed/zed.go
@@ -4,9 +4,8 @@
 // Zed reads a project-root `.rules` file as additional system context
 // for the inline assistant. MCP servers are configured in
 // `.zed/settings.json` under the `context_servers` key (note: not
-// `mcpServers`), with a nested `{path, args, env}` command shape. Zed
-// only supports stdio transport natively; HTTP / SSE entries need a
-// local `mcp-remote` bridge and are routed through it automatically.
+// `mcpServers`), with a flat `command`/`args`/`env` shape for stdio and
+// a native `url`/`headers` shape for remote (HTTP / SSE) servers.
 //
 // When `outputs.zed.tasks-file` is set, hook specs additionally emit
 // as Zed Tasks (https://zed.dev/docs/tasks): one entry per hook in the
@@ -126,52 +125,41 @@ func buildContextServers(mcps []spec.Entry) map[string]any {
 }
 
 // buildContextServer renders one Zed context_server entry. Stdio specs
-// produce a nested `command: {path, args, env}` block. HTTP / SSE specs
-// fall back to launching the upstream MCP through the `mcp-remote`
-// npx shim since Zed has no native HTTP MCP transport.
+// produce a flat `command`/`args`/`env` block; HTTP / SSE specs produce
+// a native `url`/`headers` block. Both shapes match Zed's current
+// `context_servers` schema (https://zed.dev/docs/ai/mcp).
 func buildContextServer(e spec.Entry) map[string]any {
 	transport, _ := e.Meta["type"].(string)
 	if transport == "" {
 		transport = "stdio"
 	}
-	cmd := map[string]any{}
+	out := map[string]any{}
 
 	switch transport {
 	case "stdio":
-		path, _ := e.Meta["command"].(string)
-		if path == "" {
+		cmd, _ := e.Meta["command"].(string)
+		if cmd == "" {
 			return nil
 		}
-		cmd["path"] = path
+		out["command"] = cmd
 		if args := emit.StringSlice(e.Meta["args"]); len(args) > 0 {
-			cmd["args"] = args
+			out["args"] = args
 		}
 		if env := emit.StringMap(e.Meta["env"]); len(env) > 0 {
-			cmd["env"] = env
-		} else {
-			cmd["env"] = map[string]string{}
+			out["env"] = env
 		}
 	case "http", "sse":
 		url, _ := e.Meta["url"].(string)
 		if url == "" {
 			return nil
 		}
-		_, _ = fmt.Fprintf(emit.Warner,
-			"zed: routing %q through `npx mcp-remote` shim (Zed has no native HTTP MCP transport)\n",
-			e.Name)
-		cmd["path"] = "npx"
-		cmd["args"] = []string{"-y", "mcp-remote", url}
-		if env := emit.StringMap(e.Meta["env"]); len(env) > 0 {
-			cmd["env"] = env
-		} else {
-			cmd["env"] = map[string]string{}
+		out["url"] = url
+		if h := emit.StringMap(e.Meta["headers"]); len(h) > 0 {
+			out["headers"] = h
 		}
 	default:
 		return nil
 	}
 
-	return map[string]any{
-		"command":  cmd,
-		"settings": map[string]any{},
-	}
+	return out
 }

--- a/internal/adapters/zed/zed_test.go
+++ b/internal/adapters/zed/zed_test.go
@@ -57,22 +57,25 @@ func TestEmit_MCP_StdioWritesContextServers(t *testing.T) {
 	for _, want := range []string{
 		`"context_servers"`,
 		`"fs"`,
-		`"command"`,
-		`"path": "npx"`,
+		`"command": "npx"`,
 		`"@modelcontextprotocol/server-filesystem"`,
 		`"env"`,
 		`"ALLOWED_PATHS"`,
-		`"settings"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in %s", want, got)
 		}
 	}
+	// The stale nested-command schema must not reappear.
+	for _, absent := range []string{`"path"`, `"settings"`} {
+		if strings.Contains(got, absent) {
+			t.Errorf("unexpected stale key %q in %s", absent, got)
+		}
+	}
 }
 
-// HTTP MCP entries bridge through `npx mcp-remote <url>` since Zed
-// only supports stdio natively.
-func TestEmit_MCP_HTTPBridgesViaMcpRemote(t *testing.T) {
+// HTTP / SSE MCP entries use Zed's native url/headers shape.
+func TestEmit_MCP_HTTPWritesNativeURL(t *testing.T) {
 	dir := testutil.TempCwd(t)
 
 	entries := []spec.Entry{
@@ -80,8 +83,9 @@ func TestEmit_MCP_HTTPBridgesViaMcpRemote(t *testing.T) {
 			Kind: spec.KindMCP,
 			Name: "linear",
 			Meta: map[string]any{
-				"type": "http",
-				"url":  "https://mcp.linear.app",
+				"type":    "http",
+				"url":     "https://mcp.linear.app",
+				"headers": map[string]any{"Authorization": "Bearer x"},
 			},
 		},
 	}
@@ -91,12 +95,17 @@ func TestEmit_MCP_HTTPBridgesViaMcpRemote(t *testing.T) {
 	got := readFile(t, filepath.Join(dir, ".zed/settings.json"))
 	for _, want := range []string{
 		`"linear"`,
-		`"path": "npx"`,
-		`"mcp-remote"`,
-		`"https://mcp.linear.app"`,
+		`"url": "https://mcp.linear.app"`,
+		`"headers"`,
+		`"Authorization"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in %s", want, got)
+		}
+	}
+	for _, absent := range []string{`"path"`, `"mcp-remote"`, `"settings"`} {
+		if strings.Contains(got, absent) {
+			t.Errorf("unexpected stale key %q in %s", absent, got)
 		}
 	}
 }


### PR DESCRIPTION
## What

Zed MCP servers now use Zed's current `context_servers` schema: flat `command`/`args`/`env` for stdio, native `url`/`headers` for remote (HTTP/SSE).

## Why

The adapter emitted a stale nested `command:{path,args,env}` + `settings:{}` shape and bridged HTTP/SSE through a `npx mcp-remote <url>` shim. Current Zed parses flat stdio entries and supports remote transports natively, so the generated servers failed to load. Verified against https://raw.githubusercontent.com/zed-industries/zed/main/docs/src/ai/mcp.md.

## Changes

- `buildContextServer`: flat stdio + native remote `url`/`headers`; drop `settings:{}` and the `mcp-remote` shim/warning.
- Package doc + `docs/user/targets.md` Zed MCP section updated.
- Unit tests rewritten to assert the new shape and reject the stale keys; kit-sink + integration goldens regenerated.
- CHANGELOG.

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)