### PR TITLE
feat(init): ignore generated outputs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Changed
 
+- `init` now writes `gitignore.enabled: true` by default, so a fresh project ignores its generated outputs (`.claude/`, `.codex/`, `CLAUDE.md`, `AGENTS.md`, ...) and keeps `.agnostic-ai/` as the only committed copy. The TTY prompt defaults to yes and non-interactive runs take the default; pass `init --gitignore=false` to commit outputs instead. Existing configs without a `gitignore` key are unaffected.
+
 ### Fixed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ CI gate to fail PRs that drift from source specs:
   with: { command: check }
 ```
 
-**Commit or ignore generated outputs?** Recommended: gitignore them, keep `.agnostic-ai/` as the single source of truth, and let contributors run `sync` locally. Set `gitignore.enabled: true` and every `sync` maintains a managed `.gitignore` block listing each emitted path (see [configuration](docs/user/configuration.md#gitignore)). Committing the outputs is also valid when teammates lack the CLI. The `check` gate guards drift either way.
+**Commit or ignore generated outputs?** `agnostic-ai init` ignores them by default (`gitignore.enabled: true`): `.agnostic-ai/` is the single source of truth and contributors run `sync` locally, while every `sync` maintains a managed `.gitignore` block listing each emitted path (see [configuration](docs/user/configuration.md#gitignore)). Prefer to commit the outputs (e.g. teammates lack the CLI)? Scaffold with `init --gitignore=false`. The `check` gate guards drift either way.
 
 ## Documentation
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -305,7 +305,7 @@ Fires when an adapter receives spec kinds it does not support (e.g. `hooks` for 
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `enabled` | `false` | When true, every `sync` rewrites a managed block in `.gitignore` listing every path the configured adapters emit. |
+| `enabled` | `false` when the key is absent; `agnostic-ai init` writes `true` | When true, every `sync` rewrites a managed block in `.gitignore` listing every path the configured adapters emit. |
 | `path` | `.gitignore` | Override the file location. Useful for monorepos or local-only ignore files. |
 
 The managed block is delimited by `# >>> agnostic-ai (managed) >>>` and `# <<< agnostic-ai (managed) <<<`. Lines outside the block are preserved as-is. Re-running `sync` with no spec changes is a no-op (file mtime unchanged). Every entry is root-anchored (`/AGENTS.md`, not `AGENTS.md`), so a generated file never ignores a same-named file nested elsewhere.
@@ -314,9 +314,11 @@ Override per-run with `--gitignore on|off` on `sync`.
 
 ### Picking the default at `init`
 
-`agnostic-ai init` asks whether to enable the managed block when stdin is a TTY. Pick "No" (default) to commit emitted target files. Pick "Yes" to treat them as build artifacts. Non-interactive runs (CI, piped stdin) skip the prompt. Pass `--gitignore` to opt in:
+`agnostic-ai init` writes `gitignore.enabled: true` by default, so a fresh project keeps its generated outputs out of git and `.agnostic-ai/` stays the single committed source. When stdin is a TTY the confirm prompt defaults to "Yes, ignore them"; pick "No" to commit emitted files instead (useful when teammates lack the CLI). Non-interactive runs (CI, piped stdin) take the default without prompting. Opt out with `--gitignore=false`:
 
