### PR TITLE
fix(revert): restore and force-delete entry-point files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- `revert` now restores the entry-point files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `AGNOSTIC_AI.md`) from their `.bak`, matching adapter-emitted files. A `sync --backup` then `revert` round-trip previously left the user's original content orphaned in `.bak`; `revert --force` now also deletes the generated entry-point files. Closes #389.
 - Flat-file skills (`.agnostic-ai/skills/<name>.md`) no longer leak their sibling skills' bodies into each emitted skill folder. Sibling-asset propagation now applies only to folder-based skills (`<name>/SKILL.md`), which own their directory. Affects the claude, codex, amp, and antigravity targets. Closes #387.
 
 ### Removed

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -285,7 +285,7 @@ Each entry in `writes` and `skipped` has: `target` (string), `path` (string), `a
 
 ## revert
 
-Undo a previous sync. For every file an adapter would emit, restores `<path>.bak` when present (and removes the .bak). With no `.bak`, the file is left in place by default so user-authored content sharing a path with adapter output (helper scripts next to `SKILL.md`, templates inside a propagated skill folder) is not deleted. Pass `--force` to delete those unbacked files.
+Undo a previous sync. For every file an adapter would emit, plus the entry-point files sync distributes (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `.agnostic-ai/AGNOSTIC_AI.md`), restores `<path>.bak` when present (and removes the .bak). With no `.bak`, the file is left in place by default so user-authored content sharing a path with adapter output (helper scripts next to `SKILL.md`, templates inside a propagated skill folder) is not deleted. Pass `--force` to delete those unbacked files, including the generated entry-point files.
 
 ```bash
 agnostic-ai revert [flags]

--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -53,6 +53,29 @@ func writeAgnosticEntryPoints(cfg *config.Config, targets []string, dryRun bool)
 	return nil
 }
 
+// entryPointPaths returns the entry-point files sync distributes: the
+// canonical AGNOSTIC_AI.md plus each enabled target's native file
+// (CLAUDE.md, AGENTS.md, GEMINI.md, ...), deduplicated and in target order.
+// Targets on the legacy concatenated rules-file layout are skipped because
+// the adapter owns that write. Mirrors writeAgnosticEntryPoints' path
+// selection so revert and check stay symmetric with sync (#389).
+func entryPointPaths(cfg *config.Config, targets []string) []string {
+	seen := map[string]bool{adapters.AgnosticEntryPointPath: true}
+	paths := []string{adapters.AgnosticEntryPointPath}
+	for _, t := range targets {
+		if adapters.HasLegacyRulesFile(cfg, t) {
+			continue
+		}
+		path := adapters.EntryPointPath(cfg, t)
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		paths = append(paths, path)
+	}
+	return paths
+}
+
 // warnOnHandAuthoredEntryPoint prints a single-line warning when path
 // exists, has non-empty content, and lacks the agnostic-ai provenance
 // marker. The marker is the same one `header.Has` uses to recognize a

--- a/internal/cli/revert.go
+++ b/internal/cli/revert.go
@@ -19,7 +19,8 @@ func newRevertCmd() *cobra.Command {
 		Use:   "revert",
 		Short: "Undo a previous sync. Restores .bak files when present.",
 		Long: "revert reverses the effect of `sync` for every target.\n" +
-			"For each file the matching adapter would emit:\n" +
+			"For each file the matching adapter would emit, plus the entry-point\n" +
+			"files sync distributes (CLAUDE.md, AGENTS.md, GEMINI.md, ...):\n" +
 			"  - if <path>.bak exists, the .bak content is restored and the .bak removed\n" +
 			"  - otherwise the file is left in place to protect user-authored content\n" +
 			"    that happens to share a path with an adapter-emitted file (e.g. a\n" +
@@ -100,6 +101,24 @@ func newRevertCmd() *cobra.Command {
 				}
 				_ = restored
 				_ = removed
+			}
+
+			// sync writes the entry-point files (CLAUDE.md, AGENTS.md, ...)
+			// outside adapter emission, so revert them on the same terms.
+			paths := entryPointPaths(cfg, effective)
+			summaryf("← revert entry-points\n")
+			var preserved int
+			for _, p := range paths {
+				action, err := revertOne(p, dryRun, force)
+				if err != nil {
+					return fmt.Errorf("entry-point: %w", err)
+				}
+				if action == "preserve" {
+					preserved++
+				}
+			}
+			if preserved > 0 {
+				summaryf("    %d file(s) preserved (no .bak; pass --force to delete)\n", preserved)
 			}
 			return nil
 		},
