### PR TITLE
feat(gitignore): add allow list for managed-block re-allow lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `gitignore.allow` config: a list of re-allow patterns emitted as `!`-prefixed lines at the end of the managed `.gitignore` block. Keeps a tracked file (e.g. a `testdata/AGENTS.md` fixture) from being ignored by a broader rule, without hand-editing the block. Closes #388.
+
 ### Changed
 
 - `init` now writes `gitignore.enabled: true` by default, so a fresh project ignores its generated outputs (`.claude/`, `.codex/`, `CLAUDE.md`, `AGENTS.md`, ...) and keeps `.agnostic-ai/` as the only committed copy. The TTY prompt defaults to yes and non-interactive runs take the default; pass `init --gitignore=false` to commit outputs instead. Existing configs without a `gitignore` key are unaffected.

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -242,6 +242,12 @@
         },
         "path": {
           "type": "string"
+        },
+        "allow": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -147,6 +147,8 @@ on-unsupported: warn   # warn | error | silent
 gitignore:
   enabled: false
   path: .gitignore   # default
+  allow:             # keep these tracked even when a broader ignore matches
+    - "**/testdata/AGENTS.md"
 ```
 
 ## Top-level fields
@@ -307,8 +309,9 @@ Fires when an adapter receives spec kinds it does not support (e.g. `hooks` for 
 |-------|---------|-------------|
 | `enabled` | `false` when the key is absent; `agnostic-ai init` writes `true` | When true, every `sync` rewrites a managed block in `.gitignore` listing every path the configured adapters emit. |
 | `path` | `.gitignore` | Override the file location. Useful for monorepos or local-only ignore files. |
+| `allow` | empty | Re-allow patterns emitted as `!`-prefixed lines at the end of the managed block. Keeps a tracked file (e.g. a `testdata/AGENTS.md` fixture) from being ignored by a broader rule, without hand-editing. Patterns are gitignore globs, emitted verbatim. |
 
-The managed block is delimited by `# >>> agnostic-ai (managed) >>>` and `# <<< agnostic-ai (managed) <<<`. Lines outside the block are preserved as-is. Re-running `sync` with no spec changes is a no-op (file mtime unchanged). Every entry is root-anchored (`/AGENTS.md`, not `AGENTS.md`), so a generated file never ignores a same-named file nested elsewhere.
+The managed block is delimited by `# >>> agnostic-ai (managed) >>>` and `# <<< agnostic-ai (managed) <<<`. Lines outside the block are preserved as-is. Re-running `sync` with no spec changes is a no-op (file mtime unchanged). Every generated entry is root-anchored (`/AGENTS.md`, not `AGENTS.md`), so a generated file never ignores a same-named file nested elsewhere. For cases a root-anchored ignore can't express, add the glob to `allow`; its `!` line is written last so it overrides the ignores above it.
 
 Override per-run with `--gitignore on|off` on `sync`.
 

--- a/internal/cli/gitignore.go
+++ b/internal/cli/gitignore.go
@@ -158,6 +158,40 @@ func gitignoreTopSegment(p string) string {
 	return p
 }
 
+// buildManagedBlock assembles the managed-block lines: collapsed,
+// root-anchored ignores first, then the configured re-allow exceptions as
+// `!`-prefixed lines. Allows are emitted last so they override any broader
+// ignore above them, letting a project keep a tracked fixture (e.g.
+// `internal/adapters/**/testdata/**`) without hand-editing the block (#388).
+func buildManagedBlock(cfg *config.Config, entries []string) []string {
+	block := collapseManagedEntries(normalizeAndSort(entries), protectedSourceTopDirs(cfg))
+	return append(block, normalizeAllowEntries(cfg.Gitignore.Allow)...)
+}
+
+// normalizeAllowEntries turns the configured allow patterns into `!`-prefixed
+// gitignore lines: forward slashes, leading `./` and `!` trimmed before the
+// canonical `!` is re-added, blanks dropped, deduplicated, sorted. Patterns
+// are gitignore globs and stay unanchored so a re-allow like `**/AGENTS.md`
+// keeps matching at any depth.
+func normalizeAllowEntries(patterns []string) []string {
+	seen := make(map[string]struct{}, len(patterns))
+	for _, p := range patterns {
+		p = strings.TrimSpace(filepath.ToSlash(p))
+		p = strings.TrimPrefix(p, "./")
+		p = strings.TrimPrefix(p, "!")
+		if p == "" {
+			continue
+		}
+		seen["!"+p] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // updateGitignore rewrites the managed block in `.gitignore` (or
 // cfg.Gitignore.Path) with the provided entries. Lines outside the block
 // are preserved as-is. The file is created if missing. An empty entries

--- a/internal/cli/gitignore.go
+++ b/internal/cli/gitignore.go
@@ -59,12 +59,7 @@ func normalizeAndSort(paths []string) []string {
 			seen[n] = struct{}{}
 		}
 	}
-	out := make([]string, 0, len(seen))
-	for p := range seen {
-		out = append(out, p)
-	}
-	sort.Strings(out)
-	return out
+	return sortedKeys(seen)
 }
 
 // normalizeGitignorePath converts a filesystem path to a gitignore entry:
@@ -184,12 +179,7 @@ func normalizeAllowEntries(patterns []string) []string {
 		}
 		seen["!"+p] = struct{}{}
 	}
