### PR TITLE
fix(cleanup): scope .bak removal to sync-written backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- `cleanup` now removes only the `.bak` backups `sync --backup` wrote (scoped to emitted target files and entry-point files), instead of every `*.bak` under the project. Unrelated backups (vim, manual saves, other tools) are no longer destroyed. Closes #390.
 - `revert` now restores the entry-point files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `AGNOSTIC_AI.md`) from their `.bak`, matching adapter-emitted files. A `sync --backup` then `revert` round-trip previously left the user's original content orphaned in `.bak`; `revert --force` now also deletes the generated entry-point files. Closes #389.
 - Flat-file skills (`.agnostic-ai/skills/<name>.md`) no longer leak their sibling skills' bodies into each emitted skill folder. Sibling-asset propagation now applies only to folder-based skills (`<name>/SKILL.md`), which own their directory. Affects the claude, codex, amp, and antigravity targets. Closes #387.
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -86,7 +86,7 @@ git commit -m "chore(agnostic-ai): regenerate per-target configs (no semantic ch
 - Reviewers focus on commit 1 (content) and skim commit 2 (cosmetic).
 - Importing from multiple CLIs: run each `import` + commit pair before the final `sync`.
 - Gitignoring generated files instead (see [`gitignore.enabled`](configuration.md#gitignore)): skip commit 2. Version only `.agnostic-ai/`; each contributor runs `sync` locally.
-- `sync --backup` keeps a `.bak` next to each overwritten file so you can `revert`. Clear them with `agnostic-ai cleanup`.
+- `sync --backup` keeps a `.bak` next to each overwritten file so you can `revert`. Clear them with `agnostic-ai cleanup` (scoped to the sync-written backups; unrelated `.bak` files are left alone).
 
 #### What `import` does NOT capture
 

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -1,13 +1,16 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
 // newCleanupCmd builds `agnostic-ai cleanup`. With no flags it removes
@@ -24,18 +27,19 @@ func newCleanupCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "cleanup",
-		Short: "Remove agnostic-ai-generated leftovers (currently: .bak files).",
+		Short: "Remove .bak backups left by `sync --backup`.",
 		Long: `cleanup removes housekeeping leftovers from previous agnostic-ai runs.
 
-Today only .bak cleanup is supported. It walks the project root, finds
-every file ending in '.bak' (the form ` + "`sync --backup`" + ` writes), and
-removes them. ` + "`.git/`" + ` and ` + "`.agnostic-ai/`" + ` are skipped.
+Today only .bak cleanup is supported. It removes the ` + "`<path>.bak`" + ` backups
+that ` + "`sync --backup`" + ` writes, scoped to the paths the configured adapters
+emit plus the entry-point files (CLAUDE.md, AGENTS.md, ...). Unrelated
+.bak files (vim backups, manual saves, other tools) are never touched.
 
 Pair with --dry-run to preview the deletions without touching disk.`,
 		Example: `  # Preview which .bak files would be removed
   agnostic-ai cleanup --dry-run
 
-  # Remove every .bak under the project root (no flag needed)
+  # Remove the .bak backups sync --backup wrote (no flag needed)
   agnostic-ai cleanup
 
   # Explicit form for scripts that prefer to spell the mode out
@@ -50,39 +54,38 @@ Pair with --dry-run to preview the deletions without touching disk.`,
 	return cmd
 }
 
-// runCleanupBackups walks root and deletes (or lists) every file whose
-// name ends in `.bak`. `.git/` and `.agnostic-ai/` are pruned so the
-// command never reaches under VCS metadata or the managed state dir.
+// runCleanupBackups removes (or lists) the `.bak` backups `sync --backup`
+// would have written: one per emitted adapter file plus per entry-point
+// file. Scoping to the sync-owned set is the whole point: a blind `*.bak`
+// sweep destroys unrelated user backups (#390). Backups that are absent are
+// skipped silently.
 func runCleanupBackups(root string, dryRun bool) error {
-	skipDirs := map[string]bool{".git": true, ".agnostic-ai": true}
-	var removed, listed int
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			if skipDirs[d.Name()] && path != root {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(d.Name(), ".bak") {
-			return nil
-		}
-		if dryRun {
-			summaryf("  would remove %s\n", path)
-			listed++
-			return nil
-		}
-		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("remove %s: %w", path, err)
-		}
-		verbosef("  removed %s\n", path)
-		removed++
-		return nil
-	})
+	cfg, b, err := loadProject(root)
 	if err != nil {
 		return err
+	}
+	baks, err := syncBackupPaths(cfg, b)
+	if err != nil {
+		return err
+	}
+	var removed, listed int
+	for _, bak := range baks {
+		if _, err := os.Stat(bak); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("stat %s: %w", bak, err)
+		}
+		if dryRun {
+			summaryf("  would remove %s\n", bak)
+			listed++
+			continue
+		}
+		if err := os.Remove(bak); err != nil {
+			return fmt.Errorf("remove %s: %w", bak, err)
+		}
+		verbosef("  removed %s\n", bak)
+		removed++
 	}
 	if dryRun {
 		summaryf("cleanup: %d .bak file(s) would be removed (dry-run)\n", listed)
@@ -90,4 +93,40 @@ func runCleanupBackups(root string, dryRun bool) error {
 		summaryf("cleanup: removed %d .bak file(s)\n", removed)
 	}
 	return nil
+}
+
+// syncBackupPaths returns the `<path>.bak` paths `sync --backup` creates:
+// one per emitted adapter file plus per entry-point file, deduplicated. The
+// emitted set is captured the same way check and revert compute it, so
+// cleanup only ever targets sync-written backups, never unrelated *.bak.
+func syncBackupPaths(cfg *config.Config, b spec.Bundle) ([]string, error) {
+	seen := map[string]bool{}
+	var out []string
+	add := func(path string) {
+		bak := path + ".bak"
+		if seen[bak] {
+			return
+		}
+		seen[bak] = true
+		out = append(out, bak)
+	}
+	for _, t := range cfg.Targets {
+		adapter, err := adapters.Resolve(t)
+		if err != nil {
+			continue
+		}
+		adapters.StartCapture()
+		// dryRun=true: capture the paths without writing anything.
+		if err := adapters.EmitWithProvenance(adapter, b, cfg, true); err != nil {
+			adapters.StopCapture()
+			return nil, fmt.Errorf("%s: %w", t, err)
+		}
+		for _, f := range adapters.StopCapture() {
+			add(f.Path)
+		}
+	}
+	for _, p := range entryPointPaths(cfg, cfg.Targets) {
+		add(p)
+	}
+	return out, nil
 }

