### PR TITLE
docs: align target docs and matrices with actual adapter behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Changed
 
+- Docs: README capability matrix and legend now show per-kind support depth (native / bundled / opt-in / not supported) instead of a 3-state glyph, with accurate cells for source-dir-only rules and opt-in skills.
+
 ### Fixed
+
+- Docs: Gemini emits the hook `event:` value verbatim (no `PostToolUse`->`AfterTool` translation); fixed the spec-format example that produced an invalid Gemini config, and pointed Codex hook rendering at `.codex/hooks.json`.
+- Docs: clarified that `amp` and `warp` share Codex's `AGENTS.md` pointer body via auto-dedup and do not collide; corrected the `DefaultTargets`, `collision.go`, and configuration.md wording.
+- Docs: README marked Zed hooks unsupported; the adapter emits `.zed/tasks.json` via opt-in `outputs.zed.tasks-file`.
+- Docs: filled missing `outputs.*` keys in configuration.md (cursor `commands-dir`, copilot `chatmodes-dir`, cline/windsurf `workflows-dir`, continue `assistants-dir`, zed `tasks-file`, antigravity `skills-dir`, codex `hooks-file`) and the codex `shared-subagents` default (`true`).
+- Docs: targets.md capability matrix now renders the Commands column for every target; provenance verify steps use `grep` so they work on files that lead with frontmatter.
+- Docs: corrected stale claims for Cursor skills, the `on-unsupported` examples, Zed MCP transport (native `url`/`headers`, not `npx mcp-remote`), the Antigravity MCP no-support list, the per-directory scope table, and the Claude `.claude/rules/` import note.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### **One spec. Every AI CLI. Zero drift.**
 
