### PR TITLE
fix(gemini): SSE MCP servers use url, not httpUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - Zed MCP servers now emit Zed's current `context_servers` schema: flat `command`/`args`/`env` for stdio and native `url`/`headers` for remote (HTTP/SSE). Drops the stale nested `command:{path,...}` + `settings:{}` shape and the `npx mcp-remote` bridge. Closes [#373](https://github.com/Chemaclass/agnostic-ai/issues/373).
 - Continue MCP files under `.continue/mcpServers/` now emit the required block wrapper (`name` + `version` + `schema: v1` with the server nested under `mcpServers:`); the previous flat single-server files did not load. Closes [#374](https://github.com/Chemaclass/agnostic-ai/issues/374).
 - Remote (HTTP/SSE) MCP servers now carry an explicit `type` in `.mcp.json` (Claude), `.cursor/mcp.json` (Cursor), and `.warp/.mcp.json` (Warp); a url-only entry was ambiguous. Stdio entries stay type-less. Closes [#375](https://github.com/Chemaclass/agnostic-ai/issues/375).
+- Gemini SSE MCP servers now emit `url` instead of `httpUrl`; only streamable-HTTP servers use `httpUrl`. SSE servers routed through `httpUrl` failed to connect. Closes [#376](https://github.com/Chemaclass/agnostic-ai/issues/376).
 
 ### Removed
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -121,7 +121,7 @@ GEMINI.md                              # canonical entry-point pointer body (wri
 
 - **Rules**: `sync` writes `GEMINI.md` with the pointer body. Per-directory scoping (e.g. `src/GEMINI.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.gemini.rules-file: GEMINI.md` for the legacy concatenated layout.
 - **Agents**: TOML slash commands under `.gemini/commands/` per [Gemini CLI custom commands](https://geminicli.com/docs/cli/custom-commands/). Skills default to source-only; set `outputs.gemini.emit-skills-as-commands: true` to emit one `skill-<name>.toml` per skill.
-- **MCP + hooks**: written into `.gemini/settings.json` (`mcpServers` map, `hooks` map). Gemini uses `httpUrl` (not `url`) for HTTP MCP servers; the adapter renames automatically. Hooks route by `event` frontmatter (`BeforeTool`, `AfterTool`, `SessionStart`); each entry is `{matcher, command}`. Pre-existing user keys survive syncs.
+- **MCP + hooks**: written into `.gemini/settings.json` (`mcpServers` map, `hooks` map). Gemini keys the endpoint by transport: streamable-HTTP servers (`type: http`) use `httpUrl`, SSE servers (`type: sse`) use `url`; the adapter routes each automatically. Hooks route by `event` frontmatter (`BeforeTool`, `AfterTool`, `SessionStart`); each entry is `{matcher, command}`. Pre-existing user keys survive syncs.
 
 Config keys: `outputs.gemini.commands-dir` (default `.gemini/commands`), `outputs.gemini.mcp-file` (default `.gemini/settings.json`, also holds hooks), `outputs.gemini.emit-skills-as-commands` (default `false`), `outputs.gemini.rules-file` (unset; writes legacy concatenated rules and skips the pointer-body write).
 

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -136,9 +136,18 @@ func buildMCPServer(e spec.Entry) map[string]any {
 		if args := emit.StringSlice(e.Meta["args"]); len(args) > 0 {
 			out["args"] = args
 		}
-	case "http", "sse":
+	case "http":
+		// Gemini CLI uses `httpUrl` for the streamable-HTTP endpoint.
 		if url, _ := e.Meta["url"].(string); url != "" {
 			out["httpUrl"] = url
+		}
+		if h := emit.StringMap(e.Meta["headers"]); len(h) > 0 {
+			out["headers"] = h
+		}
+	case "sse":
+		// Gemini CLI uses `url` for the SSE endpoint (not `httpUrl`).
+		if url, _ := e.Meta["url"].(string); url != "" {
+			out["url"] = url
 		}
 		if h := emit.StringMap(e.Meta["headers"]); len(h) > 0 {
 			out["headers"] = h

--- a/internal/adapters/gemini/gemini_test.go
+++ b/internal/adapters/gemini/gemini_test.go
@@ -286,6 +286,32 @@ func TestEmit_MCP_HTTPUsesHttpUrlKey(t *testing.T) {
 	}
 }
 
+// SSE MCP uses Gemini's `url` key (not `httpUrl`, which is HTTP-only).
+func TestEmit_MCP_SSEUsesUrlKey(t *testing.T) {
+	dir := testutil.TempCwd(t)
+
+	entries := []spec.Entry{
+		{
+			Kind: spec.KindMCP,
+			Name: "asana",
+			Meta: map[string]any{
+				"type": "sse",
+				"url":  "https://mcp.asana.com/sse",
+			},
+		},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, filepath.Join(dir, ".gemini/settings.json"))
+	if strings.Contains(got, `"httpUrl"`) {
+		t.Errorf("SSE server must use url, not httpUrl: %s", got)
+	}
+	if !strings.Contains(got, `"url": "https://mcp.asana.com/sse"`) {
+		t.Errorf("missing SSE url key: %s", got)
+	}
+}
+
 // Hooks emit under hooks.<event> = [{matcher, command}, ...].
 func TestEmit_Hook_GroupsByEvent(t *testing.T) {
 	dir := testutil.TempCwd(t)


### PR DESCRIPTION
## What

Gemini SSE MCP servers (`type: sse`) now emit `url`; only streamable-HTTP servers (`type: http`) use `httpUrl`.

## Why

Gemini CLI keys the MCP endpoint by transport: `httpUrl` for streamable-HTTP, `url` for SSE. The adapter routed both through `httpUrl`, so SSE servers failed to connect over SSE. Verified against https://raw.githubusercontent.com/google-gemini/gemini-cli/main/docs/tools/mcp-server.md.

## Changes

- `buildMCPServer`: split the `http`/`sse` case so SSE emits `url`.
- New unit test asserts SSE uses `url` (not `httpUrl`).
- `docs/user/targets.md` Gemini MCP note + CHANGELOG.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)