--- a/internal/cli/cleanup_test.go
+++ b/internal/cli/cleanup_test.go
@@ -8,16 +8,18 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
-func TestRunCleanupBackups_RemovesBakFiles(t *testing.T) {
-	dir := t.TempDir()
+// Regression for #390: cleanup removes only the `.bak` backups sync wrote
+// (emitted target files + entry-point files), never unrelated user `.bak`
+// files. setupFixture configures the default targets, so CLAUDE.md and
+// .claude/rules/r1.md are in the emitted set; important.bak is not.
+func TestRunCleanupBackups_RemovesOnlySyncBackups(t *testing.T) {
+	dir := setupFixture(t)
 	testutil.Chdir(t, dir)
+	silence(t)
 
-	for _, p := range []string{
-		"CLAUDE.md.bak",
-		".claude/rules/foo.md.bak",
-		".claude/agents/keep.md", // not a .bak; must survive
-		"sub/dir/x.bak",
-	} {
+	syncBak := []string{"CLAUDE.md.bak", ".claude/rules/r1.md.bak"}
+	userBak := []string{"important.bak", "docs/notes.bak"}
+	for _, p := range append(append([]string{}, syncBak...), userBak...) {
 		full := filepath.Join(dir, p)
 		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 			t.Fatal(err)
@@ -26,23 +28,29 @@ func TestRunCleanupBackups_RemovesBakFiles(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
 	if err := runCleanupBackups(".", false); err != nil {
 		t.Fatal(err)
 	}
-	for _, p := range []string{"CLAUDE.md.bak", ".claude/rules/foo.md.bak", "sub/dir/x.bak"} {
+
+	for _, p := range syncBak {
 		if _, err := os.Stat(filepath.Join(dir, p)); !os.IsNotExist(err) {
-			t.Errorf("expected %s removed: %v", p, err)
+			t.Errorf("expected sync backup %s removed: %v", p, err)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(dir, ".claude/agents/keep.md")); err != nil {
-		t.Errorf("unrelated file lost: %v", err)
+	for _, p := range userBak {
+		if _, err := os.Stat(filepath.Join(dir, p)); err != nil {
+			t.Errorf("unrelated backup %s must survive: %v", p, err)
+		}
 	}
 }
 
 func TestRunCleanupBackups_DryRunListsButDoesNotDelete(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupFixture(t)
 	testutil.Chdir(t, dir)
-	path := filepath.Join(dir, "a.bak")
+	silence(t)
+
+	path := filepath.Join(dir, "CLAUDE.md.bak")
 	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -54,12 +62,10 @@ func TestRunCleanupBackups_DryRunListsButDoesNotDelete(t *testing.T) {
 	}
 }
 
-// TestCleanupCmd_BareInvocationRemovesBakFiles regresses #219.
-// Pre-#219, `agnostic-ai cleanup` errored out with "nothing to do:
-// pass --backups". Since --backups is the only mode, bare cleanup
-// should just do the default thing.
+// TestCleanupCmd_BareInvocationRemovesBakFiles regresses #219: bare
+// `agnostic-ai cleanup` must run the default mode without erroring.
 func TestCleanupCmd_BareInvocationRemovesBakFiles(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupFixture(t)
 	testutil.Chdir(t, dir)
 	silence(t)
 
@@ -75,34 +81,5 @@ func TestCleanupCmd_BareInvocationRemovesBakFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("expected .bak removed by bare cleanup, err=%v", err)
-	}
-}
-
-func TestRunCleanupBackups_SkipsGitAndAgnosticDirs(t *testing.T) {
-	dir := t.TempDir()
-	testutil.Chdir(t, dir)
-	for _, p := range []string{
-		".git/x.bak",
-		".agnostic-ai/y.bak",
-		"top.bak",
-	} {
-		full := filepath.Join(dir, p)
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(full, []byte("data"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := runCleanupBackups(".", false); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "top.bak")); !os.IsNotExist(err) {
-		t.Errorf("top.bak should be removed")
-	}
-	for _, p := range []string{".git/x.bak", ".agnostic-ai/y.bak"} {
-		if _, err := os.Stat(filepath.Join(dir, p)); err != nil {
-			t.Errorf("protected dir lost a file: %s err=%v", p, err)
-		}
 	}
 }


### PR DESCRIPTION
## Summary
- `cleanup` no longer walks the tree deleting every `*.bak`. It now removes only the `<path>.bak` backups `sync --backup` writes, scoped to the paths the configured adapters emit plus the entry-point files (`CLAUDE.md`, `AGENTS.md`, ...).
- Unrelated `.bak` files (vim backups, manual saves, other tools) survive. Fixes the data-loss repro in #390.
- Emitted set is captured the same way `check` and `revert` compute it (`syncBackupPaths`). Updated the command help and `getting-started.md`.

## Notes
- Mandatory ref pass found no changes worth a separate commit: the per-target capture loop in `syncBackupPaths` follows an idiom already repeated across 7 commands (check, collision, render, revert, status). A cross-command dedup is a separate refactor concern (one concern per PR).

## Test plan
- [x] go test ./... (1126 pass)
- Rewrote cleanup tests for the scoped behavior: `TestRunCleanupBackups_RemovesOnlySyncBackups` (sync backups removed, `important.bak`/`docs/notes.bak` survive), dry-run, bare-invocation.

Closes #390