-Write your agents, skills, rules, and hooks **once**. Ship them to Claude Code, Codex, Gemini, Cursor, Copilot, and 10 more in their native format.
+Write your agents, skills, rules, and hooks **once**. Ship them to Claude Code, Codex, Gemini, Cursor, Copilot, and 9 more in their native format.
 
 [![CI](https://github.com/Chemaclass/agnostic-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/Chemaclass/agnostic-ai/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/chemaclass/agnostic-ai)](https://goreportcard.com/report/github.com/chemaclass/agnostic-ai)
@@ -72,26 +72,35 @@ Same shape lands at `.claude/rules/`, `.windsurf/rules/`, `.clinerules/`, `.cont
 
 ## Supported targets
 
+All 14 targets are first-class: author a spec once, `sync`, and it lands in each tool's native format. The matrix shows the emission shape per kind, not whether the tool is supported (it always is). Scan a row for your tool; scan the ✅ column for what works out of the box.
+
 | Target              | Agents | Skills | Rules | Hooks | MCPs |
 |---------------------|:------:|:------:|:-----:|:-----:|:----:|
 | Claude Code         |   ✅    |   ✅    |   ✅   |   ✅   |  ✅   |
-| Codex CLI           |   ✅    |   ✅    |   ✅   |   ✅   |  ✅   |
-| Gemini CLI          |   ✅    |   ✅    |   ✅   |   ✅   |  ✅   |
+| Codex CLI           |   ✅    |   ✅    |   ○   |   ✅   |  ✅   |
+| Gemini CLI          |   ✅    |   ○    |   ○   |   ✅   |  ✅   |
 | Cursor              |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
 | GitHub Copilot      |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
-| Aider               |   ◐    |   ◐    |   ✅   |   -   |  -   |
+| Aider               |   ○    |   ○    |   ○   |   -   |  -   |
 | Cline               |   ✅    |   ✅    |   ✅   |   -   |  -   |
 | Windsurf            |   ✅    |   ✅    |   ✅   |   -   |  -   |
 | Continue            |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
-| Amp                 |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
-| Zed                 |   ◐    |   ◐    |   ✅   |   -   |  ✅   |
-| Warp                |   ◐    |   ◐    |   ✅   |   -   |  ✅   |
-| OpenCode            |   ✅    |   ◐    |   ✅   |   -   |  ✅   |
+| Amp                 |   ✅    |   ✅    |   ○   |   -   |  ✅   |
+| Zed                 |   ◐    |   ◐    |   ◐   |   ○   |  ✅   |
+| Warp                |   ○    |   ○    |   ○   |   -   |  ✅   |
+| OpenCode            |   ✅    |   ○    |   ○   |   -   |  ✅   |
 | Google Antigravity  |   ✅    |   ✅    |   ✅   |   -   |  -   |
 
-Legend: ✅ separate files · ◐ merged into single doc · `-` not supported. Hooks propagate to Claude, Codex, and Gemini. MCPs propagate to 10 targets in each tool's native schema.
+Legend, in descending order of native support:
 
-A ✅ means the file lands where the target documents. Not every cell is a path the upstream tool auto-loads. See [targets](docs/user/targets.md) for which paths are native vs. convention and how to wire conventions into each tool.
+- **✅ native** — written in the tool's own format at the path it auto-loads: one file per spec for agents/skills/rules, the tool's native settings/MCP file for hooks and MCPs.
+- **◐ bundled** — folded into the target's single entry-point or merged doc (no per-spec file). Zed's `.rules` is the only target that merges by default.
+- **○ opt-in / source-dir** — not emitted as a dedicated file by default; the spec stays in the source dir, referenced from the entry-point. Set the matching `outputs.<target>.*` key (e.g. `rules-file`, `workflows-dir`, `emit-skills-as-commands`) to materialize a file.
+- **- not supported** — the kind is skipped with a warning. Suppress with `on-unsupported: silent`.
+
+Hooks are native on Claude, Codex, and Gemini; Zed runs them as on-demand tasks via opt-in `outputs.zed.tasks-file`. MCPs propagate to 10 of the 14 targets in each tool's native schema (every target except Aider, Cline, Windsurf, and Antigravity).
+
+The matrix tracks the adapter's current output, locked by golden-snapshot tests. Each target also carries a **Verify with the real CLI** checklist in [targets](docs/user/targets.md) that confirms the emitted paths against the live tool, so the cells stay honest about what each tool actually auto-loads.
 
 ## Install
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -41,9 +41,12 @@ sources:
   commands: commands
 
 # AI CLIs to emit configs for. These 12 are the default set (used when
-# `targets` is omitted). Two more adapters exist, `amp` and `warp`, but
-# both emit the root `AGENTS.md` like `codex`, so enabling them together
-# collides. Add one and give it an `outputs.<target>.file` override.
+# `targets` is omitted). Two more adapters exist, `amp` and `warp`. They
+# share the root `AGENTS.md` pointer body with `codex` (written once via
+# auto-dedup, since the body is byte-identical), so they add no new
+# entry-point and are left out of the default set. Enable them explicitly
+# if you use those tools. A real collision only happens when two targets
+# set a conflicting `outputs.<target>.rules-file: AGENTS.md`.
 targets:
   - claude
   - codex
@@ -95,28 +98,33 @@ outputs:
   cursor:
     rules-dir: .cursor/rules     # default
     mcp-file: .cursor/mcp.json   # default
+    # commands-dir: .cursor/commands  # opt-in: also emit each agent as a Cursor Custom Command.
   copilot:
     instructions-dir: .github/instructions  # default. One .instructions.md per scoped rule, agent, skill.
     mcp-file: .vscode/mcp.json              # default
+    # chatmodes-dir: .github/chatmodes      # opt-in: also emit each agent as a Copilot Custom Chat Mode.
   aider:
     # Opt-in: also merge .aider.conf.yml so Aider auto-loads CONVENTIONS.md.
     # conf-file: .aider.conf.yml
     # model: gpt-4o
     # weak-model: gpt-4o-mini
   cline:
-    rules-dir: .clinerules       # default
+    rules-dir: .clinerules       # default. One .md per rule, agent, and skill.
+    # workflows-dir: .clinerules/workflows  # opt-in: also emit each agent as a Cline Workflow (/<name>.md).
   windsurf:
-    rules-dir: .windsurf/rules   # default
+    rules-dir: .windsurf/rules   # default. One .md per rule, agent, and skill.
+    # workflows-dir: .windsurf/workflows    # opt-in: also emit each agent as a Windsurf Workflow (/<name>).
   continue:
     rules-dir: .continue/rules        # default
     mcp-dir: .continue/mcpServers     # default. One YAML per MCP server.
   amp:
-    commands-dir: .agents/commands  # default. One .md per agent (and per skill when opted in).
-    emit-skills-as-commands: false  # default
+    commands-dir: .agents/commands  # default. One .md per agent.
+    skills-dir: .agents/skills      # default. One folder per skill (<name>/SKILL.md).
     mcp-file: .amp/settings.json    # default. amp.mcpServers (dotted key).
   zed:
     file: .rules                  # default
-    mcp-file: .zed/settings.json  # default. context_servers (stdio native, HTTP via mcp-remote).
+    mcp-file: .zed/settings.json  # default. context_servers (stdio command/args/env, HTTP/SSE native url/headers).
+    # tasks-file: .zed/tasks.json # opt-in: emit each hook as an on-demand Zed Task.
   warp:
     # workflows-dir: .warp/workflows  # opt-in: emit Warp Workflow YAMLs per agent.
     mcp-file: .warp/.mcp.json     # default. Standard mcpServers schema.
@@ -126,9 +134,11 @@ outputs:
     mcp-file: opencode.json              # default. mcp map with type: local|remote.
   antigravity:
     rules-dir: .agent/rules             # default. One .md per rule and per agent.
+    skills-dir: .agent/skills           # default. One folder per skill (<name>/SKILL.md).
+    # rules-file: .agent/AGENTS.md      # opt-in: legacy merged doc; skips the pointer-body write.
 
 # What to do when a spec kind is unsupported by a target
-# (e.g. hooks for any target other than claude).
+# (e.g. hooks for Cursor, or mcps for Cline).
 on-unsupported: warn   # warn | error | silent
 
 # Auto-manage a block in .gitignore listing every generated path.
@@ -185,25 +195,31 @@ Per-target paths. Each target reads only the fields it understands. Irrelevant f
 | `gemini` | `emit-skills-as-commands` | `false` | When true, skills also emit as `.gemini/commands/skill-<name>.toml`. |
 | `gemini` | `rules-file` | _empty_ | When set, writes a legacy concatenated rules document at that path. `sync` skips the pointer-body write for `gemini`. |
 | `gemini` | `mcp-file` | `.gemini/settings.json` | Holds both `mcpServers` and `hooks`. HTTP MCP entries use `httpUrl`. |
-| `cursor` | `rules-dir` | `.cursor/rules` | One `.mdc` per rule and per agent. |
+| `cursor` | `rules-dir` | `.cursor/rules` | One `.mdc` per rule, agent, and skill (`skill-<name>.mdc`). |
+| `cursor` | `commands-dir` | _empty_ | When set, each agent also emits as a Cursor Custom Command at `<dir>/<name>.md`. The rule-form `.mdc` emission still happens. Opt-in. |
 | `cursor` | `mcp-file` | `.cursor/mcp.json` | Standard `mcpServers` schema. |
 | `copilot` | `instructions-dir` | `.github/instructions` | One `.instructions.md` per scoped rule, agent, skill. `applyTo:` frontmatter derived from `globs` or scope. |
+| `copilot` | `chatmodes-dir` | _empty_ | When set, each agent also emits as a Copilot Custom Chat Mode at `<dir>/<name>.chatmode.md`. The `agent-<name>.instructions.md` emission still happens. Opt-in. |
 | `copilot` | `rules-file` | _empty_ | When set, writes always-on rules concatenated at that path (legacy layout). `sync` skips the pointer-body write for `copilot`. |
 | `copilot` | `mcp-file` | `.vscode/mcp.json` | VS Code schema: top-level `servers` with `type` field per entry. |
 | `aider` | `rules-file` | _empty_ | When set, writes a legacy merged document at that path (typically `CONVENTIONS.md`). `sync` skips the pointer-body write for `aider`. |
 | `aider` | `conf-file` | _empty_ | When set, merges `.aider.conf.yml` so Aider auto-loads `CONVENTIONS.md`. Pre-existing keys preserved; `read:` list de-duplicates. Opt-in. |
 | `aider` | `model` | _empty_ | Optional `model:` value written into the conf file. |
 | `aider` | `weak-model` | _empty_ | Optional `weak-model:` value written into the conf file. |
-| `cline` | `rules-dir` | `.clinerules` | One `.md` per rule and per agent. |
-| `windsurf` | `rules-dir` | `.windsurf/rules` | One `.md` per rule and per agent. |
-| `continue` | `rules-dir` | `.continue/rules` | One `.md` per rule and per agent. |
+| `cline` | `rules-dir` | `.clinerules` | One `.md` per rule, agent, and skill (`skill-<name>.md`). |
+| `cline` | `workflows-dir` | _empty_ | When set, each agent also emits as a Cline Workflow at `<dir>/<name>.md` (invokable as `/<name>.md`). The rule-form emission still happens. Opt-in. |
+| `windsurf` | `rules-dir` | `.windsurf/rules` | One `.md` per rule, agent, and skill (`skill-<name>.md`). |
+| `windsurf` | `workflows-dir` | _empty_ | When set, each agent also emits as a Windsurf Workflow at `<dir>/<name>.md` (invokable as `/<name>`). The rule-form emission still happens. Opt-in. |
+| `continue` | `rules-dir` | `.continue/rules` | One `.md` per rule, agent, and skill (`skill-<name>.md`). |
 | `continue` | `mcp-dir` | `.continue/mcpServers` | One YAML per MCP server. |
+| `continue` | `assistants-dir` | _empty_ | When set, each agent also emits as a Continue local Assistant YAML at `<dir>/<name>.yaml`. The rule-form emission still happens. Opt-in. |
 | `amp` | `commands-dir` | `.agents/commands` | One `.md` per agent. |
 | `amp` | `skills-dir` | `.agents/skills` | One folder per skill with a `SKILL.md` (Amp's native skills layout). |
 | `amp` | `rules-file` | _empty_ | When set, writes a legacy concatenated rules document at that path. `sync` skips the pointer-body write for `amp`. |
 | `amp` | `mcp-file` | `.amp/settings.json` | Writes `amp.mcpServers` (dotted key). Pre-existing keys preserved. |
 | `zed` | `file` | `.rules` | Single merged document. |
-| `zed` | `mcp-file` | `.zed/settings.json` | `context_servers` map. Stdio native; HTTP/SSE auto-bridges via `npx mcp-remote`. |
+| `zed` | `mcp-file` | `.zed/settings.json` | `context_servers` map. Stdio uses `command`/`args`/`env`; HTTP/SSE use a native `url`/`headers` shape. |
+| `zed` | `tasks-file` | _empty_ | When set, each hook emits as an on-demand Zed Task (`sh -c "<command>"`). Zed has no lifecycle-hook surface, so tasks run from the command palette. Opt-in. |
 | `warp` | `workflows-dir` | _empty_ | When set, each agent emits as a Warp Workflow YAML at `<dir>/<name>.yaml`. |
 | `warp` | `rules-file` | _empty_ | When set, writes a legacy concatenated rules document at that path. `sync` skips the pointer-body write for `warp`. |
 | `warp` | `mcp-file` | `.warp/.mcp.json` | Standard `mcpServers` schema. |
@@ -212,11 +228,12 @@ Per-target paths. Each target reads only the fields it understands. Irrelevant f
 | `opencode` | `rules-file` | _empty_ | When set, writes a legacy concatenated rules document at that path. `sync` skips the pointer-body write for `opencode`. |
 | `opencode` | `mcp-file` | `opencode.json` | `mcp` map with `type: "local"\|"remote"`. Pre-existing user keys preserved. |
 | `antigravity` | `rules-dir` | `.agent/rules` | One `.md` per rule and per agent. |
+| `antigravity` | `skills-dir` | `.agent/skills` | One folder per skill (`<name>/SKILL.md`, Antigravity's native skills layout). |
 | `antigravity` | `rules-file` | _empty_ | When set, writes a legacy merged document at that path. `sync` skips the pointer-body write for `antigravity`. |
 
 ## `targets`
 
-When omitted: the 12 default adapters above (every adapter except `amp` and `warp`, which collide with `codex` on the root `AGENTS.md`). Comment out entries to disable targets. CLI flag `-t/--target` overrides for a single run.
+When omitted: the 12 default adapters above (every adapter except `amp` and `warp`, which share `codex`'s root `AGENTS.md` pointer body and so add no new entry-point). Enabling `amp` or `warp` alongside `codex` is safe: the identical body is written once via auto-dedup. Comment out entries to disable targets. CLI flag `-t/--target` overrides for a single run.
 
 ### Interactive target selection
 
@@ -276,7 +293,7 @@ import:
 
 ## `on-unsupported`
 
-Fires when an adapter receives spec kinds it does not support (e.g. `hooks` for Codex or `skills` for Cursor).
+Fires when an adapter receives spec kinds it does not support (e.g. `hooks` for Cursor or `mcps` for Cline).
 
 | Value | Behavior |
 |-------|----------|

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -28,17 +28,13 @@ Adapters that produce per-directory output honor the scope:
 
 | Target          | Scoped layout                              |
 |-----------------|--------------------------------------------|
-| `codex`         | `<scope>/AGENTS.md` (routed via globs; layout wins) |
 | `cursor`        | `<scope>/.cursor/rules/<name>.mdc`         |
 | `cline`         | `<scope>/.clinerules/<name>.md`            |
 | `windsurf`      | `<scope>/.windsurf/rules/<name>.md`        |
 | `continue`      | `<scope>/.continue/rules/<name>.md`        |
 | `copilot`       | `<scope>/**` glob on one `.github/instructions/<name>.instructions.md` (no nested dirs) |
-| `gemini`        | `<scope>/GEMINI.md`                        |
-| `amp`           | `<scope>/AGENTS.md`                        |
-| `warp`          | `<scope>/AGENTS.md`                        |
 
-Single-document targets (`claude` CLAUDE.md, `aider` CONVENTIONS.md) merge regardless of scope. The scope stays in the source provenance comment (`<!-- source: rules/backend/auth.md -->`).
+Single-document targets (`claude` CLAUDE.md, `aider` CONVENTIONS.md) merge regardless of scope. Source-dir targets (`codex`, `gemini`, `amp`, `warp`) reference rules from the spec dir and no longer emit per-directory scoped files (e.g. `src/AGENTS.md`) by default. The scope stays in the source provenance comment (`<!-- source: rules/backend/auth.md -->`).
 
 A frontmatter `scope:` field is also accepted as a fallback when moving the file is impractical (a single rule scoped to a subtree).
 
@@ -243,7 +239,9 @@ target: codex   # shell-expanded codex path; do not leak to other tools
 | `Stop` | When the model stops generating. |
 | `Notification` | When Claude Code surfaces a system notification. |
 
-Native emission: Claude Code (`.claude/settings.json`), Codex (`.codex/config.toml` `[[hooks.<event>]]`), Gemini (`.gemini/settings.json` `hooks`, with event names like `BeforeTool`/`AfterTool`). Other targets log a warning and skip. See each tool's docs for its full event list and matcher semantics.
+Native emission: Claude Code (`.claude/settings.json`), Codex (`.codex/hooks.json`, per-event arrays), Gemini (`.gemini/settings.json` `hooks`). Other targets log a warning and skip. See each tool's docs for its full event list and matcher semantics.
+
+agnostic-ai emits the `event:` value **verbatim** into each target's schema; it does not translate event names between tools. Claude and Codex share the `PreToolUse` / `PostToolUse` / `UserPromptSubmit` vocabulary, so one hook spec feeds both. Gemini uses its own names (`BeforeTool`, `AfterTool`, `SessionStart`, `SessionEnd`), so a Gemini hook must set `event:` to one of those. `agnostic-ai validate` flags any event a target does not recognize.
 
 ### Per-target rendering
 
@@ -272,15 +270,32 @@ Renders to `.claude/settings.json`:
 }
 ```
 
-Renders to `.codex/config.toml`:
+Renders to `.codex/hooks.json` (same nested shape as Claude, routed into per-event arrays):
 
-```toml
-[[hooks.PostToolUse]]
-matcher = "Bash(git commit*)"
-command = "echo \"tests please\""
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash(git commit*)",
+        "hooks": [
+          {"type": "command", "command": "echo \"tests please\""}
+        ]
+      }
+    ]
+  }
+}
 ```
 
-Renders to `.gemini/settings.json`:
+Gemini uses different event names, so a Gemini hook sets `event:` to one of its own. This spec:
+
+```yaml
+event: AfterTool
+matcher: Bash(git commit*)
+command: echo "tests please"
+```
+
+Renders to `.gemini/settings.json` (flat shape, event name passed through unchanged):
 
 ```json
 {
@@ -292,7 +307,7 @@ Renders to `.gemini/settings.json`:
 }
 ```
 
-When `command` is a list, each entry becomes a separate hook entry (Claude) or a separate `[[hooks.<event>]]` block (Codex).
+When `command` is a list, each entry becomes a separate hook entry (Claude, Codex).
 
 ## MCP servers
 
@@ -334,11 +349,11 @@ Targets with native MCP propagation:
 | Gemini | `.gemini/settings.json` | `mcpServers` (uses `httpUrl` for HTTP) |
 | Continue | `.continue/mcpServers/<name>.yaml` | one YAML per server |
 | Amp | `.amp/settings.json` | `amp.mcpServers` (dotted key) |
-| Zed | `.zed/settings.json` | `context_servers` (stdio only; HTTP bridges via `npx mcp-remote`) |
+| Zed | `.zed/settings.json` | `context_servers` (stdio: `command`/`args`/`env`; HTTP/SSE: native `url`/`headers`) |
 | Warp | `.warp/.mcp.json` | standard `mcpServers` |
 | OpenCode | `opencode.json` | `mcp` with `type: local\|remote` |
 
-Aider, Cline, and Windsurf have no project-scoped MCP file and skip with a warning.
+Aider, Cline, Windsurf, and Antigravity have no project-scoped MCP file and skip with a warning.
 
 ## Commands
 
@@ -403,9 +418,9 @@ Resolution per target:
 |--------|-----------------------|
 | `claude` | `name`, `description`, `model`, `allowed-tools` |
 | `cursor` | `name`, `description`, `model`, `globs`, `alwaysApply` |
-| `gemini` | `name`, `description`, `model` |
+| `gemini` | `description` (`name` becomes the `.toml` filename; `model` has no native command surface and is not emitted) |
 
-For Codex agents, `x-codex` fields (`model`, `model_reasoning_effort`, `sandbox_mode`, `nickname_candidates`) pass through to the generated `.agents/agents/<name>.toml`. For Codex skills, `x-codex.interface`, `x-codex.policy`, and `x-codex.dependencies` trigger an additional `.agents/skills/<name>/agents/openai.yaml` for UI customization, policy, and tool dependencies.
+For Codex agents, `x-codex` fields (`model`, `model_reasoning_effort`, `sandbox_mode`, `nickname_candidates`) pass through to the generated `.codex/agents/<name>.toml`. For Codex skills, `x-codex.interface`, `x-codex.policy`, and `x-codex.dependencies` trigger an additional `.codex/skills/<name>/agents/openai.yaml` for UI customization, policy, and tool dependencies.
 
 ### Arbitrary custom keys
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -18,7 +18,7 @@ Each adapter emits in its tool's native format: separate files where the tool su
 | **opencode**    | `.opencode/AGENTS.md`             |
 | **antigravity** | `.agent/AGENTS.md`                |
 
-Targets sharing a path (codex + amp + warp at `AGENTS.md`) write it once; dedup is automatic. Targets without a row (cursor, cline, windsurf, continue, zed) emit only per-file artifacts under their own directory and have no root entry-point.
+Targets sharing a path (codex + amp + warp at `AGENTS.md`) write it once; dedup is automatic. Targets absent from the table above (cursor, cline, windsurf, continue, zed) have no root entry-point: they emit only per-file artifacts under their own directory.
 
 Set `outputs.<target>.rules-file: <path>` to use the legacy concatenated rules layout. The adapter writes a single merged document at `<path>` and `sync` skips the pointer-body write for that target so they do not collide.
 
@@ -28,24 +28,24 @@ Set `outputs.<target>.rules-file: <path>` to use the legacy concatenated rules l
 |-----------------|---------------------|--------|--------------------------|-------|------|----------|
 | **claude**      | `.claude/agents/`   | `.claude/skills/` | `.claude/rules/*.md`   | `.claude/settings.json` | `.mcp.json` | `.claude/commands/<name>.md` |
 | **codex**       | `.codex/agents/*.toml` | `.codex/skills/<name>/SKILL.md` | source-dir only (legacy concat via `outputs.codex.rules-file`) | `.codex/hooks.json` (per-event arrays) | `.codex/config.toml` (`[mcp_servers.<name>]`) | `.codex/prompts/<name>.md` |
-| **gemini**      | `.gemini/commands/<name>.toml` | `.gemini/commands/skill-<name>.toml` w/ opt-in | source-dir only (legacy concat via `outputs.gemini.rules-file`) | `.gemini/settings.json` (`hooks`) | `.gemini/settings.json` (`mcpServers`) |
-| **cursor**      | as `.mdc` (alwaysApply: false) | as `.mdc` (`skill-<name>.mdc`) | `.cursor/rules/*.mdc` | - | `.cursor/mcp.json` |
-| **copilot**     | `.github/instructions/agent-<name>.instructions.md` | `.github/instructions/skill-<name>.instructions.md` | `.github/instructions/<name>.instructions.md` (scoped); always-on via `outputs.copilot.rules-file` | - | `.vscode/mcp.json` |
-| **aider**       | source-dir only (legacy merge via `outputs.aider.rules-file`) | source-dir only | source-dir only (`.aider.conf.yml` w/ opt-in) | - | - |
-| **cline**       | as `.md` rule (+ `.clinerules/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - |
-| **windsurf**    | as `.md` rule (+ `.windsurf/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.windsurf/rules/*.md`   | -     | - |
-| **continue**    | as `.md` rule (+ `.continue/assistants/<name>.yaml` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.continue/rules/*.md`   | -     | `.continue/mcpServers/*.yaml` |
-| **amp**         | `.agents/commands/<name>.md` | `.agents/skills/<name>/SKILL.md` | source-dir only (legacy concat via `outputs.amp.rules-file`) | - | `.amp/settings.json` (`amp.mcpServers`) |
-| **zed**         | merged in `.rules` | listed in `.rules` | `.rules` | `.zed/tasks.json` w/ opt-in | `.zed/settings.json` (`context_servers`) |
-| **warp**        | `.warp/workflows/<name>.yaml` w/ opt-in | source-dir only | source-dir only (legacy concat via `outputs.warp.rules-file`) | - | `.warp/.mcp.json` |
-| **opencode**    | `.opencode/commands/<name>.md` | `.opencode/commands/skill-<name>.md` w/ opt-in | source-dir only (legacy concat via `outputs.opencode.rules-file`) | - | `opencode.json` (`mcp`) |
-| **antigravity** | as `.md` rule (`agent-<name>.md`) | `.agent/skills/<name>/SKILL.md` | `.agent/rules/*.md` (legacy merge via `outputs.antigravity.rules-file`) | - | - |
+| **gemini**      | `.gemini/commands/<name>.toml` | `.gemini/commands/skill-<name>.toml` w/ opt-in | source-dir only (legacy concat via `outputs.gemini.rules-file`) | `.gemini/settings.json` (`hooks`) | `.gemini/settings.json` (`mcpServers`) | - |
+| **cursor**      | as `.mdc` (alwaysApply: false) | as `.mdc` (`skill-<name>.mdc`) | `.cursor/rules/*.mdc` | - | `.cursor/mcp.json` | - |
+| **copilot**     | `.github/instructions/agent-<name>.instructions.md` | `.github/instructions/skill-<name>.instructions.md` | `.github/instructions/<name>.instructions.md` (scoped); always-on via `outputs.copilot.rules-file` | - | `.vscode/mcp.json` | - |
+| **aider**       | source-dir only (legacy merge via `outputs.aider.rules-file`) | source-dir only | source-dir only (`.aider.conf.yml` w/ opt-in) | - | - | - |
+| **cline**       | as `.md` rule (+ `.clinerules/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - | - |
+| **windsurf**    | as `.md` rule (+ `.windsurf/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.windsurf/rules/*.md`   | -     | - | - |
+| **continue**    | as `.md` rule (+ `.continue/assistants/<name>.yaml` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.continue/rules/*.md`   | -     | `.continue/mcpServers/*.yaml` | - |
+| **amp**         | `.agents/commands/<name>.md` | `.agents/skills/<name>/SKILL.md` | source-dir only (legacy concat via `outputs.amp.rules-file`) | - | `.amp/settings.json` (`amp.mcpServers`) | - |
+| **zed**         | merged in `.rules` | listed in `.rules` | `.rules` | `.zed/tasks.json` w/ opt-in | `.zed/settings.json` (`context_servers`) | - |
+| **warp**        | `.warp/workflows/<name>.yaml` w/ opt-in | source-dir only | source-dir only (legacy concat via `outputs.warp.rules-file`) | - | `.warp/.mcp.json` | - |
+| **opencode**    | `.opencode/commands/<name>.md` | `.opencode/commands/skill-<name>.md` w/ opt-in | source-dir only (legacy concat via `outputs.opencode.rules-file`) | - | `opencode.json` (`mcp`) | - |
+| **antigravity** | as `.md` rule (`agent-<name>.md`) | `.agent/skills/<name>/SKILL.md` | `.agent/rules/*.md` (legacy merge via `outputs.antigravity.rules-file`) | - | - | - |
 
 Cross-cutting kind notes:
 
 - **Skills**: only Claude Code executes them natively. On every other target they are reference material the agent or human reads and follows.
 - **Hooks**: shell commands on lifecycle events (`PreToolUse`, `PostToolUse`, `SessionStart`, etc.). Native on Claude Code, Codex, and Gemini in each tool's schema. Zed runs them via opt-in `outputs.zed.tasks-file` as on-demand tasks, not event-triggered hooks. Other targets skip with a warning.
-- **MCP servers**: propagate to every target with a project-scoped MCP file (10 of 14, see matrix). Aider, Cline, Windsurf, and Antigravity have no MCP surface and skip with a warning. Remote (HTTP / SSE) entries carry an explicit `type`; stdio entries omit it (it is the inferred default).
+- **MCP servers**: propagate to every target with a project-scoped MCP file (10 of 14, see matrix). Aider, Cline, Windsurf, and Antigravity have no MCP surface and skip with a warning. On targets whose native schema uses a `type` field (claude, cursor, copilot, warp, continue, opencode), remote (HTTP / SSE) entries carry an explicit `type` and stdio entries omit it (the inferred default). amp, gemini, and zed have no `type` field and infer the transport from the emitted keys (gemini via `httpUrl` vs `url`; amp and zed via `url` vs `command`).
 - **Commands**: slash-prompt files authored under `commands/`. Native on Claude Code (`.claude/commands/<name>.md`) and Codex (`.codex/prompts/<name>.md`). Other targets skip with a warning.
 
 ## Per-target output
@@ -63,7 +63,7 @@ CLAUDE.md                # canonical entry-point pointer body (written by sync)
 .mcp.json
 ```
 
-- **Rules**: one file per spec under `.claude/rules/`. Reference them from `CLAUDE.md` with `@.claude/rules/<name>.md` imports; the pointer body lists `.claude/rules/` so imports survive syncs. `CLAUDE.md` is owned by `sync` and overwritten with the pointer body each run. Set `outputs.claude.rules-file: CLAUDE.md` for the legacy concatenated layout; `sync` then skips the pointer-body write for `claude`.
+- **Rules**: one file per spec under `.claude/rules/` for reference. They are not auto-imported by default: the sync-owned `CLAUDE.md` pointer body lists the source spec dir (e.g. `.agnostic-ai/rules/`), not `.claude/rules/`, and emits no `@`-import lines. `CLAUDE.md` is overwritten with the pointer body each run, so to have Claude Code load the per-rule files add `@.claude/rules/<name>.md` imports to a file `sync` does not own, or set `outputs.claude.rules-file: CLAUDE.md` for the legacy concatenated layout (`sync` then skips the pointer-body write for `claude`).
 - **Commands**: one file per spec under `.claude/commands/`. Spec `deploy` becomes `/deploy`. Frontmatter passes through; body is the prompt template.
 - **Settings overlay**: `agnostic-ai import claude` captures the non-`hooks` portion of `.claude/settings.json` (statusLine, enabledPlugins, any top-level key) into `.agnostic-ai/overlays/claude.settings.json`. `sync -t claude` layers the spec-derived `hooks` key on top, reproducing the full settings.json from a fresh checkout. Re-run `import claude` after editing settings.json by hand.
 - **MCP import**: `import claude` reads `.mcp.json` and writes one spec under `<mcps>/<name>.yaml` per `mcpServers.<name>`. The next `sync` distributes them to codex, copilot, cursor, continue, amp, zed, warp, gemini, opencode.
@@ -74,7 +74,7 @@ Config keys: `outputs.claude.dir` (default `.claude`), `outputs.claude.rules-dir
 Verify with the real CLI:
 
 1. Install: `npm install -g @anthropic-ai/claude-code` (or the desktop app; both read the same files).
-2. Check the tree: `ls CLAUDE.md .claude/agents/ .claude/skills/ .claude/rules/ .claude/commands/ .claude/settings.json .mcp.json` and `head -1 .claude/agents/*.md .claude/rules/*.md .claude/commands/*.md` for the provenance header.
+2. Check the tree: `ls CLAUDE.md .claude/agents/ .claude/skills/ .claude/rules/ .claude/commands/ .claude/settings.json .mcp.json` and `grep "Generated by agnostic-ai" .claude/agents/*.md .claude/rules/*.md .claude/commands/*.md` for the provenance header (it sits after the YAML frontmatter, so `head -1` would only show `---`).
 3. Validate JSON: `python -m json.tool .claude/settings.json > /dev/null && python -m json.tool .mcp.json > /dev/null`.
 4. Launch `claude` from the project root. `/agents`, `/skills`, and the slash-command picker should list every entry. The MCP picker shows each `.mcp.json` server green.
 5. Trigger a matcher action (e.g. an `Edit` for `PostToolUse`/`Edit`); the hook command runs with no "schema mismatch" in the log.
@@ -99,7 +99,7 @@ AGENTS.md                                    # canonical entry-point pointer bod
 - **Commands**: one file per spec under `.codex/prompts/` (project-tier mirror of `~/.codex/prompts/`). Frontmatter passes through; body is the prompt template.
 - **Import**: `import codex` captures `.codex/config.toml` minus `hooks` and `mcp_servers` into `.agnostic-ai/overlays/codex.config.toml`. `sync -t codex` prepends it before the spec-derived sections, so `model`, `sandbox`, `approval_policy`, `notify`, `[history]`, `[profiles.*]`, `[model_providers.*]`, and any other key survive a `.codex/` wipe. On conflict with `outputs.codex.config.*` the overlay wins and the first-class key is dropped to keep TOML valid. `import codex` also reads `.codex/prompts/*.md` and writes them byte-for-byte to `<commands>/`, so user-authored prompts round-trip.
 
-Config keys: `outputs.codex.agents-dir` (default `.codex/agents`; override to `.agents/agents` for the community shared layout), `outputs.codex.skills-dir` (default `.codex/skills`; override to `.agents/skills`), `outputs.codex.shared-subagents` (default `false` when `claude` is also a target to avoid duplicating `.claude/skills/<name>/`, `true` when codex is alone), `outputs.codex.commands-dir` (default `.codex/prompts`), `outputs.codex.mcp-file` (default `.codex/config.toml`, also holds hooks), `outputs.codex.rules-file` (unset; writes legacy concatenated rules and skips the pointer-body write).
+Config keys: `outputs.codex.agents-dir` (default `.codex/agents`; override to `.agents/agents` for the community shared layout), `outputs.codex.skills-dir` (default `.codex/skills`; override to `.agents/skills`), `outputs.codex.shared-subagents` (default `true`; emits the per-skill tree at `skills-dir`. Set `false` to skip codex skill emission, useful when Codex reads claude's `.claude/skills/` tree directly), `outputs.codex.commands-dir` (default `.codex/prompts`), `outputs.codex.mcp-file` (default `.codex/config.toml`), `outputs.codex.hooks-file` (default `.codex/hooks.json`), `outputs.codex.rules-file` (unset; writes legacy concatenated rules and skips the pointer-body write).
 
 Verify with the real CLI:
 
@@ -150,7 +150,7 @@ Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.curs
 Verify with the real IDE:
 
 1. Install Cursor from [cursor.com](https://cursor.com).
-2. Check the tree: `ls .cursor/rules/ .cursor/mcp.json`, `head -1 .cursor/rules/*.mdc` for the provenance header (after frontmatter), `python -m json.tool .cursor/mcp.json > /dev/null`.
+2. Check the tree: `ls .cursor/rules/ .cursor/mcp.json`, `grep "Generated by agnostic-ai" .cursor/rules/*.mdc` for the provenance header (it sits after the frontmatter block), `python -m json.tool .cursor/mcp.json > /dev/null`.
 3. Open the project. The Rules panel loads every `.cursor/rules/*.mdc`; confirm `alwaysApply` matches each rule's frontmatter, no "failed to parse" warnings.
 4. If MCPs are configured, Settings → MCP shows every `mcpServers.<name>` green.
 
@@ -169,12 +169,12 @@ Verify with the real IDE:
 - **Chat modes**: when `outputs.copilot.chatmodes-dir` is set, each agent also emits as a [Copilot Custom Chat Mode](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot#about-custom-chat-modes) at `<dir>/<name>.chatmode.md` with `description`/`model`/`tools` frontmatter. The `agent-<name>.instructions.md` emission keeps working.
 - **MCP**: VS Code schema, top-level `servers` key, each entry carrying a `type` (`stdio`, `http`, or `sse`).
 
-Config keys: `outputs.copilot.instructions-dir` (default `.github/instructions`), `outputs.copilot.mcp-file` (default `.vscode/mcp.json`), `outputs.copilot.rules-file` (unset; writes always-on rules concatenated at that path and skips the pointer-body write).
+Config keys: `outputs.copilot.instructions-dir` (default `.github/instructions`), `outputs.copilot.mcp-file` (default `.vscode/mcp.json`), `outputs.copilot.chatmodes-dir` (default empty, opt-in; emits one Custom Chat Mode per agent), `outputs.copilot.rules-file` (unset; writes always-on rules concatenated at that path and skips the pointer-body write).
 
 Verify with the real extension:
 
 1. Install the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) (and optional Copilot Chat) in VS Code.
-2. Check the tree: `ls .github/copilot-instructions.md .github/instructions/ .vscode/mcp.json`, `head -1 .github/instructions/*.md` for the provenance header, `python -m json.tool .vscode/mcp.json > /dev/null`.
+2. Check the tree: `ls .github/copilot-instructions.md .github/instructions/ .vscode/mcp.json`, `grep "Generated by agnostic-ai" .github/instructions/*.md` for the provenance header (it sits after the `applyTo` frontmatter), `python -m json.tool .vscode/mcp.json > /dev/null`.
 3. Open the project. Copilot loads `.github/copilot-instructions.md` plus every matching `.instructions.md`. The `Output → GitHub Copilot` channel shows no "failed to parse instructions" warnings.
 4. Open a file matching a rule glob (e.g. a `.go` file for `applyTo: "**/*.go"`) and trigger chat; the rule body shows in context.
 5. If MCPs are configured, run `MCP: Show Installed Servers`; each `servers.<name>` from `.vscode/mcp.json` is ready.
@@ -212,7 +212,7 @@ Config keys: `outputs.cline.rules-dir` (default `.clinerules`), `outputs.cline.w
 Verify with the real extension:
 
 1. Install the [Cline extension](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev) in VS Code.
-2. Check the tree: `ls .clinerules/`, `head -1 .clinerules/*.md` for the provenance header.
+2. Check the tree: `ls .clinerules/`, `grep "Generated by agnostic-ai" .clinerules/*.md` for the provenance header.
 3. Open the project, open the Cline panel. Cline loads every `.clinerules/*.md`; each appears in the rules list with no "failed to parse" warnings.
 4. If `outputs.cline.workflows-dir` is set, each `<workflows-dir>/<name>.md` is invokable as `/<name>.md`; the italic description previews the workflow.
 
@@ -230,7 +230,7 @@ Config keys: `outputs.windsurf.rules-dir` (default `.windsurf/rules`), `outputs.
 Verify with the real IDE:
 
 1. Install Windsurf from [windsurf.com](https://windsurf.com).
-2. Check the tree: `ls .windsurf/rules/`, `head -1 .windsurf/rules/*.md` for the provenance header.
+2. Check the tree: `ls .windsurf/rules/`, `grep "Generated by agnostic-ai" .windsurf/rules/*.md` for the provenance header.
 3. Open the project. Cascade loads every `.windsurf/rules/*.md`; each appears in the Rules panel with no "failed to parse" warnings.
 4. When `outputs.windsurf.workflows-dir` is set, each `<workflows-dir>/<name>.md` is invokable in Cascade as `/<name>` with the rendered description.
 
@@ -250,7 +250,7 @@ Config keys: `outputs.continue.rules-dir` (default `.continue/rules`), `outputs.
 Verify with the real extension:
 
 1. Install the [Continue extension](https://marketplace.visualstudio.com/items?itemName=Continue.continue) in VS Code (or JetBrains).
-2. Check the tree: `ls .continue/rules/ .continue/mcpServers/`, `head -1 .continue/rules/*.md .continue/mcpServers/*.yaml` for the provenance header, `python -c "import yaml,sys; [yaml.safe_load(open(f)) for f in __import__('glob').glob('.continue/mcpServers/*.yaml')]"`.
+2. Check the tree: `ls .continue/rules/ .continue/mcpServers/`, `grep "Generated by agnostic-ai" .continue/rules/*.md .continue/mcpServers/*.yaml` for the provenance header, `python -c "import yaml,sys; [yaml.safe_load(open(f)) for f in __import__('glob').glob('.continue/mcpServers/*.yaml')]"`.
 3. Open the project. Continue loads every `.continue/rules/*.md`; each appears in the rules picker with no "failed to parse" warnings.
 4. The MCP picker shows each `.continue/mcpServers/<name>.yaml` green.
 5. If `outputs.continue.assistants-dir` is set, each `<dir>/<name>.yaml` is listed under the assistants picker with name + description.
@@ -275,7 +275,7 @@ Config keys: `outputs.amp.commands-dir` (default `.agents/commands`), `outputs.a
 Verify with the real CLI:
 
 1. Install: `npm install -g @sourcegraph/amp` (or the VS Code extension; both read the same files).
-2. Check the tree: `ls AGENTS.md .agents/commands/ .agents/skills/ .amp/settings.json`, `head -1 .agents/commands/*.md` for the provenance header, `test -f .agents/skills/*/SKILL.md`.
+2. Check the tree: `ls AGENTS.md .agents/commands/ .agents/skills/ .amp/settings.json`, `grep "Generated by agnostic-ai" .agents/commands/*.md` for the provenance header (it sits after the frontmatter), `test -f .agents/skills/*/SKILL.md`.
 3. Validate JSON: `python -m json.tool .amp/settings.json > /dev/null`.
 4. Open the project; Amp indexes `AGENTS.md` under "Project rules" with no `AGENT.md.bak` warning, and loads each `.agents/skills/<name>/SKILL.md` as a skill.
 5. The slash-command list shows each `.agents/commands/<name>.md` as `/<name>` with the rendered description.
@@ -297,7 +297,7 @@ Config keys: `outputs.zed.file` (default `.rules`), `outputs.zed.mcp-file` (defa
 Verify with the real editor:
 
 1. Install Zed from [zed.dev](https://zed.dev).
-2. Check the tree: `ls .rules .zed/settings.json .zed/tasks.json`, `head -1 .rules` for the "Generated by agnostic-ai" intro line, `python -m json.tool .zed/settings.json > /dev/null`, `python -m json.tool .zed/tasks.json > /dev/null`.
+2. Check the tree: `ls .rules .zed/settings.json .zed/tasks.json`, `grep "Generated by agnostic-ai" .rules` for the intro line (it follows the `# Project rules` title, not on line 1), `python -m json.tool .zed/settings.json > /dev/null`, `python -m json.tool .zed/tasks.json > /dev/null`.
 3. Open the project. The inline assistant reads `.rules` as system context; confirm a prompt sees the rule content.
 4. The MCP picker shows each `context_servers.<name>` ready.
 5. The command palette runs every entry from `.zed/tasks.json` as a Zed Task.
@@ -319,7 +319,7 @@ Config keys: `outputs.warp.workflows-dir` (default empty, opt-in), `outputs.warp
 Verify with the real terminal:
 
 1. Install Warp from [warp.dev](https://www.warp.dev).
-2. Check the tree: `ls AGENTS.md .warp/workflows/ .warp/.mcp.json`, `head -1 .warp/workflows/*.yaml` for the provenance header, `python -m json.tool .warp/.mcp.json > /dev/null`.
+2. Check the tree: `ls AGENTS.md .warp/workflows/ .warp/.mcp.json`, `grep "Generated by agnostic-ai" .warp/workflows/*.yaml` for the provenance header, `python -m json.tool .warp/.mcp.json > /dev/null`.
 3. Open the project; confirm the rules panel surfaces `AGENTS.md` (no "unrecognized file" warnings), the Warp Drive workflows picker shows every `<workflows-dir>/<name>.yaml`, and the MCP picker lists every `mcpServers.<name>` from `.warp/.mcp.json`.
 
 ### OpenCode (`opencode`)
@@ -339,7 +339,7 @@ Config keys: `outputs.opencode.commands-dir` (default `.opencode/commands`), `ou
 Verify with the real CLI:
 
 1. Install: `npm install -g sst/opencode` ([install docs](https://opencode.ai/)).
-2. Check the tree: `ls .opencode/AGENTS.md .opencode/commands/ opencode.json`, `head -1 .opencode/commands/*.md` for the provenance header, `python -m json.tool opencode.json > /dev/null`.
+2. Check the tree: `ls .opencode/AGENTS.md .opencode/commands/ opencode.json`, `grep "Generated by agnostic-ai" .opencode/commands/*.md` for the provenance header (it sits after the frontmatter), `python -m json.tool opencode.json > /dev/null`.
 3. Launch `opencode`. Every `.opencode/commands/<name>.md` appears in the slash-command picker with the rendered description.
 4. The MCP panel shows each `mcp.<name>` from `opencode.json` ready.
 
@@ -363,7 +363,7 @@ Config keys: `outputs.antigravity.rules-dir` (default `.agent/rules`), `outputs.
 Verify with the real IDE:
 
 1. Install Antigravity from the Google Antigravity public-preview download page.
-2. Check the tree: `ls .agent/AGENTS.md .agent/rules/ .agent/skills/`, `head -1 .agent/rules/*.md` for the provenance header, `test -f .agent/skills/*/SKILL.md`.
+2. Check the tree: `ls .agent/AGENTS.md .agent/rules/ .agent/skills/`, `grep "Generated by agnostic-ai" .agent/rules/*.md` for the provenance header (it sits after the frontmatter), `test -f .agent/skills/*/SKILL.md`.
 3. Open the project; it surfaces `.agent/AGENTS.md` in the project-instructions panel with no "unrecognized file" warnings.
 4. Open one of `.agent/rules/<name>.md` and verify the per-rule file is picked up; confirm each `.agent/skills/<name>/SKILL.md` loads as a skill.
 5. Trigger an agent action (e.g. ask for a refactor); the rules apply, with no schema-validation log entries referencing `.agent/`.

--- a/internal/cli/collision.go
+++ b/internal/cli/collision.go
@@ -22,8 +22,12 @@ import (
 //   - prefer-spec: skip the collision check; let the last adapter win.
 //   - fail: hard error with no resolution hint.
 //
-// AGENTS.md is the canonical example: Codex, Amp, Warp, OpenCode, and Zed
-// all default to that file. Enabling more than one causes silent
+// AGENTS.md is the canonical shared path: Codex, Amp, and Warp all default to
+// it (OpenCode defaults to .opencode/AGENTS.md and Zed to .rules, so neither
+// contends here). Their entry-point pointer body is byte-identical, so sync
+// deduplicates the write and they do not collide. A genuine collision is two
+// adapters writing DIFFERENT content to one path (e.g. a conflicting
+// outputs.<target>.rules-file: AGENTS.md), which would otherwise cause silent
 // last-writer-wins and perpetual drift in `sync --check`.
 func detectCollisions(cfg *config.Config, b spec.Bundle, targets []string) error {
 	policy := cfg.Sync.CollisionPolicy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,12 +382,13 @@ func warnLegacyOnce(path string) {
 		LegacyConfigFileName, ConfigFileName)
 }
 
-// DefaultTargets returns the safe out-of-the-box target list. Codex,
-// Amp, and Warp all default to root AGENTS.md per the community spec;
-// enabling more than one without an `outputs.<target>.file` override
-// triggers an output-collision error. The default picks Codex (which
-// also emits .codex/config.toml). Users who run Amp or Warp instead
-// must add them explicitly and drop or remap the colliders.
+// DefaultTargets returns the safe out-of-the-box target list. Codex, Amp,
+// and Warp all default to the root AGENTS.md per the community spec, but the
+// entry-point pointer body is byte-identical across them, so sync writes it
+// once (auto-dedup) and enabling more than one does not collide. The default
+// still picks only Codex (which also emits .codex/config.toml) and leaves Amp
+// and Warp out, since they add no new entry-point. A real collision needs two
+// targets to set a conflicting `outputs.<target>.rules-file: AGENTS.md`.
 func DefaultTargets() []string {
 	return []string{
 		"claude", "codex", "gemini", "cursor",


### PR DESCRIPTION
## Summary

Audited all 14 target adapters against the README, `targets.md`, `configuration.md`, and `spec-format.md`. **Every target syncs correctly, no code bugs found** — but the docs and two code comments had drifted from the working code. This PR realigns them. Docs/comments only, no behavior change.

Driven by a per-target audit that ran real `sync` against an all-kinds fixture (agents, skills+assets, scoped/globbed rules, all hook events, stdio+http+sse MCP, commands) and adversarially verified each finding. 33 confirmed misalignments.

## README capability matrix + legend

Replaced the 3-state glyph (`✅`/`◐`/`-`) with a **4-level support-depth scale** so each cell honestly says what you get out of the box:

- **✅ native** — tool's own format at the auto-load path
- **◐ bundled** — folded into the entry-point / merged doc (only Zed by default)
- **○ opt-in / source-dir** — flip an `outputs.<target>.*` key to materialize a file
- **- not supported**

Corrected cells: source-dir-only Rules (codex/gemini/amp/warp/opencode/aider) `✅→○`, gemini Skills `✅→○` (now matches opencode), Zed Hooks `-→○`, Warp Agents/Skills `◐→○`. Added a first-class framing lead-in and a verification note.

## Other fixes (high → low)

- **spec-format**: Gemini emits the hook `event:` verbatim — removed the example that taught a non-existent `PostToolUse`→`AfterTool` mapping (it produced an invalid Gemini config). Codex hooks render to `.codex/hooks.json`, not `config.toml`. Trimmed the per-directory scope table to targets that still scope. Zed MCP uses native `url`/`headers` (not `npx mcp-remote`). MCP no-support list +antigravity. gemini `model` drop documented.
- **config.go / collision.go**: `codex`+`amp`+`warp` share a byte-identical `AGENTS.md` pointer body via auto-dedup and **do not collide** (verified: combined sync exits 0, `--check` clean). OpenCode/Zed don't even default to root `AGENTS.md`.
- **configuration.md**: `amp` ignores `emit-skills-as-commands` (removed). Added missing `outputs.*` keys (cursor `commands-dir`, copilot `chatmodes-dir`, cline/windsurf `workflows-dir`, continue `assistants-dir`, zed `tasks-file`, antigravity `skills-dir`). Fixed the amp/warp "collision" wording and the backwards `on-unsupported` examples.
- **targets.md**: Commands column rendered on every matrix row (12 rows were short a cell). Provenance verify steps switched from `head -1` to `grep` so they work on frontmatter-leading files. Fixed codex `shared-subagents` default (`true`), the Claude `.claude/rules/` import note, copilot `chatmodes-dir`, and the MCP `type` note.

## Verification

- `go build ./...` ✓
- `go test ./...` → 1114 passed ✓
- `go run ./cmd/schemagen` → no diff (comment-only `config.go` edit) ✓
- Every capability-matrix row now has 7 columns ✓

## Note

The antigravity `sync --check` "drift" (gitignored `.agent/skills/` never synced after #372) is **correct by design**, not fixed here.