### PR TITLE
fix(skills): stop flat-file skills leaking siblings into each folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- Flat-file skills (`.agnostic-ai/skills/<name>.md`) no longer leak their sibling skills' bodies into each emitted skill folder. Sibling-asset propagation now applies only to folder-based skills (`<name>/SKILL.md`), which own their directory. Affects the claude, codex, amp, and antigravity targets. Closes #387.
+
 ### Removed
 
 ## v0.32.1 - 2026-06-04

--- a/internal/adapters/amp/skill.go
+++ b/internal/adapters/amp/skill.go
@@ -27,13 +27,8 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 	if err := emit.WriteFile(filepath.Join(folder, "SKILL.md"), emit.WithHeader(skillMarkdown(s), emit.FormatMarkdown), dryRun); err != nil {
 		return err
 	}
-	return emit.PropagateSkillAssets(s, folder, skipSKILL, dryRun)
+	return emit.PropagateSkillAssets(s, folder, emit.SkipSKILLMd, dryRun)
 }
-
-// skipSKILL excludes the re-rendered SKILL.md from sibling-asset
-// propagation; everything else next to the source SKILL.md is copied
-// verbatim.
-func skipSKILL(rel string) bool { return rel == "SKILL.md" }
 
 func skillMarkdown(s spec.Entry) string {
 	resolved := emit.ResolveMeta(s.Meta, target)

--- a/internal/adapters/amp/skill.go
+++ b/internal/adapters/amp/skill.go
@@ -27,22 +27,13 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 	if err := emit.WriteFile(filepath.Join(folder, "SKILL.md"), emit.WithHeader(skillMarkdown(s), emit.FormatMarkdown), dryRun); err != nil {
 		return err
 	}
-	return propagateSkillAssets(s, folder, dryRun)
+	return emit.PropagateSkillAssets(s, folder, skipSKILL, dryRun)
 }
 
-// propagateSkillAssets mirrors every sibling file under the source skill
-// directory into the emitted folder, skipping SKILL.md because the
-// adapter re-renders it from the spec frontmatter. No-op when the source
-// path is unknown (in-memory specs from the playground).
-func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
-	if s.Path == "" {
-		return nil
-	}
-	srcDir := filepath.Dir(s.Path)
-	return emit.CopyTree(srcDir, dstDir, func(rel string) bool {
-		return rel == "SKILL.md"
-	}, dryRun)
-}
+// skipSKILL excludes the re-rendered SKILL.md from sibling-asset
+// propagation; everything else next to the source SKILL.md is copied
+// verbatim.
+func skipSKILL(rel string) bool { return rel == "SKILL.md" }
 
 func skillMarkdown(s spec.Entry) string {
 	resolved := emit.ResolveMeta(s.Meta, target)

--- a/internal/adapters/antigravity/skill.go
+++ b/internal/adapters/antigravity/skill.go
@@ -24,13 +24,8 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 	if err := emit.WriteFile(filepath.Join(folder, "SKILL.md"), emit.WithHeader(skillMarkdown(s), emit.FormatMarkdown), dryRun); err != nil {
 		return err
 	}
-	return emit.PropagateSkillAssets(s, folder, skipSKILL, dryRun)
+	return emit.PropagateSkillAssets(s, folder, emit.SkipSKILLMd, dryRun)
 }
-
-// skipSKILL excludes the re-rendered SKILL.md from sibling-asset
-// propagation; everything else next to the source SKILL.md is copied
-// verbatim.
-func skipSKILL(rel string) bool { return rel == "SKILL.md" }
 
 func skillMarkdown(s spec.Entry) string {
 	resolved := emit.ResolveMeta(s.Meta, target)

--- a/internal/adapters/antigravity/skill.go
+++ b/internal/adapters/antigravity/skill.go
@@ -24,22 +24,13 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 	if err := emit.WriteFile(filepath.Join(folder, "SKILL.md"), emit.WithHeader(skillMarkdown(s), emit.FormatMarkdown), dryRun); err != nil {
 		return err
 	}
-	return propagateSkillAssets(s, folder, dryRun)
+	return emit.PropagateSkillAssets(s, folder, skipSKILL, dryRun)
 }
 
