### PR TITLE
fix(mcp): carry explicit type on remote servers in mcpServers schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - Antigravity no longer reports skills as unsupported while silently writing a `skill-<name>.md` rule file; skills are a declared, native kind now. [#371](https://github.com/Chemaclass/agnostic-ai/issues/371).
 - Zed MCP servers now emit Zed's current `context_servers` schema: flat `command`/`args`/`env` for stdio and native `url`/`headers` for remote (HTTP/SSE). Drops the stale nested `command:{path,...}` + `settings:{}` shape and the `npx mcp-remote` bridge. Closes [#373](https://github.com/Chemaclass/agnostic-ai/issues/373).
 - Continue MCP files under `.continue/mcpServers/` now emit the required block wrapper (`name` + `version` + `schema: v1` with the server nested under `mcpServers:`); the previous flat single-server files did not load. Closes [#374](https://github.com/Chemaclass/agnostic-ai/issues/374).
+- Remote (HTTP/SSE) MCP servers now carry an explicit `type` in `.mcp.json` (Claude), `.cursor/mcp.json` (Cursor), and `.warp/.mcp.json` (Warp); a url-only entry was ambiguous. Stdio entries stay type-less. Closes [#375](https://github.com/Chemaclass/agnostic-ai/issues/375).
 
 ### Removed
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -45,7 +45,7 @@ Cross-cutting kind notes:
 
 - **Skills**: only Claude Code executes them natively. On every other target they are reference material the agent or human reads and follows.
 - **Hooks**: shell commands on lifecycle events (`PreToolUse`, `PostToolUse`, `SessionStart`, etc.). Native on Claude Code, Codex, and Gemini in each tool's schema. Zed runs them via opt-in `outputs.zed.tasks-file` as on-demand tasks, not event-triggered hooks. Other targets skip with a warning.
-- **MCP servers**: propagate to every target with a project-scoped MCP file (10 of 14, see matrix). Aider, Cline, Windsurf, and Antigravity have no MCP surface and skip with a warning.
+- **MCP servers**: propagate to every target with a project-scoped MCP file (10 of 14, see matrix). Aider, Cline, Windsurf, and Antigravity have no MCP surface and skip with a warning. Remote (HTTP / SSE) entries carry an explicit `type`; stdio entries omit it (it is the inferred default).
 - **Commands**: slash-prompt files authored under `commands/`. Native on Claude Code (`.claude/commands/<name>.md`) and Codex (`.codex/prompts/<name>.md`). Other targets skip with a warning.
 
 ## Per-target output

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -1088,6 +1088,38 @@ func TestEmit_WritesMCPFile(t *testing.T) {
 	}
 }
 
+// Remote (http/sse) servers carry an explicit type in .mcp.json; stdio
+// stays type-less (it is the inferred default).
+func TestEmit_MCP_RemoteCarriesType_StdioDoesNot(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindMCP, Name: "local", Meta: map[string]any{"command": "npx"}},
+		{Kind: spec.KindMCP, Name: "remote", Meta: map[string]any{"type": "http", "url": "https://mcp.example.com/mcp"}},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	servers := parsed["mcpServers"].(map[string]any)
+	remote := servers["remote"].(map[string]any)
+	if remote["type"] != "http" {
+		t.Errorf("remote server missing type=http: %s", raw)
+	}
+	local := servers["local"].(map[string]any)
+	if _, ok := local["type"]; ok {
+		t.Errorf("stdio server should not carry type: %s", raw)
+	}
+}
+
 func TestEmit_MCPFileOverride(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/adapters/claude/testdata/kitsink/.mcp.json
+++ b/internal/adapters/claude/testdata/kitsink/.mcp.json
@@ -4,6 +4,7 @@
       "command": "x"
     },
     "http-server": {
+      "type": "http",
       "url": "https://example.test/mcp"
     },
     "stdio-server": {

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/mcp.json
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/mcp.json
@@ -4,6 +4,7 @@
       "command": "x"
     },
     "http-server": {
+      "type": "http",
       "url": "https://example.test/mcp"
     },
     "stdio-server": {

--- a/internal/adapters/internal/emit/mcp.go
+++ b/internal/adapters/internal/emit/mcp.go
@@ -92,6 +92,10 @@ func buildServer(e spec.Entry, schema MCPSchema) map[string]any {
 		if h := mapField(e.Meta, "headers"); len(h) > 0 {
 			out["headers"] = h
 		}
+		// Remote servers carry an explicit `type` in every schema. A
+		// `.mcp.json` entry with only `url` is ambiguous (http vs sse);
+		// stdio stays type-less since it is the inferred default.
+		out["type"] = transport
 	}
 
 	if env := mapField(e.Meta, "env"); len(env) > 0 {

--- a/internal/adapters/warp/testdata/kitsink/.warp/.mcp.json
+++ b/internal/adapters/warp/testdata/kitsink/.warp/.mcp.json
@@ -4,6 +4,7 @@
       "command": "x"
     },
     "http-server": {
+      "type": "http",
       "url": "https://example.test/mcp"
     },
     "stdio-server": {


### PR DESCRIPTION
## What

Remote (HTTP/SSE) MCP servers now carry an explicit `type` in the shared `mcpServers` schema: `.mcp.json` (Claude), `.cursor/mcp.json` (Cursor), `.warp/.mcp.json` (Warp). Stdio entries stay type-less.

## Why

A remote entry with only `url`/`headers` and no `type` is ambiguous (the tool cannot tell http from sse). Every remote example in the Claude docs carries an explicit `type`; stdio is the inferred default and the canonical project-scope example omits it. Verified against https://code.claude.com/docs/en/mcp.

## Changes

- `emit.buildServer`: set `out["type"] = transport` in the http/sse branch (applies to all schemas). VS Code schema still stamps `type` on every server incl stdio (unchanged).
- New claude unit test asserts remote carries `type=http` and stdio omits it.
- claude/cursor/warp kit-sink + integration goldens regenerated.
- `docs/user/targets.md` MCP note + CHANGELOG.

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)