@@ -199,6 +218,22 @@ func runRevertJSON(cmd *cobra.Command, targets []string, dryRun, force bool) err
 			} else {
 				out.Writes = append(out.Writes, rec)
 			}
+		}
+	}
+
+	// Entry-point files are written outside adapter emission; revert them
+	// too so the JSON report matches the text path.
+	for _, p := range entryPointPaths(cfg, targets) {
+		action, err := revertOne(p, dryRun, force)
+		if err != nil {
+			out.Errors = append(out.Errors, errorRecord{Target: "agnostic-ai", Message: err.Error()})
+			continue
+		}
+		rec := fileRecord{Target: "agnostic-ai", Path: p, Action: action, Bytes: 0}
+		if action == "skip" || action == "preserve" {
+			out.Skipped = append(out.Skipped, rec)
+		} else {
+			out.Writes = append(out.Writes, rec)
 		}
 	}
 	return emitJSON(cmd, out)

--- a/internal/cli/revert_test.go
+++ b/internal/cli/revert_test.go
@@ -219,6 +219,71 @@ func TestRevertCmd_RestoresFromBackup(t *testing.T) {
 	}
 }
 
+// Regression for #389 repro A: a `sync --backup` over a hand-authored
+// entry-point file must be undone by `revert`, restoring the original
+// content from the .bak and removing the .bak. Before the fix revert never
+// touched entry-point files, orphaning the user's content in CLAUDE.md.bak.
+func TestRevertCmd_RestoresEntryPointFromBackup(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	claudeMd := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudeMd, []byte("MY ORIGINAL NOTES\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--backup"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"revert", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(claudeMd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "MY ORIGINAL NOTES\n" {
+		t.Errorf("entry-point not restored, got %q", got)
+	}
+	if _, err := os.Stat(claudeMd + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("expected CLAUDE.md.bak removed after restore")
+	}
+}
+
+// Regression for #389 repro B: `revert --force` must delete generated
+// entry-point files, not just adapter-emitted ones.
+func TestRevertCmd_ForceRemovesEntryPoints(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	claudeMd := filepath.Join(dir, "CLAUDE.md")
+	if _, err := os.Stat(claudeMd); err != nil {
+		t.Fatalf("expected CLAUDE.md after sync: %v", err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"revert", "-t", "claude", "--force"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(claudeMd); !os.IsNotExist(err) {
+		t.Errorf("expected CLAUDE.md removed after revert --force, err=%v", err)
+	}
+}
+
 func TestRevertCmd_DryRunNoSideEffects(t *testing.T) {
 	dir := setupFixture(t)
 	testutil.Chdir(t, dir)


### PR DESCRIPTION
## Summary
- `revert` now handles the entry-point files sync writes outside adapter emission (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `.agnostic-ai/AGNOSTIC_AI.md`).
- Plain `revert` restores each from its `.bak` and drops the `.bak`; `revert --force` deletes the generated entry-point files. Fixes the data-loss round-trip (repro A) and the orphaned files on `--force` (repro B).
- Shared `entryPointPaths` helper mirrors `writeAgnosticEntryPoints`' path selection (skips legacy rules-file targets, dedupes), keeping revert symmetric with sync and `check`'s `collectEntryPointDrift`.

## Notes
- Mandatory ref pass found no changes worth a separate commit: the new code mirrors the existing adapter-loop structure (text counts vs JSON records). `entryPointPaths` could later dedupe `collectEntryPointDrift` and `writeAgnosticEntryPoints`, but that's a separate refactor (one concern per PR).

## Test plan
- [x] go test ./... (1127 pass)
- New tests: `TestRevertCmd_RestoresEntryPointFromBackup` (repro A), `TestRevertCmd_ForceRemovesEntryPoints` (repro B).

Closes #389