-// propagateSkillAssets mirrors every sibling file under the source skill
-// directory into the emitted folder, skipping SKILL.md because the
-// adapter re-renders it from the spec frontmatter. No-op when the source
-// path is unknown (in-memory specs from the playground).
-func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
-	if s.Path == "" {
-		return nil
-	}
-	srcDir := filepath.Dir(s.Path)
-	return emit.CopyTree(srcDir, dstDir, func(rel string) bool {
-		return rel == "SKILL.md"
-	}, dryRun)
-}
+// skipSKILL excludes the re-rendered SKILL.md from sibling-asset
+// propagation; everything else next to the source SKILL.md is copied
+// verbatim.
+func skipSKILL(rel string) bool { return rel == "SKILL.md" }
 
 func skillMarkdown(s spec.Entry) string {
 	resolved := emit.ResolveMeta(s.Meta, target)

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -81,7 +81,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		if err := emit.WriteFile(path, body, dryRun); err != nil {
 			return err
 		}
-		if err := propagateSkillAssets(s, folder, dryRun); err != nil {
+		if err := emit.PropagateSkillAssets(s, folder, claudeSkillSkipFor(s), dryRun); err != nil {
 			return err
 		}
 	}
@@ -134,20 +134,6 @@ func materializeHookScripts(hooks []spec.Entry, dryRun bool) error {
 		}
 	}
 	return nil
-}
-
-// propagateSkillAssets mirrors every sibling file under the source
-// skill directory (`<skills-src>/<name>/`) into the emitted skill
-// folder, skipping SKILL.md (re-rendered from the spec), any
-// `agents/openai.yaml` (codex-only metadata that Claude does not read),
-// and any other top-level entry the spec marks under `x-codex.assets`
-// (folders the codex importer pulled in that the claude side never had,
-// e.g. helper `scripts/` directories — #305).
-//
-// Flat-file skills share one source directory, so emit.PropagateSkillAssets
-// suppresses propagation for them (#387).
-func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
-	return emit.PropagateSkillAssets(s, dstDir, claudeSkillSkipFor(s), dryRun)
 }
 
 // claudeSkillSkipFor returns a per-skill skip predicate honoring the

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -144,16 +144,10 @@ func materializeHookScripts(hooks []spec.Entry, dryRun bool) error {
 // (folders the codex importer pulled in that the claude side never had,
 // e.g. helper `scripts/` directories — #305).
 //
-// No-op when the source path is unknown (e.g. specs loaded from raw
-// bytes in the WASM playground) so adapters stay safe for in-memory
-// callers.
+// Flat-file skills share one source directory, so emit.PropagateSkillAssets
+// suppresses propagation for them (#387).
 func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
-	if s.Path == "" {
-		return nil
-	}
-	srcDir := filepath.Dir(s.Path)
-	skip := claudeSkillSkipFor(s)
-	return emit.CopyTree(srcDir, dstDir, skip, dryRun)
+	return emit.PropagateSkillAssets(s, dstDir, claudeSkillSkipFor(s), dryRun)
 }
 
 // claudeSkillSkipFor returns a per-skill skip predicate honoring the

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -215,6 +215,53 @@ func TestEmit_PropagatesSkillAssets(t *testing.T) {
 	}
 }
 
+// Flat-file skills (`skills/<name>.md`, the default `agnostic-ai new skill`
+// scaffold) share one source directory. Each emitted skill folder must hold
+// only its own SKILL.md, not a copy of every sibling skill's body (#387).
+func TestEmit_FlatFileSkillsDoNotLeakSiblings(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	skillsDir := filepath.Join(dir, ".agnostic-ai", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	names := []string{"alpha", "beta", "gamma"}
+	entries := make([]spec.Entry, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(skillsDir, name+".md")
+		if err := os.WriteFile(path, []byte("---\nname: "+name+"\n---\nbody\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		entries = append(entries, spec.Entry{
+			Kind: spec.KindSkill,
+			Name: name,
+			Path: path,
+			Meta: map[string]any{"name": name},
+			Body: "body",
+		})
+	}
+
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range names {
+		folder := filepath.Join(dir, ".claude", "skills", name)
+		got, err := os.ReadDir(folder)
+		if err != nil {
+			t.Fatalf("read %s: %v", folder, err)
+		}
+		var files []string
+		for _, e := range got {
+			files = append(files, e.Name())
+		}
+		if len(files) != 1 || files[0] != "SKILL.md" {
+			t.Errorf("skill %q folder = %v, want only [SKILL.md]", name, files)
+		}
+	}
+}
+
 // A spec that lists codex-only subtrees under `x-codex.assets` must skip
 // those subtrees during claude emit, even if they live in the agnostic
 // source dir (#305).

--- a/internal/adapters/codex/skill.go
+++ b/internal/adapters/codex/skill.go
@@ -40,7 +40,7 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 		return err
 	}
 