-	out := make([]string, 0, len(seen))
-	for p := range seen {
-		out = append(out, p)
-	}
-	sort.Strings(out)
-	return out
+	return sortedKeys(seen)
 }
 
 // updateGitignore rewrites the managed block in `.gitignore` (or

--- a/internal/cli/gitignore_test.go
+++ b/internal/cli/gitignore_test.go
@@ -247,6 +247,45 @@ func TestCollapseManagedEntries_NeverIgnoresSourceTree(t *testing.T) {
 	}
 }
 
+func TestNormalizeAllowEntries_PrefixesDedupesSorts(t *testing.T) {
+	got := normalizeAllowEntries([]string{
+		"internal/adapters/**/testdata/**",
+		"!**/AGENTS.md",        // user-supplied bang is tolerated, not doubled
+		"./fixtures/CLAUDE.md", // leading ./ stripped
+		"  ",                   // blank dropped
+		"**/AGENTS.md",         // duplicate of the bang form above
+	})
+	want := []string{
+		"!**/AGENTS.md",
+		"!fixtures/CLAUDE.md",
+		"!internal/adapters/**/testdata/**",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// The managed block lists collapsed ignores first, then re-allow lines so a
+// fixture tree stays tracked even when enabled (#388).
+func TestBuildManagedBlock_AppendsAllowExceptionsLast(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gitignore.Allow = []string{"internal/adapters/**/testdata/**"}
+	got := buildManagedBlock(cfg, []string{".claude/CLAUDE.md", "AGENTS.md"})
+	if len(got) == 0 || got[len(got)-1] != "!internal/adapters/**/testdata/**" {
+		t.Fatalf("re-allow line not appended last: %v", got)
+	}
+	for _, e := range got[:len(got)-1] {
+		if strings.HasPrefix(e, "!") {
+			t.Errorf("re-allow line %q appeared before ignores: %v", e, got)
+		}
+	}
+}
+
 func TestProtectedSourceTopDirs_IncludesLayerAndSources(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Sources.Agents = ".agnostic-ai/agents"

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -171,7 +171,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	if gitignoreOn {
 		entries := adapters.StopRecording()
 		entries = append(entries, ".agnostic-ai/.sync-state")
-		block := collapseManagedEntries(normalizeAndSort(entries), protectedSourceTopDirs(cfg))
+		block := buildManagedBlock(cfg, entries)
 		if err := updateGitignore(cfg, block); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
@@ -332,7 +332,7 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 	if gitignoreOn {
 		entries := adapters.StopRecording()
 		entries = append(entries, ".agnostic-ai/.sync-state")
-		block := collapseManagedEntries(normalizeAndSort(entries), protectedSourceTopDirs(cfg))
+		block := buildManagedBlock(cfg, entries)
 		if err := updateGitignore(cfg, block); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,11 @@ type Gitignore struct {
 	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Path overrides the .gitignore location relative to the project root.
 	Path string `yaml:"path,omitempty"    json:"path,omitempty"`
+	// Allow lists re-allow patterns emitted as `!`-prefixed lines at the
+	// end of the managed block. Use it to keep tracked files (e.g.
+	// `testdata/AGENTS.md` fixtures) that a broader ignore would otherwise
+	// catch. Patterns are gitignore globs, emitted verbatim.
+	Allow []string `yaml:"allow,omitempty"   json:"allow,omitempty"`
 }
 
 type Sources struct {

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -99,6 +99,28 @@ func TestSync_AddsStateFileToGitignore(t *testing.T) {
 	}
 }
 
+func TestSync_GitignoreAllowEmitsReAllowLines(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	// Override the fixture config to add a re-allow pattern for a fixture tree.
+	must(t, os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"),
+		[]byte("version: 1\ngitignore:\n  enabled: true\n  allow:\n    - \"**/testdata/AGENTS.md\"\n"), 0o644))
+
+	root := cli.NewRootCmd("test")
+	root.SetArgs([]string{"sync"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(content), "!**/testdata/AGENTS.md") {
+		t.Errorf("expected re-allow line in managed block, got:\n%s", content)
+	}
+}
+
 func TestSync_LedgerSweepsOrphanedAdapterOutput(t *testing.T) {
 	dir := setupFixture(t)
 	testutil.Chdir(t, dir)


### PR DESCRIPTION
## Summary
- New `gitignore.allow` config: a list of glob patterns emitted as `!`-prefixed re-allow lines at the **end** of the managed `.gitignore` block, so they override the ignores above them.
- Lets a project that ships fixtures named like adapter outputs (e.g. `testdata/AGENTS.md`) enable `gitignore.enabled: true` and keep those fixtures tracked, without hand-editing the block.
- Both `sync` paths (text + JSON) now build the block through one `buildManagedBlock` helper. Schema regenerated.

## Notes
- This repo's own hand-rolled `.gitignore` (the dogfooding example in the issue) is left as-is; migrating it to the managed block is a separate, optional follow-up.
- Ref pass surfaced one cleanup: reuse the existing `sortedKeys` helper for allow normalization.

## Test plan
- [x] go test ./... (1125 pass)
- [x] agnostic-ai sync --check (no drift)
- [x] schema regenerated (`go run ./cmd/schemagen`)
- New tests: `normalizeAllowEntries` (prefix/dedup/sort), `buildManagedBlock` (allows appended last), integration `TestSync_GitignoreAllowEmitsReAllowLines`.

Closes #388