-    agnostic-ai init --all --gitignore
+    agnostic-ai init --all --gitignore=false
+
+Note this only affects newly scaffolded configs. An existing `agnostic-ai.yaml` with no `gitignore` key keeps the absent-key default (`false`); add the block by hand to opt in.
 
 ## Claude settings
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -30,10 +30,10 @@ func newInitCmd() *cobra.Command {
 			"Default base dir is .agnostic-ai/. Pass a positional argument " +
 			"to override (use \".\" for the legacy root-level layout). " +
 			"When stdin is a terminal, init prompts for which targets to enable " +
-			"and whether to keep a managed .gitignore block of every emitted target path; " +
+			"and whether to keep a managed .gitignore block of every emitted target path (default yes); " +
 			"pipe a comma-separated list to skip the target prompt, or pass --all / -a " +
 			"to skip both prompts and enable every supported target. " +
-			"Pass --gitignore to opt into the managed .gitignore block without a prompt. " +
+			"The managed .gitignore block is on by default; pass --gitignore=false to commit generated outputs instead. " +
 			"Pass --demo to seed each source folder with a minimal example spec. " +
 			"Pass --preset <name> to seed idiomatic specs for a stack (go, ts-react, python). " +
 			"Pass --from <cli> to scaffold and then import existing CLI config in one step.",
@@ -52,8 +52,8 @@ func newInitCmd() *cobra.Command {
   # Non-interactive: pipe the target list
   echo "claude,codex" | agnostic-ai init
 
-  # Enable the managed .gitignore block without prompting
-  agnostic-ai init --all --gitignore
+  # Commit generated outputs instead of ignoring them
+  agnostic-ai init --all --gitignore=false
 
   # Seed each source folder with one minimal example spec
   agnostic-ai init --demo
@@ -126,8 +126,8 @@ func newInitCmd() *cobra.Command {
 		"Print files that would be scaffolded without writing.")
 	cmd.Flags().StringVar(&fromCLI, "from", "",
 		"After scaffolding, import existing config from this CLI (e.g. claude, cursor, all).")
-	cmd.Flags().BoolVar(&gitignore, "gitignore", false,
-		"Persist gitignore.enabled=true so `sync` keeps a managed .gitignore block of every emitted target path. When unset and stdin is a TTY, init prompts.")
+	cmd.Flags().BoolVar(&gitignore, "gitignore", true,
+		"Persist gitignore.enabled so `sync` keeps a managed .gitignore block of every emitted target path. Enabled by default; pass --gitignore=false to commit generated outputs instead. When unset and stdin is a TTY, init prompts (defaulting to yes).")
 	_ = cmd.RegisterFlagCompletionFunc("preset", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return availablePresets(), cobra.ShellCompDirectiveNoFileComp
 	})
@@ -135,15 +135,21 @@ func newInitCmd() *cobra.Command {
 }
 
 // resolveGitignoreChoice picks the effective gitignore.enabled value
-// for a single init invocation:
+// for a single init invocation. A fresh project ignores its generated
+// outputs by default; the source specs under .agnostic-ai/ stay the one
+// committed copy and contributors run `sync` locally.
 //
-//   - explicit --gitignore wins (any value the user typed sticks),
-//   - --all skips the prompt and falls back to the flag default,
-//   - otherwise the TTY confirm prompt drives the choice; non-TTY stdin
-//     silently defaults to false so CI flows stay deterministic.
+//   - an explicit --gitignore / --gitignore=false wins (the typed value sticks),
+//   - --all skips the prompt and enables the managed block,
+//   - otherwise the TTY confirm prompt drives the choice (defaulting to
+//     yes); non-TTY stdin enables it so first-time and CI inits never
+//     silently commit generated files.
 func resolveGitignoreChoice(cmd *cobra.Command, all, flagValue bool) (bool, error) {
-	if cmd.Flags().Changed("gitignore") || all {
+	if cmd.Flags().Changed("gitignore") {
 		return flagValue, nil
+	}
+	if all {
+		return true, nil
 	}
 	return promptGitignoreEnable(cmd.InOrStdin())
 }

--- a/internal/cli/init_interactive.go
+++ b/internal/cli/init_interactive.go
@@ -139,22 +139,24 @@ func runInteractivePrompt(stderr io.Writer, preselected []string) ([]string, err
 
 // promptGitignoreEnable asks the user whether to enable
 // gitignore.enabled in the rendered config. Only TTY stdin runs the
-// confirm widget; piped or closed stdin falls back to false so CI
-// flows stay deterministic (use the --gitignore flag to flip it on
-// non-interactively).
+// confirm widget; piped or closed stdin falls back to true so first-time
+// and CI inits ignore generated outputs without a prompt (pass
+// --gitignore=false to commit them instead).
 //
-// Defaults to false because most teams commit emitted target files
-// (CLAUDE.md, AGENTS.md, .cursor/, ...) so non-agnostic-ai users still
-// see the project conventions without running `sync`.
+// Defaults to true: the source specs under .agnostic-ai/ are the one
+// committed copy, and treating the emitted target files (CLAUDE.md,
+// AGENTS.md, .cursor/, ...) as build artifacts keeps them out of git
+// and review noise. Flip off if teammates lack the CLI and need the
+// generated conventions committed.
 func promptGitignoreEnable(in io.Reader) (bool, error) {
 	f, ok := in.(*os.File)
 	if !ok || !term.IsTerminal(f.Fd()) {
-		return false, nil
+		return true, nil
 	}
-	picked := false
+	picked := true
 	form := huh.NewConfirm().
 		Title("Ignore generated target files in .gitignore?").
-		Description("`sync` will keep a managed block of every emitted target path. Off by default; flip on if your team treats emitted files as build artifacts.").
+		Description("`sync` will keep a managed block of every emitted target path. On by default; flip off if your team commits emitted files so teammates without the CLI still see the conventions.").
 		Affirmative("Yes, ignore them").
 		Negative("No, commit them").
 		Value(&picked)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -329,7 +329,7 @@ func TestInitCmd_GitignoreFlagPersistsEnabled(t *testing.T) {
 	}
 }
 
-func TestInitCmd_NonTTY_NoPromptDefaultsDisabled(t *testing.T) {
+func TestInitCmd_NonTTY_NoPromptDefaultsEnabled(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)
 	silence(t)
@@ -344,8 +344,27 @@ func TestInitCmd_NonTTY_NoPromptDefaultsDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !strings.Contains(string(cfg), "gitignore:\n  enabled: true\n") {
+		t.Errorf("non-TTY init must default to the managed gitignore block:\n%s", cfg)
+	}
+}
+
+func TestInitCmd_GitignoreOptOut(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"init", "--all", "--gitignore=false"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "agnostic-ai.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Contains(string(cfg), "gitignore:") {
-		t.Errorf("non-TTY init without --gitignore must not write gitignore block:\n%s", cfg)
+		t.Errorf("--gitignore=false must commit generated outputs (no gitignore block):\n%s", cfg)
 	}
 }
 


### PR DESCRIPTION
## What

`agnostic-ai init` now scaffolds `agnostic-ai.yaml` with `gitignore.enabled: true` by default. A fresh project keeps its generated outputs (`.claude/`, `.codex/`, `CLAUDE.md`, `AGENTS.md`, ...) out of git, and `.agnostic-ai/` stays the single committed source of truth. Every `sync` maintains the managed `.gitignore` block.

## Why

The default was off, so the common first-time non-interactive flow silently committed generated files:

```
echo "claude,codex" | agnostic-ai init   # no gitignore block -> sync commits outputs
```

Non-TTY stdin fell through to `false`, contradicting the README's own "Recommended: gitignore them".

## Behavior

- TTY confirm prompt now defaults to **yes**.
- Non-interactive runs (CI, piped stdin) and `--all` take the **enabled** default without prompting.
- Opt out with `agnostic-ai init --gitignore=false` to commit outputs instead.
- **Scope-safe:** only fresh `init` writes the key. Existing `agnostic-ai.yaml` files with no `gitignore` key keep the absent-key default (`false`), so upgrading changes nothing for current projects.

## Changes

- `resolveGitignoreChoice`: `--all` and non-interactive paths resolve to `true`; explicit `--gitignore[=false]` still wins.
- `promptGitignoreEnable`: non-TTY returns `true`; TTY confirm defaults to yes.
- `--gitignore` flag default `true` (opt out via `--gitignore=false`).
- Docs: `configuration.md`, `README.md`, init help/examples, CHANGELOG.

## Tests

- Inverted the non-TTY default test (now expects the managed block).
- Added an opt-out test (`init --all --gitignore=false` writes no block).
- `go vet`, `golangci-lint`, gofmt, full `go test ./...` green. Smoke-tested the built binary: default-on for piped/`--all`, off for `--gitignore=false`, and `init --demo` + `sync` ignores the outputs end-to-end.