-	if err := emit.PropagateSkillAssets(s, folder, skipSKILL, dryRun); err != nil {
+	if err := emit.PropagateSkillAssets(s, folder, emit.SkipSKILLMd, dryRun); err != nil {
 		return err
 	}
 
@@ -51,11 +51,6 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 	}
 	return nil
 }
-
-// skipSKILL excludes the re-rendered SKILL.md from sibling-asset
-// propagation; everything else next to the source SKILL.md is copied
-// verbatim.
-func skipSKILL(rel string) bool { return rel == "SKILL.md" }
 
 func skillMarkdown(s spec.Entry) string {
 	// Resolve description through the per-target meta so a spec

--- a/internal/adapters/codex/skill.go
+++ b/internal/adapters/codex/skill.go
@@ -40,7 +40,7 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 		return err
 	}
 
-	if err := propagateSkillAssets(s, folder, dryRun); err != nil {
+	if err := emit.PropagateSkillAssets(s, folder, skipSKILL, dryRun); err != nil {
 		return err
 	}
 
@@ -52,19 +52,10 @@ func emitSkill(s spec.Entry, skillsDir string, dryRun bool) error {
 	return nil
 }
 
-// propagateSkillAssets mirrors every sibling file under the source
-// skill directory into the emitted folder, skipping SKILL.md because
-// the adapter re-renders it from the spec frontmatter. No-op when the
-// source path is unknown (in-memory specs from the playground).
-func propagateSkillAssets(s spec.Entry, dstDir string, dryRun bool) error {
-	if s.Path == "" {
-		return nil
-	}
-	srcDir := filepath.Dir(s.Path)
-	return emit.CopyTree(srcDir, dstDir, func(rel string) bool {
-		return rel == "SKILL.md"
-	}, dryRun)
-}
+// skipSKILL excludes the re-rendered SKILL.md from sibling-asset
+// propagation; everything else next to the source SKILL.md is copied
+// verbatim.
+func skipSKILL(rel string) bool { return rel == "SKILL.md" }
 
 func skillMarkdown(s spec.Entry) string {
 	// Resolve description through the per-target meta so a spec

--- a/internal/adapters/internal/emit/skill_assets.go
+++ b/internal/adapters/internal/emit/skill_assets.go
@@ -1,0 +1,35 @@
+package emit
+
+import (
+	"path/filepath"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// PropagateSkillAssets mirrors the sibling files of a folder-based skill
+// (`<skills-src>/<name>/SKILL.md`) into the emitted skill folder, applying
+// skip to exclude entries the adapter re-renders itself (SKILL.md, plus any
+// adapter-specific extras such as codex-only assets).
+//
+// Flat-file skills (`<skills-src>/<name>.md`, the default `agnostic-ai new
+// skill` scaffold) share one source directory, so a naive copy would mirror
+// every other skill's body into each skill's folder (#387). Detection keys
+// on the SKILL.md basename, matching the loader's folder-skill rule, and
+// propagation is suppressed for flat-file skills.
+//
+// No-op when the source path is unknown (empty Path, e.g. in-memory specs
+// from the WASM playground) so adapters stay safe for non-disk callers.
+func PropagateSkillAssets(s spec.Entry, dstDir string, skip func(rel string) bool, dryRun bool) error {
+	if !FolderBasedSkill(s) {
+		return nil
+	}
+	return CopyTree(filepath.Dir(s.Path), dstDir, skip, dryRun)
+}
+
+// FolderBasedSkill reports whether the skill spec owns its own directory
+// (`<name>/SKILL.md`) rather than living as a flat file (`<name>.md`).
+// Folder-based skills own their sibling assets; flat-file skills share the
+// parent skills directory and have no per-skill assets to propagate.
+func FolderBasedSkill(s spec.Entry) bool {
+	return s.Path != "" && filepath.Base(s.Path) == "SKILL.md"
+}

--- a/internal/adapters/internal/emit/skill_assets.go
+++ b/internal/adapters/internal/emit/skill_assets.go
@@ -26,6 +26,11 @@ func PropagateSkillAssets(s spec.Entry, dstDir string, skip func(rel string) boo
 	return CopyTree(filepath.Dir(s.Path), dstDir, skip, dryRun)
 }
 
+// SkipSKILLMd is the common sibling-asset skip predicate: it excludes the
+// re-rendered SKILL.md and copies everything else verbatim. Adapters that
+// need extra exclusions (e.g. codex-only assets) pass their own predicate.
+func SkipSKILLMd(rel string) bool { return rel == "SKILL.md" }
+
 // FolderBasedSkill reports whether the skill spec owns its own directory
 // (`<name>/SKILL.md`) rather than living as a flat file (`<name>.md`).
 // Folder-based skills own their sibling assets; flat-file skills share the

--- a/internal/adapters/internal/emit/skill_assets_test.go
+++ b/internal/adapters/internal/emit/skill_assets_test.go
@@ -1,0 +1,86 @@
+package emit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+func TestFolderBasedSkill(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"folder skill", filepath.Join("skills", "alpha", "SKILL.md"), true},
+		{"flat skill", filepath.Join("skills", "alpha.md"), false},
+		{"in-memory spec", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FolderBasedSkill(spec.Entry{Name: "alpha", Path: tc.path}); got != tc.want {
+				t.Errorf("FolderBasedSkill(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// A flat-file skill shares the skills/ directory with its siblings, so
+// propagation must copy nothing — otherwise every sibling skill body leaks
+// into this skill's folder (#387).
+func TestPropagateSkillAssets_FlatFileSkipsSiblings(t *testing.T) {
+	dir := t.TempDir()
+	skillsDir := filepath.Join(dir, "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"alpha.md", "beta.md", "gamma.md"} {
+		if err := os.WriteFile(filepath.Join(skillsDir, name), []byte("---\nname: x\n---\nbody\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := spec.Entry{Kind: spec.KindSkill, Name: "alpha", Path: filepath.Join(skillsDir, "alpha.md")}
+	dst := filepath.Join(dir, "out", "alpha")
+	if err := PropagateSkillAssets(s, dst, skipNothing, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if entries, err := os.ReadDir(dst); err == nil && len(entries) > 0 {
+		t.Errorf("flat-file skill leaked %d sibling files into %s", len(entries), dst)
+	}
+}
+
+// A folder-based skill owns its directory, so every sibling asset (minus the
+// re-rendered SKILL.md) propagates into the emitted folder.
+func TestPropagateSkillAssets_FolderCopiesSiblings(t *testing.T) {
+	dir := t.TempDir()
+	srcSkill := filepath.Join(dir, "skills", "alpha")
+	if err := os.MkdirAll(filepath.Join(srcSkill, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "SKILL.md"), []byte("---\nname: alpha\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcSkill, "scripts", "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := spec.Entry{Kind: spec.KindSkill, Name: "alpha", Path: filepath.Join(srcSkill, "SKILL.md")}
+	dst := filepath.Join(dir, "out", "alpha")
+	skip := func(rel string) bool { return rel == "SKILL.md" }
+	if err := PropagateSkillAssets(s, dst, skip, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, "scripts", "run.sh")); err != nil {
+		t.Errorf("folder skill did not propagate sibling asset: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "SKILL.md")); err == nil {
+		t.Errorf("skip predicate ignored: SKILL.md was copied")
+	}
+}
+
+func skipNothing(string) bool { return false }


### PR DESCRIPTION
## Summary
- Flat-file skills (`.agnostic-ai/skills/<name>.md`) shared one source directory, so sibling-asset propagation copied every other skill's body into each emitted skill folder (and a redundant self-copy of the spec file). Propagation now runs only for folder-based skills (`<name>/SKILL.md`), which own their directory.
- Factored the four duplicated `propagateSkillAssets` copies (claude, codex, amp, antigravity) into one `emit.PropagateSkillAssets` helper, with a shared `emit.SkipSKILLMd` predicate.
- Detection keys on the `SKILL.md` basename, matching the loader's folder-skill rule. In-memory specs (empty Path, WASM playground) stay a no-op.

## Test plan
- [x] go test ./... (1122 pass)
- [x] agnostic-ai sync --check (no drift; repo dogfoods folder-based skills)
- New regression tests: flat-file multi-skill emit keeps each `.claude/skills/<name>/` to just its own `SKILL.md`; emit-level `FolderBasedSkill` / propagation unit tests.

Closes #387