### PR TITLE
docs(codex): hooks emit to .codex/hooks.json, not config.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Changed
 
+- Docs: corrected the Codex section and adapter comments to state that hooks emit to `.codex/hooks.json` (not `config.toml`); MCP servers still land in `config.toml`. [#377](https://github.com/Chemaclass/agnostic-ai/issues/377).
+
 ### Fixed
 
 - Antigravity no longer reports skills as unsupported while silently writing a `skill-<name>.md` rule file; skills are a declared, native kind now. [#371](https://github.com/Chemaclass/agnostic-ai/issues/371).

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -88,12 +88,14 @@ AGENTS.md                                    # canonical entry-point pointer bod
 .codex/skills/<name>/SKILL.md                # one folder per skill (Codex CLI's native path)
 .codex/skills/<name>/agents/openai.yaml      # optional, when x-codex provides UI/policy/deps
 .codex/prompts/<name>.md                     # one per command (slash prompt)
-.codex/config.toml                           # when hook and/or MCP entries exist
+.codex/config.toml                           # when MCP entries exist
+.codex/hooks.json                            # when hook entries exist
 ```
 
 - **Rules**: `sync` writes `AGENTS.md` with the pointer body. Codex loads rules from the spec source dir referenced there. Per-directory scoping (e.g. `src/AGENTS.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.codex.rules-file: AGENTS.md` for the legacy concatenated layout.
 - **Skills**: [Codex skills layout](https://developers.openai.com/codex/skills), one folder per skill with a required `SKILL.md` (frontmatter `name` + `description`, plus body). When the spec carries `x-codex.interface`, `x-codex.policy`, or `x-codex.dependencies`, an `agents/openai.yaml` is also written for UI customization and policy declarations.
-- **Hooks + MCP**: both land in `.codex/config.toml`. Hooks route by `event` frontmatter (`SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact`, `PostCompact`) into `[[hooks.<event>]]` tables with `matcher` and `command`. MCP servers emit as `[mcp_servers.<name>]`: stdio uses `command`/`args`/`env`, HTTP/SSE uses `url`/`bearer_token_env_var`/`http_headers`. The project-tier config.toml is managed (overwritten each sync); put unmanaged Codex config in `~/.codex/config.toml`.
+- **Hooks**: land in `.codex/hooks.json` (override via `outputs.codex.hooks-file`), routed by `event` frontmatter (`SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact`, `PostCompact`) into per-event arrays with `matcher` and `command`. The JSON form preserves matcher metadata the inline `[[hooks.<event>]]` TOML cannot.
+- **MCP**: lands in `.codex/config.toml`. Servers emit as `[mcp_servers.<name>]`: stdio uses `command`/`args`/`env`, HTTP/SSE uses `url`/`bearer_token_env_var`/`http_headers`. The project-tier config.toml is managed (overwritten each sync); put unmanaged Codex config in `~/.codex/config.toml`.
 - **Commands**: one file per spec under `.codex/prompts/` (project-tier mirror of `~/.codex/prompts/`). Frontmatter passes through; body is the prompt template.
 - **Import**: `import codex` captures `.codex/config.toml` minus `hooks` and `mcp_servers` into `.agnostic-ai/overlays/codex.config.toml`. `sync -t codex` prepends it before the spec-derived sections, so `model`, `sandbox`, `approval_policy`, `notify`, `[history]`, `[profiles.*]`, `[model_providers.*]`, and any other key survive a `.codex/` wipe. On conflict with `outputs.codex.config.*` the overlay wins and the first-class key is dropped to keep TOML valid. `import codex` also reads `.codex/prompts/*.md` and writes them byte-for-byte to `<commands>/`, so user-authored prompts round-trip.
 

--- a/internal/adapters/codex/codex.go
+++ b/internal/adapters/codex/codex.go
@@ -18,11 +18,12 @@
 // or `x-codex.dependencies`, an additional `agents/openai.yaml` is written
 // alongside SKILL.md for UI customization and policy declarations.
 //
-// Codex's lifecycle hooks and MCP servers both live in
-// `.codex/config.toml`. The hook engine (SessionStart, Stop,
-// UserPromptSubmit, PreToolUse, PostToolUse, pre/post compact) emits
-// as `[[hooks.<event>]]` array of tables; each MCP server emits as a
-// `[mcp_servers.<name>]` table.
+// Codex MCP servers live in `.codex/config.toml` (one
+// `[mcp_servers.<name>]` table each). Lifecycle hooks (SessionStart,
+// Stop, UserPromptSubmit, PreToolUse, PostToolUse, pre/post compact)
+// emit to `.codex/hooks.json`, which preserves matcher metadata the
+// inline `[[hooks.<event>]]` TOML form cannot. Override the hooks path
+// via `outputs.codex.hooks-file`.
 package codex
 
 import (
@@ -64,8 +65,8 @@ const (
 var caps = emit.Capabilities{
 	Target: target,
 	// Codex consumes agents, rules, skills (the latter as listings),
-	// commands (slash prompts under .codex/prompts/), plus lifecycle
-	// hooks and MCP servers via .codex/config.toml.
+	// commands (slash prompts under .codex/prompts/), MCP servers via
+	// .codex/config.toml, and lifecycle hooks via .codex/hooks.json.
 	Supports: []spec.Kind{spec.KindAgent, spec.KindRule, spec.KindSkill, spec.KindHook, spec.KindMCP, spec.KindCommand},
 }
 
@@ -79,9 +80,9 @@ func New() *Adapter { return &Adapter{} }
 func (Adapter) Name() string { return target }
 
 // Emit writes one TOML per agent, one folder per skill, one prompt per
-// command, the .codex/config.toml (hooks + MCP), and—when opted in via
-// outputs.codex.rules-file—a legacy concatenated rules document. The
-// project-root AGENTS.md is written by `sync`, not here.
+// command, .codex/config.toml (MCP), .codex/hooks.json (hooks), and—when
+// opted in via outputs.codex.rules-file—a legacy concatenated rules
+// document. The project-root AGENTS.md is written by `sync`, not here.
 func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	if err := emit.ReportUnsupported(caps, b, cfg.OnUnsupported); err != nil {
 		return err


### PR DESCRIPTION
## What

Correct the Codex docs/comments: lifecycle hooks emit to `.codex/hooks.json`, not `config.toml`. MCP servers still land in `config.toml`.

## Why

The `codex.go` package doc, caps comment, and `Emit` comment, plus `docs/user/targets.md`, described hooks as `[[hooks.<event>]]` tables in `config.toml`. The adapter actually writes `.codex/hooks.json` (the JSON form preserves matcher metadata the inline TOML cannot). Doc-only drift surfaced by the targets audit. No behavior change.

## Changes

- `codex.go`: package doc, caps comment, Emit comment.
- `docs/user/targets.md`: split Hooks/MCP bullets, output tree comment.
- CHANGELOG.

Refs #377 (the codex item; amp custom-command deprecation and antigravity `.agents/` plural remain tracked there, both blocked on upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)