### PR TITLE
feat(sync): add target-overview appendix to entry-point files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- New `sync.target-overview` config flag. When enabled, each target entry-point file (CLAUDE.md, AGENTS.md, ...) gains a generated appendix listing where that tool's generated artifacts live, honoring `outputs.<target>.*` overrides. Shared entry-points list each consumer; `import` strips the appendix so the AGNOSTIC_AI.md round-trip stays lossless. (#397)
+
 ### Changed
 
 ### Fixed

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -386,6 +386,9 @@
       "properties": {
         "collision-policy": {
           "type": "string"
+        },
+        "target-overview": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -275,6 +275,20 @@ sync:
   collision-policy: prefer-spec   # CI-safe: skip collision check
 ```
 
+### `sync.target-overview`
+
+Off by default. When `true`, each target entry-point file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, ...) gains a generated appendix listing where that tool's generated artifacts live (rules dir, agents dir, MCP file, ...). The locations honor your `outputs.<target>.*` overrides.
+
+```yaml
+# In agnostic-ai.yaml
+sync:
+  target-overview: true
+```
+
+The canonical body stays identical across every target; only the appendix differs per file. An entry-point shared by several targets (codex, amp, and warp all read `AGENTS.md`) lists each consumer in its own section. The appendix sits between `<!-- agnostic-ai:target-overview:start -->` and `<!-- agnostic-ai:target-overview:end -->` markers; `import` strips it, so the `AGNOSTIC_AI.md` round-trip stays lossless. `.agnostic-ai/AGNOSTIC_AI.md` itself never carries the appendix. Do not hand-edit the block: every sync regenerates it.
+
+Targets whose artifacts all flow through the entry-point pointer (aider) get no appendix.
+
 ## `import`
 
 Per-source knobs for the `import` command. Empty blocks fall back to per-source defaults.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -287,7 +287,7 @@ sync:
 
 The canonical body stays identical across every target; only the appendix differs per file. An entry-point shared by several targets (codex, amp, and warp all read `AGENTS.md`) lists each consumer in its own section. The appendix sits between `<!-- agnostic-ai:target-overview:start -->` and `<!-- agnostic-ai:target-overview:end -->` markers; `import` strips it, so the `AGNOSTIC_AI.md` round-trip stays lossless. `.agnostic-ai/AGNOSTIC_AI.md` itself never carries the appendix. Do not hand-edit the block: every sync regenerates it.
 
-Targets whose artifacts all flow through the entry-point pointer (aider) get no appendix.
+Targets whose artifacts all flow through the entry-point pointer (aider) get no appendix. External adapters (`agnostic-ai-adapter-<name>` binaries) have no native-artifacts protocol yet, so their section is absent from the appendix.
 
 ## `import`
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -22,6 +22,8 @@ Targets sharing a path (codex + amp + warp at `AGENTS.md`) write it once; dedup 
 
 Set `outputs.<target>.rules-file: <path>` to use the legacy concatenated rules layout. The adapter writes a single merged document at `<path>` and `sync` skips the pointer-body write for that target so they do not collide.
 
+Set `sync.target-overview: true` to append a generated section to each entry-point file listing where that tool's generated artifacts live (rules dir, MCP file, ...). The canonical body stays identical across targets; only the appendix differs per file. See [configuration](configuration.md#synctarget-overview).
+
 ## Capability matrix
 
 | Target          | Agents              | Skills | Rules                    | Hooks | MCPs | Commands |

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -177,6 +177,55 @@ func RenderEntryPoint(cfg *config.Config) string {
 	return emit.RenderEntryPoint(cfg)
 }
 
+// NativeArtifact mirrors emit.NativeArtifact so callers outside the
+// internal emit tree can consume target-overview data.
+type NativeArtifact = emit.NativeArtifact
+
+// TargetArtifacts mirrors emit.TargetArtifacts.
+type TargetArtifacts = emit.TargetArtifacts
+
+// NativeOverviewer is the optional interface an adapter implements to
+// describe where its generated artifacts live for a given config. The
+// sync layer renders the result into the target-overview appendix of
+// the adapter's entry-point file when sync.target-overview is enabled.
+type NativeOverviewer interface {
+	NativeArtifacts(cfg *config.Config) []NativeArtifact
+}
+
+// NativeArtifactsFor returns the native artifacts the named in-tree
+// target declares, nil when the adapter is unknown or does not
+// implement NativeOverviewer.
+func NativeArtifactsFor(name string, cfg *config.Config) []NativeArtifact {
+	a, ok := registry[name]
+	if !ok {
+		return nil
+	}
+	o, ok := a.(NativeOverviewer)
+	if !ok {
+		return nil
+	}
+	return o.NativeArtifacts(cfg)
+}
+
+// RenderTargetOverview renders the sentinel-marked overview appendix
+// for one entry-point file (re-exported from the emit layer).
+func RenderTargetOverview(sections []TargetArtifacts) string {
+	return emit.RenderTargetOverview(sections)
+}
+
+// AppendTargetOverview appends a rendered overview to body, stripping
+// any pre-existing block first (re-exported from the emit layer).
+func AppendTargetOverview(body, overview string) string {
+	return emit.AppendTargetOverview(body, overview)
+}
+
+// StripTargetOverview removes the sentinel-marked overview block from
+// body (re-exported from the emit layer). Import uses it so the
+// AGNOSTIC_AI.md round-trip stays lossless.
+func StripTargetOverview(body string) string {
+	return emit.StripTargetOverview(body)
+}
+
 // Adapter is the contract every target implementation satisfies.
 type Adapter interface {
 	// Name returns the target identifier used in config and CLI flags.

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -184,23 +184,29 @@ type NativeArtifact = emit.NativeArtifact
 // TargetArtifacts mirrors emit.TargetArtifacts.
 type TargetArtifacts = emit.TargetArtifacts
 
-// NativeOverviewer is the optional interface an adapter implements to
+// OverviewStartMarker mirrors emit.OverviewStartMarker so callers (and
+// tests) outside the internal emit tree can detect the appendix block.
+const OverviewStartMarker = emit.OverviewStartMarker
+
+// nativeOverviewer is the optional interface an adapter implements to
 // describe where its generated artifacts live for a given config. The
 // sync layer renders the result into the target-overview appendix of
 // the adapter's entry-point file when sync.target-overview is enabled.
-type NativeOverviewer interface {
+type nativeOverviewer interface {
 	NativeArtifacts(cfg *config.Config) []NativeArtifact
 }
 
-// NativeArtifactsFor returns the native artifacts the named in-tree
-// target declares, nil when the adapter is unknown or does not
-// implement NativeOverviewer.
+// NativeArtifactsFor returns the native artifacts the named target
+// declares, nil when the adapter does not implement nativeOverviewer.
+// Lookup is in-tree only: external adapters have no native-artifacts
+// protocol yet, so an external target's section is silently absent
+// from the overview appendix.
 func NativeArtifactsFor(name string, cfg *config.Config) []NativeArtifact {
 	a, ok := registry[name]
 	if !ok {
 		return nil
 	}
-	o, ok := a.(NativeOverviewer)
+	o, ok := a.(nativeOverviewer)
 	if !ok {
 		return nil
 	}

--- a/internal/adapters/amp/overview.go
+++ b/internal/adapters/amp/overview.go
@@ -1,0 +1,18 @@
+package amp
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where Amp reads each generated artifact,
+// honoring the same outputs.amp.* overrides Emit resolves. Rules are
+// absent: Amp reads them through the entry-point pointer to the source
+// specs.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	return []emit.NativeArtifact{
+		{Label: "Agents", Location: emit.OutputCommandsDir(cfg, target, defaultCommandsDir) + "/", Note: "slash commands"},
+		{Label: "Skills", Location: emit.OutputSkillsDir(cfg, target, defaultSkillsDir) + "/"},
+		{Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultMCPFile)},
+	}
+}

--- a/internal/adapters/antigravity/overview.go
+++ b/internal/adapters/antigravity/overview.go
@@ -1,0 +1,18 @@
+package antigravity
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where Antigravity reads each generated
+// artifact, honoring the same outputs.antigravity.* overrides Emit
+// resolves. Agents emit as agent-* files inside the rules directory.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	rulesDir := emit.OutputRulesDir(cfg, target, defaultRulesDir)
+	return []emit.NativeArtifact{
+		{Label: "Rules", Location: rulesDir + "/", Note: "one file per rule"},
+		{Label: "Agents", Location: rulesDir + "/", Note: "agent-* files"},
+		{Label: "Skills", Location: emit.OutputSkillsDir(cfg, target, defaultSkillsDir) + "/"},
+	}
+}

--- a/internal/adapters/claude/overview.go
+++ b/internal/adapters/claude/overview.go
@@ -1,0 +1,24 @@
+package claude
+
+import (
+	"path/filepath"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where Claude Code reads each generated
+// artifact, honoring the same outputs.claude.* overrides Emit resolves.
+// Consumed by the sync layer to render the target-overview appendix in
+// CLAUDE.md when sync.target-overview is enabled.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	dir := emit.OutputDir(cfg, target, defaultDir)
+	return []emit.NativeArtifact{
+		{Label: "Agents", Location: filepath.Join(dir, "agents") + "/"},
+		{Label: "Skills", Location: filepath.Join(dir, "skills") + "/"},
+		{Label: "Rules", Location: emit.OutputRulesDir(cfg, target, defaultRulesDir) + "/", Note: "one file per rule"},
+		{Label: "Commands", Location: emit.OutputCommandsDir(cfg, target, defaultCommandsDir) + "/"},
+		{Label: "Hooks", Location: filepath.Join(dir, "settings.json"), Note: "hooks key"},
+		{Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultMCPFile)},
+	}
+}

--- a/internal/adapters/codex/hooks_json.go
+++ b/internal/adapters/codex/hooks_json.go
@@ -35,10 +35,7 @@ func emitHooksJSON(hooks []spec.Entry, cfg *config.Config, dryRun bool) error {
 	if err != nil {
 		return err
 	}
-	path := defaultHooksFile
-	if o, ok := cfg.Outputs[target]; ok && o.HooksFile != "" {
-		path = o.HooksFile
-	}
+	path := emit.OutputHooksFile(cfg, target, defaultHooksFile)
 	// `.codex/hooks.json` lives under .codex/ alongside config.toml;
 	// emit.WriteFile already handles parent-dir creation.
 	return emit.WriteFile(path, string(body)+"\n", dryRun)

--- a/internal/adapters/codex/overview.go
+++ b/internal/adapters/codex/overview.go
@@ -1,0 +1,24 @@
+package codex
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where Codex CLI reads each generated
+// artifact, honoring the same outputs.codex.* overrides Emit resolves.
+// Rules are absent: Codex reads them through the entry-point pointer to
+// the source specs, not from a native rules directory.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	hooksFile := defaultHooksFile
+	if o, ok := cfg.Outputs[target]; ok && o.HooksFile != "" {
+		hooksFile = o.HooksFile
+	}
+	return []emit.NativeArtifact{
+		{Label: "Agents", Location: emit.OutputAgentsDir(cfg, target, defaultAgentsDir) + "/"},
+		{Label: "Skills", Location: emit.OutputSkillsDir(cfg, target, defaultSkillsDir) + "/"},
+		{Label: "Commands", Location: emit.OutputCommandsDir(cfg, target, defaultCommandsDir) + "/", Note: "prompts"},
+		{Label: "Hooks", Location: hooksFile},
+		{Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultConfigFile), Note: "mcp_servers tables"},
+	}
+}

--- a/internal/adapters/codex/overview.go
+++ b/internal/adapters/codex/overview.go
@@ -10,15 +10,11 @@ import (
 // Rules are absent: Codex reads them through the entry-point pointer to
 // the source specs, not from a native rules directory.
 func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
-	hooksFile := defaultHooksFile
-	if o, ok := cfg.Outputs[target]; ok && o.HooksFile != "" {
-		hooksFile = o.HooksFile
-	}
 	return []emit.NativeArtifact{
 		{Label: "Agents", Location: emit.OutputAgentsDir(cfg, target, defaultAgentsDir) + "/"},
 		{Label: "Skills", Location: emit.OutputSkillsDir(cfg, target, defaultSkillsDir) + "/"},
 		{Label: "Commands", Location: emit.OutputCommandsDir(cfg, target, defaultCommandsDir) + "/", Note: "prompts"},
-		{Label: "Hooks", Location: hooksFile},
+		{Label: "Hooks", Location: emit.OutputHooksFile(cfg, target, defaultHooksFile)},
 		{Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultConfigFile), Note: "mcp_servers tables"},
 	}
 }

--- a/internal/adapters/copilot/overview.go
+++ b/internal/adapters/copilot/overview.go
@@ -1,0 +1,25 @@
+package copilot
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where GitHub Copilot reads each generated
+// artifact, honoring the same outputs.copilot.* overrides Emit
+// resolves. Agents and skills emit into the instructions directory with
+// agent- / skill- filename prefixes; chatmodes appear only when the
+// user opted in via outputs.copilot.chatmodes-dir.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	instructionsDir := emit.OutputInstructionsDir(cfg, target, defaultInstructionsDir)
+	arts := []emit.NativeArtifact{
+		{Label: "Rules", Location: instructionsDir + "/", Note: "path-scoped *.instructions.md"},
+		{Label: "Agents", Location: instructionsDir + "/", Note: "agent-* files"},
+		{Label: "Skills", Location: instructionsDir + "/", Note: "skill-* files"},
+		{Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultMCPFile)},
+	}
+	if dir := emit.OutputChatmodesDir(cfg, target, ""); dir != "" {
+		arts = append(arts, emit.NativeArtifact{Label: "Chat modes", Location: dir + "/"})
+	}
+	return arts
+}

--- a/internal/adapters/gemini/overview.go
+++ b/internal/adapters/gemini/overview.go
@@ -1,0 +1,24 @@
+package gemini
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where Gemini CLI reads each generated
+// artifact, honoring the same outputs.gemini.* overrides Emit resolves.
+// Skills appear only with outputs.gemini.emit-skills-as-commands; rules
+// reach Gemini through the entry-point pointer.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	commandsDir := emit.OutputCommandsDir(cfg, target, defaultCommandsDir)
+	arts := []emit.NativeArtifact{
+		{Label: "Agents", Location: commandsDir + "/", Note: "one TOML per agent"},
+	}
+	if emit.EmitSkillsAsCommands(cfg, target) {
+		arts = append(arts, emit.NativeArtifact{Label: "Skills", Location: commandsDir + "/", Note: skillFilenamePrefix + "* commands"})
+	}
+	arts = append(arts, emit.NativeArtifact{
+		Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultSettingsFile),
+	})
+	return arts
+}

--- a/internal/adapters/internal/emit/output.go
+++ b/internal/adapters/internal/emit/output.go
@@ -34,6 +34,14 @@ func OutputRulesFile(cfg *config.Config, target, fallback string) string {
 	return fallback
 }
 
+// OutputHooksFile returns cfg.Outputs[target].HooksFile when set, otherwise fallback.
+func OutputHooksFile(cfg *config.Config, target, fallback string) string {
+	if o, ok := cfg.Outputs[target]; ok && o.HooksFile != "" {
+		return o.HooksFile
+	}
+	return fallback
+}
+
 // OutputMCPFile returns cfg.Outputs[target].MCPFile when set, otherwise fallback.
 func OutputMCPFile(cfg *config.Config, target, fallback string) string {
 	if o, ok := cfg.Outputs[target]; ok && o.MCPFile != "" {

--- a/internal/adapters/internal/emit/overview.go
+++ b/internal/adapters/internal/emit/overview.go
@@ -1,0 +1,123 @@
+package emit
+
+import "strings"
+
+// NativeArtifact describes one generated artifact a target tool reads
+// natively: a label ("Rules", "MCP servers"), the resolved
+// project-relative location, and an optional note ("one file per rule").
+// Adapters that have an entry-point file implement NativeArtifacts to
+// describe their layout; the sync layer renders the result into the
+// target-overview appendix of that entry-point.
+type NativeArtifact struct {
+	Label    string
+	Location string
+	Note     string
+}
+
+// TargetArtifacts pairs a target name with its native artifacts. The
+// overview for a shared entry-point path (codex + amp + warp all write
+// AGENTS.md) carries one entry per contributing target.
+type TargetArtifacts struct {
+	Target    string
+	Artifacts []NativeArtifact
+}
+
+// Sentinel markers delimiting the generated target-overview appendix
+// inside an entry-point file. Import strips everything between (and
+// including) the markers before mirroring the body to AGNOSTIC_AI.md,
+// so the canonical body round-trips losslessly.
+const (
+	overviewStartMarker = "<!-- agnostic-ai:target-overview:start -->"
+	overviewEndMarker   = "<!-- agnostic-ai:target-overview:end -->"
+)
+
+// RenderTargetOverview renders the sentinel-marked appendix for one
+// entry-point file. Returns "" when no target contributes artifacts,
+// so callers can append the result unconditionally.
+//
+// With a single contributing target the artifact bullets render flat;
+// with several (a shared AGENTS.md) each target gets its own
+// sub-heading so the reader can tell the layouts apart.
+func RenderTargetOverview(sections []TargetArtifacts) string {
+	var present []TargetArtifacts
+	for _, s := range sections {
+		if len(s.Artifacts) > 0 {
+			present = append(present, s)
+		}
+	}
+	if len(present) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(overviewStartMarker)
+	b.WriteString("\n\n## Native artifact locations\n\n")
+	b.WriteString("Generated copies read natively by the tool(s) consuming this file. ")
+	b.WriteString("Edit the source specs above, not these paths; `agnostic-ai sync` overwrites them.\n")
+	for _, s := range present {
+		if len(present) > 1 {
+			b.WriteString("\n### ")
+			b.WriteString(s.Target)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		for _, a := range s.Artifacts {
+			b.WriteString("- **")
+			b.WriteString(a.Label)
+			b.WriteString("**: `")
+			b.WriteString(a.Location)
+			b.WriteString("`")
+			if a.Note != "" {
+				b.WriteString(" (")
+				b.WriteString(a.Note)
+				b.WriteString(")")
+			}
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+	b.WriteString(overviewEndMarker)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// AppendTargetOverview returns body with the rendered overview appended
+// after one blank line. Returns body unchanged when overview is empty.
+// Any pre-existing overview block in body is stripped first so repeated
+// syncs never stack appendixes.
+func AppendTargetOverview(body, overview string) string {
+	body = StripTargetOverview(body)
+	if overview == "" {
+		return body
+	}
+	return strings.TrimRight(body, "\n") + "\n\n" + overview
+}
+
+// StripTargetOverview removes the sentinel-marked overview block (markers
+// included) from body. Returns body unchanged when no block is present.
+// A start marker without an end marker drops everything from the start
+// marker on, which matches how a truncated generated block should heal
+// on the next sync.
+func StripTargetOverview(body string) string {
+	start := strings.Index(body, overviewStartMarker)
+	if start < 0 {
+		return body
+	}
+	head := strings.TrimRight(body[:start], "\n")
+	rest := body[start+len(overviewStartMarker):]
+	end := strings.Index(rest, overviewEndMarker)
+	if end < 0 {
+		if head == "" {
+			return ""
+		}
+		return head + "\n"
+	}
+	tail := strings.TrimLeft(rest[end+len(overviewEndMarker):], "\n")
+	if head == "" {
+		return tail
+	}
+	if tail == "" {
+		return head + "\n"
+	}
+	return head + "\n\n" + tail
+}

--- a/internal/adapters/internal/emit/overview.go
+++ b/internal/adapters/internal/emit/overview.go
@@ -27,8 +27,8 @@ type TargetArtifacts struct {
 // including) the markers before mirroring the body to AGNOSTIC_AI.md,
 // so the canonical body round-trips losslessly.
 const (
-	overviewStartMarker = "<!-- agnostic-ai:target-overview:start -->"
-	overviewEndMarker   = "<!-- agnostic-ai:target-overview:end -->"
+	OverviewStartMarker = "<!-- agnostic-ai:target-overview:start -->"
+	OverviewEndMarker   = "<!-- agnostic-ai:target-overview:end -->"
 )
 
 // RenderTargetOverview renders the sentinel-marked appendix for one
@@ -50,7 +50,7 @@ func RenderTargetOverview(sections []TargetArtifacts) string {
 	}
 
 	var b strings.Builder
-	b.WriteString(overviewStartMarker)
+	b.WriteString(OverviewStartMarker)
 	b.WriteString("\n\n## Native artifact locations\n\n")
 	b.WriteString("Generated copies read natively by the tool(s) consuming this file. ")
 	b.WriteString("Edit the source specs above, not these paths; `agnostic-ai sync` overwrites them.\n")
@@ -76,20 +76,20 @@ func RenderTargetOverview(sections []TargetArtifacts) string {
 		}
 	}
 	b.WriteString("\n")
-	b.WriteString(overviewEndMarker)
+	b.WriteString(OverviewEndMarker)
 	b.WriteString("\n")
 	return b.String()
 }
 
 // AppendTargetOverview returns body with the rendered overview appended
-// after one blank line. Returns body unchanged when overview is empty.
-// Any pre-existing overview block in body is stripped first so repeated
-// syncs never stack appendixes.
+// after one blank line, stripping any pre-existing overview block first
+// so repeated syncs never stack appendixes. Returns body unchanged when
+// overview is empty.
 func AppendTargetOverview(body, overview string) string {
-	body = StripTargetOverview(body)
 	if overview == "" {
 		return body
 	}
+	body = StripTargetOverview(body)
 	return strings.TrimRight(body, "\n") + "\n\n" + overview
 }
 
@@ -99,20 +99,20 @@ func AppendTargetOverview(body, overview string) string {
 // marker on, which matches how a truncated generated block should heal
 // on the next sync.
 func StripTargetOverview(body string) string {
-	start := strings.Index(body, overviewStartMarker)
+	start := strings.Index(body, OverviewStartMarker)
 	if start < 0 {
 		return body
 	}
 	head := strings.TrimRight(body[:start], "\n")
-	rest := body[start+len(overviewStartMarker):]
-	end := strings.Index(rest, overviewEndMarker)
+	rest := body[start+len(OverviewStartMarker):]
+	end := strings.Index(rest, OverviewEndMarker)
 	if end < 0 {
 		if head == "" {
 			return ""
 		}
 		return head + "\n"
 	}
-	tail := strings.TrimLeft(rest[end+len(overviewEndMarker):], "\n")
+	tail := strings.TrimLeft(rest[end+len(OverviewEndMarker):], "\n")
 	if head == "" {
 		return tail
 	}

--- a/internal/adapters/internal/emit/overview_test.go
+++ b/internal/adapters/internal/emit/overview_test.go
@@ -13,7 +13,7 @@ func TestRenderTargetOverview_SingleTargetFlatBullets(t *testing.T) {
 			{Label: "MCP servers", Location: ".mcp.json"},
 		},
 	}})
-	if !strings.Contains(out, overviewStartMarker) || !strings.Contains(out, overviewEndMarker) {
+	if !strings.Contains(out, OverviewStartMarker) || !strings.Contains(out, OverviewEndMarker) {
 		t.Fatalf("missing sentinel markers:\n%s", out)
 	}
 	if strings.Contains(out, "### claude") {
@@ -67,7 +67,7 @@ func TestStripTargetOverview_NoBlockUnchanged(t *testing.T) {
 }
 
 func TestStripTargetOverview_TruncatedBlockHeals(t *testing.T) {
-	body := "# Conventions\n\n" + overviewStartMarker + "\ntruncated, no end marker"
+	body := "# Conventions\n\n" + OverviewStartMarker + "\ntruncated, no end marker"
 	got := StripTargetOverview(body)
 	if got != "# Conventions\n" {
 		t.Errorf("got %q, want body without truncated block", got)
@@ -85,7 +85,7 @@ func TestAppendTargetOverview_DoesNotStack(t *testing.T) {
 	if once != twice {
 		t.Errorf("appendix stacked on repeated append:\nonce  %q\ntwice %q", once, twice)
 	}
-	if n := strings.Count(twice, overviewStartMarker); n != 1 {
+	if n := strings.Count(twice, OverviewStartMarker); n != 1 {
 		t.Errorf("start marker count = %d, want 1", n)
 	}
 }

--- a/internal/adapters/internal/emit/overview_test.go
+++ b/internal/adapters/internal/emit/overview_test.go
@@ -1,0 +1,91 @@
+package emit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTargetOverview_SingleTargetFlatBullets(t *testing.T) {
+	out := RenderTargetOverview([]TargetArtifacts{{
+		Target: "claude",
+		Artifacts: []NativeArtifact{
+			{Label: "Rules", Location: ".claude/rules/", Note: "one file per rule"},
+			{Label: "MCP servers", Location: ".mcp.json"},
+		},
+	}})
+	if !strings.Contains(out, overviewStartMarker) || !strings.Contains(out, overviewEndMarker) {
+		t.Fatalf("missing sentinel markers:\n%s", out)
+	}
+	if strings.Contains(out, "### claude") {
+		t.Errorf("single target must not render a sub-heading:\n%s", out)
+	}
+	if !strings.Contains(out, "- **Rules**: `.claude/rules/` (one file per rule)") {
+		t.Errorf("missing rules bullet:\n%s", out)
+	}
+	if !strings.Contains(out, "- **MCP servers**: `.mcp.json`\n") {
+		t.Errorf("missing mcp bullet without note:\n%s", out)
+	}
+}
+
+func TestRenderTargetOverview_SharedPathRendersPerTargetHeadings(t *testing.T) {
+	out := RenderTargetOverview([]TargetArtifacts{
+		{Target: "codex", Artifacts: []NativeArtifact{{Label: "Agents", Location: ".codex/agents/"}}},
+		{Target: "amp", Artifacts: []NativeArtifact{{Label: "Skills", Location: ".agents/skills/"}}},
+	})
+	if !strings.Contains(out, "### codex") || !strings.Contains(out, "### amp") {
+		t.Errorf("expected per-target headings on shared path:\n%s", out)
+	}
+}
+
+func TestRenderTargetOverview_EmptyWhenNoArtifacts(t *testing.T) {
+	if out := RenderTargetOverview(nil); out != "" {
+		t.Errorf("nil sections: got %q, want empty", out)
+	}
+	out := RenderTargetOverview([]TargetArtifacts{{Target: "aider"}})
+	if out != "" {
+		t.Errorf("artifact-less target: got %q, want empty", out)
+	}
+}
+
+func TestStripTargetOverview_RoundTrip(t *testing.T) {
+	body := "# Conventions\n\nEdit sources.\n"
+	overview := RenderTargetOverview([]TargetArtifacts{{
+		Target:    "claude",
+		Artifacts: []NativeArtifact{{Label: "Rules", Location: ".claude/rules/"}},
+	}})
+	appended := AppendTargetOverview(body, overview)
+	if got := StripTargetOverview(appended); got != body {
+		t.Errorf("round-trip mismatch:\ngot  %q\nwant %q", got, body)
+	}
+}
+
+func TestStripTargetOverview_NoBlockUnchanged(t *testing.T) {
+	body := "# Conventions\n\nNo block here.\n"
+	if got := StripTargetOverview(body); got != body {
+		t.Errorf("got %q, want unchanged", got)
+	}
+}
+
+func TestStripTargetOverview_TruncatedBlockHeals(t *testing.T) {
+	body := "# Conventions\n\n" + overviewStartMarker + "\ntruncated, no end marker"
+	got := StripTargetOverview(body)
+	if got != "# Conventions\n" {
+		t.Errorf("got %q, want body without truncated block", got)
+	}
+}
+
+func TestAppendTargetOverview_DoesNotStack(t *testing.T) {
+	body := "# Conventions\n"
+	overview := RenderTargetOverview([]TargetArtifacts{{
+		Target:    "claude",
+		Artifacts: []NativeArtifact{{Label: "Rules", Location: ".claude/rules/"}},
+	}})
+	once := AppendTargetOverview(body, overview)
+	twice := AppendTargetOverview(once, overview)
+	if once != twice {
+		t.Errorf("appendix stacked on repeated append:\nonce  %q\ntwice %q", once, twice)
+	}
+	if n := strings.Count(twice, overviewStartMarker); n != 1 {
+		t.Errorf("start marker count = %d, want 1", n)
+	}
+}

--- a/internal/adapters/opencode/overview.go
+++ b/internal/adapters/opencode/overview.go
@@ -1,0 +1,25 @@
+package opencode
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where OpenCode reads each generated
+// artifact, honoring the same outputs.opencode.* overrides Emit
+// resolves. Skills appear only with
+// outputs.opencode.emit-skills-as-commands; rules reach OpenCode
+// through the entry-point pointer.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	commandsDir := emit.OutputCommandsDir(cfg, target, defaultCommandsDir)
+	arts := []emit.NativeArtifact{
+		{Label: "Agents", Location: commandsDir + "/", Note: "slash commands"},
+	}
+	if emit.EmitSkillsAsCommands(cfg, target) {
+		arts = append(arts, emit.NativeArtifact{Label: "Skills", Location: commandsDir + "/", Note: skillFilenamePrefix + "* commands"})
+	}
+	arts = append(arts, emit.NativeArtifact{
+		Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultMCPFile),
+	})
+	return arts
+}

--- a/internal/adapters/warp/overview.go
+++ b/internal/adapters/warp/overview.go
@@ -1,0 +1,20 @@
+package warp
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// NativeArtifacts describes where Warp reads each generated artifact,
+// honoring the same outputs.warp.* overrides Emit resolves. Workflows
+// appear only when the user opted in via outputs.warp.workflows-dir;
+// rules and skills reach Warp through the entry-point pointer.
+func (Adapter) NativeArtifacts(cfg *config.Config) []emit.NativeArtifact {
+	arts := []emit.NativeArtifact{
+		{Label: "MCP servers", Location: emit.OutputMCPFile(cfg, target, defaultMCPFile)},
+	}
+	if dir := emit.OutputWorkflowsDir(cfg, target, ""); dir != "" {
+		arts = append(arts, emit.NativeArtifact{Label: "Agents", Location: dir + "/", Note: "Warp Workflows"})
+	}
+	return arts
+}

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -100,27 +100,17 @@ func collectEntryPointDrift(cfg *config.Config, targets []string) (driftReport, 
 		return rep, fmt.Errorf("%s: %w", adapters.AgnosticEntryPointPath, err)
 	}
 
-	rendered := header.With(body, header.FormatMarkdown)
-	seen := map[string]bool{adapters.AgnosticEntryPointPath: true}
-	for _, t := range targets {
-		if adapters.HasLegacyRulesFile(cfg, t) {
-			continue
-		}
-		path := adapters.EntryPointPath(cfg, t)
-		if path == "" || seen[path] {
-			continue
-		}
-		seen[path] = true
-		disk, err := os.ReadFile(path)
+	for _, f := range renderEntryPointFiles(cfg, targets, body) {
+		disk, err := os.ReadFile(f.Path)
 		if err != nil {
 			if os.IsNotExist(err) {
-				rep.Missing = append(rep.Missing, adapters.CapturedFile{Path: path, Content: rendered})
+				rep.Missing = append(rep.Missing, adapters.CapturedFile{Path: f.Path, Content: f.Content})
 				continue
 			}
-			return rep, fmt.Errorf("read %s: %w", path, err)
+			return rep, fmt.Errorf("read %s: %w", f.Path, err)
 		}
-		if string(disk) != rendered {
-			rep.Stale = append(rep.Stale, adapters.CapturedFile{Path: path, Content: rendered})
+		if string(disk) != f.Content {
+			rep.Stale = append(rep.Stale, adapters.CapturedFile{Path: f.Path, Content: f.Content})
 		}
 	}
 	return rep, nil

--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -62,7 +62,6 @@ type entryPointFile struct {
 // consumer separately).
 func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []entryPointFile {
 	body = adapters.StripTargetOverview(body)
-	seen := map[string]bool{adapters.AgnosticEntryPointPath: true}
 	var order []string
 	consumers := map[string][]string{}
 	for _, t := range targets {
@@ -73,8 +72,7 @@ func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []
 		if path == "" || path == adapters.AgnosticEntryPointPath {
 			continue
 		}
-		if !seen[path] {
-			seen[path] = true
+		if _, ok := consumers[path]; !ok {
 			order = append(order, path)
 		}
 		consumers[path] = append(consumers[path], t)
@@ -83,7 +81,7 @@ func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []
 	files := make([]entryPointFile, 0, len(order))
 	for _, path := range order {
 		content := body
-		if cfg != nil && cfg.Sync.TargetOverview {
+		if cfg.Sync.TargetOverview {
 			var sections []adapters.TargetArtifacts
 			for _, t := range consumers[path] {
 				sections = append(sections, adapters.TargetArtifacts{

--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -34,23 +34,71 @@ func writeAgnosticEntryPoints(cfg *config.Config, targets []string, dryRun bool)
 	if err != nil {
 		return err
 	}
-	rendered := header.With(body, header.FormatMarkdown)
+	for _, f := range renderEntryPointFiles(cfg, targets, body) {
+		warnOnHandAuthoredEntryPoint(f.Path)
+		if err := adapters.WriteFile(f.Path, f.Content, dryRun); err != nil {
+			return fmt.Errorf("write entry-point %s: %w", f.Path, err)
+		}
+	}
+	return nil
+}
+
+// entryPointFile pairs an entry-point path with the exact content sync
+// writes there. Shared by writeAgnosticEntryPoints and the drift check
+// so the two can never disagree on what a target's file should hold.
+type entryPointFile struct {
+	Path    string
+	Content string
+}
+
+// renderEntryPointFiles returns every target entry-point file sync
+// distributes for body, deduplicated by path in target order.
+// AGNOSTIC_AI.md is excluded: it holds the canonical body and is
+// written by resolveAgnosticBody, never with an overview appendix.
+//
+// When sync.target-overview is enabled, each file gains a generated
+// sentinel-marked appendix listing the native artifact locations of
+// every target consuming that path (a shared AGENTS.md lists each
+// consumer separately).
+func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []entryPointFile {
+	body = adapters.StripTargetOverview(body)
 	seen := map[string]bool{adapters.AgnosticEntryPointPath: true}
+	var order []string
+	consumers := map[string][]string{}
 	for _, t := range targets {
 		if adapters.HasLegacyRulesFile(cfg, t) {
 			continue
 		}
 		path := adapters.EntryPointPath(cfg, t)
-		if path == "" || seen[path] {
+		if path == "" || path == adapters.AgnosticEntryPointPath {
 			continue
 		}
-		seen[path] = true
-		warnOnHandAuthoredEntryPoint(path)
-		if err := adapters.WriteFile(path, rendered, dryRun); err != nil {
-			return fmt.Errorf("write entry-point %s: %w", path, err)
+		if !seen[path] {
+			seen[path] = true
+			order = append(order, path)
 		}
+		consumers[path] = append(consumers[path], t)
 	}
-	return nil
+
+	files := make([]entryPointFile, 0, len(order))
+	for _, path := range order {
+		content := body
+		if cfg != nil && cfg.Sync.TargetOverview {
+			var sections []adapters.TargetArtifacts
+			for _, t := range consumers[path] {
+				sections = append(sections, adapters.TargetArtifacts{
+					Target:    t,
+					Artifacts: adapters.NativeArtifactsFor(t, cfg),
+				})
+			}
+			content = adapters.AppendTargetOverview(body, adapters.RenderTargetOverview(sections))
+		}
+		files = append(files, entryPointFile{
+			Path:    path,
+			Content: header.With(content, header.FormatMarkdown),
+		})
+	}
+	return files
 }
 
 // entryPointPaths returns the entry-point files sync distributes: the

--- a/internal/cli/entrypoint_overview_test.go
+++ b/internal/cli/entrypoint_overview_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
-const overviewMarker = "<!-- agnostic-ai:target-overview:start -->"
+const overviewMarker = adapters.OverviewStartMarker
 
 func TestWriteAgnosticEntryPoints_TargetOverviewAppendsAppendix(t *testing.T) {
 	dir := testutil.TempCwd(t)
@@ -123,8 +123,12 @@ func TestCollectEntryPointDrift_NoDriftAfterSyncWithOverview(t *testing.T) {
 func TestMirrorMainFile_StripsTargetOverview(t *testing.T) {
 	dir := testutil.TempCwd(t)
 	body := "# Project\n\nBody.\n"
-	appendix := "\n" + overviewMarker + "\n\n## Native artifact locations\n\n- **Rules**: `.claude/rules/`\n\n<!-- agnostic-ai:target-overview:end -->\n"
-	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(body+appendix), 0o644); err != nil {
+	appendix := adapters.RenderTargetOverview([]adapters.TargetArtifacts{{
+		Target:    "claude",
+		Artifacts: []adapters.NativeArtifact{{Label: "Rules", Location: ".claude/rules/"}},
+	}})
+	withAppendix := adapters.AppendTargetOverview(body, appendix)
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(withAppendix), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cli/entrypoint_overview_test.go
+++ b/internal/cli/entrypoint_overview_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+const overviewMarker = "<!-- agnostic-ai:target-overview:start -->"
+
+func TestWriteAgnosticEntryPoints_TargetOverviewAppendsAppendix(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	custom := "# Project\n\nMy instructions.\n"
+	writeAgnosticFile(t, custom)
+	cfg := &config.Config{
+		Targets: []string{"claude"},
+		Sync:    config.SyncConfig{TargetOverview: true},
+		Outputs: map[string]config.Output{
+			"claude": {RulesDir: "custom/rules"},
+		},
+	}
+
+	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("CLAUDE.md not written: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, custom) {
+		t.Errorf("CLAUDE.md missing canonical body:\n%s", got)
+	}
+	if !strings.Contains(got, overviewMarker) {
+		t.Errorf("CLAUDE.md missing overview appendix:\n%s", got)
+	}
+	if !strings.Contains(got, "`custom/rules/`") {
+		t.Errorf("appendix does not honor outputs.claude.rules-dir override:\n%s", got)
+	}
+
+	// The canonical source file never carries the appendix.
+	src, err := os.ReadFile(adapters.AgnosticEntryPointPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(src), overviewMarker) {
+		t.Errorf("AGNOSTIC_AI.md must not carry the overview appendix:\n%s", src)
+	}
+}
+
+func TestWriteAgnosticEntryPoints_TargetOverviewOffByDefault(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	writeAgnosticFile(t, "# Project\n")
+	cfg := &config.Config{Targets: []string{"claude"}}
+
+	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), overviewMarker) {
+		t.Errorf("appendix written without sync.target-overview:\n%s", data)
+	}
+}
+
+func TestWriteAgnosticEntryPoints_TargetOverviewSharedPathListsEachConsumer(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	writeAgnosticFile(t, "# Project\n")
+	cfg := &config.Config{
+		Targets: []string{"codex", "amp", "warp"},
+		Sync:    config.SyncConfig{TargetOverview: true},
+	}
+
+	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("AGENTS.md not written: %v", err)
+	}
+	got := string(data)
+	for _, heading := range []string{"### codex", "### amp", "### warp"} {
+		if !strings.Contains(got, heading) {
+			t.Errorf("AGENTS.md missing %q section:\n%s", heading, got)
+		}
+	}
+	if !strings.Contains(got, "`.codex/agents/`") {
+		t.Errorf("AGENTS.md missing codex agents location:\n%s", got)
+	}
+}
+
+// Sync write and drift check must agree byte-for-byte on entry-point
+// content, appendix included, so a freshly synced tree reports no drift.
+func TestCollectEntryPointDrift_NoDriftAfterSyncWithOverview(t *testing.T) {
+	testutil.TempCwd(t)
+	writeAgnosticFile(t, "# Project\n\nBody.\n")
+	cfg := &config.Config{
+		Targets: []string{"claude", "codex"},
+		Sync:    config.SyncConfig{TargetOverview: true},
+	}
+
+	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rep, err := collectEntryPointDrift(cfg, cfg.Targets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rep.hasDrift() {
+		t.Errorf("freshly synced tree reports drift: missing=%v stale=%v",
+			paths(rep.Missing), paths(rep.Stale))
+	}
+}
+
+func TestMirrorMainFile_StripsTargetOverview(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	body := "# Project\n\nBody.\n"
+	appendix := "\n" + overviewMarker + "\n\n## Native artifact locations\n\n- **Rules**: `.claude/rules/`\n\n<!-- agnostic-ai:target-overview:end -->\n"
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(body+appendix), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wrote, err := mirrorMainFile(dir, "CLAUDE.md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrote {
+		t.Fatal("mirrorMainFile reported nothing written")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), overviewMarker) {
+		t.Errorf("AGNOSTIC_AI.md still carries the overview appendix:\n%s", data)
+	}
+	if !strings.Contains(string(data), "Body.") {
+		t.Errorf("AGNOSTIC_AI.md lost the canonical body:\n%s", data)
+	}
+}
+
+func paths(files []adapters.CapturedFile) []string {
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		out = append(out, f.Path)
+	}
+	return out
+}

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 )
@@ -127,38 +128,33 @@ func mirrorClaudeMainFile(root string) (wrote bool, srcName string, promotedNest
 	return wrote, nestedClaudeMainFile, wrote, err
 }
 
-// mirrorMainFile copies <root>/<srcName> byte-for-byte to
+// mirrorMainFile copies <root>/<srcName> to
 // <root>/.agnostic-ai/AGNOSTIC_AI.md. Returns (false, nil) when the
 // source is absent so the caller can skip its "seeded from <src>"
 // summary line. Each importer calls this with the target's own
 // top-level instructions filename so the project keeps a CLI-agnostic
 // copy under the managed directory. Later imports overwrite earlier
 // mirrors (last-import wins).
+//
+// The generated target-overview appendix (sync.target-overview) is
+// stripped before the write: it is per-entry-point derived output, not
+// part of the canonical body, and carrying it back would duplicate it
+// on the next sync.
 func mirrorMainFile(root, srcName string) (bool, error) {
 	src := filepath.Join(root, srcName)
 	dst := filepath.Join(root, agnosticMainFile)
-	wrote, err := copyFileIfExists(src, dst)
-	if err != nil {
-		return false, fmt.Errorf("mirror %s: %w", srcName, err)
-	}
-	return wrote, nil
-}
-
-// copyFileIfExists copies src to dst byte-for-byte. Returns (false,
-// nil) when src is absent so the caller can distinguish a real copy
-// from a no-op; surfaces every other read/write error.
-func copyFileIfExists(src, dst string) (bool, error) {
 	data, err := os.ReadFile(src)
 	if errors.Is(err, fs.ErrNotExist) {
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("read %s: %w", src, err)
+		return false, fmt.Errorf("mirror %s: %w", srcName, err)
 	}
+	body := adapters.StripTargetOverview(string(data))
 	if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
-	if err := importWriteFile(dst, data, 0o644); err != nil {
+	if err := importWriteFile(dst, []byte(body), 0o644); err != nil {
 		return false, fmt.Errorf("write %s: %w", dst, err)
 	}
 	return true, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,14 @@ type SyncConfig struct {
 	//   prefer-spec skip the collision pre-flight; let the last adapter win
 	//   fail        hard error with no resolution hint
 	CollisionPolicy string `yaml:"collision-policy,omitempty" json:"collision-policy,omitempty"`
+	// TargetOverview appends a generated, sentinel-marked section to each
+	// target's entry-point file (CLAUDE.md, AGENTS.md, ...) listing where
+	// that tool's generated artifacts live (rules dir, MCP file, ...).
+	// The canonical body stays byte-identical across targets; only the
+	// appendix differs per entry-point path. Off by default. The appendix
+	// is stripped on `import` so the AGNOSTIC_AI.md round-trip stays
+	// lossless. AGNOSTIC_AI.md itself never carries the appendix.
+	TargetOverview bool `yaml:"target-overview,omitempty" json:"target-overview,omitempty"`
 }
 
 // ProvenanceHeaderEnabled returns whether the named target should write


### PR DESCRIPTION
Closes #397

## What

New `sync.target-overview` config flag (off by default). When enabled, every target entry-point file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, ...) gains a generated appendix listing where that tool's generated artifacts live:

```markdown
<!-- agnostic-ai:target-overview:start -->

## Native artifact locations

- **Agents**: `.claude/agents/`
- **Rules**: `.claude/rules/` (one file per rule)
- **MCP servers**: `.mcp.json`
...
<!-- agnostic-ai:target-overview:end -->
```

## Design invariants preserved

- **Canonical body stays byte-identical** across targets; only the appendix differs per entry-point path. A shared `AGENTS.md` (codex + amp + warp) lists each consumer in its own `###` section, so write dedup keeps working.
- **Import roundtrip stays lossless**: `mirrorMainFile` strips the sentinel-marked block before writing `.agnostic-ai/AGNOSTIC_AI.md`.
- **Drift check stays symmetric**: sync write and `sync --check` now render entry-point content through one shared helper (`renderEntryPointFiles`), so they can never disagree.

## How

- Locations are derived, never hand-maintained: each entry-point adapter implements an optional `NativeArtifacts(cfg)` method mirroring its `Emit`, resolved through the same `emit.Output*` helpers, so `outputs.<target>.*` overrides are reflected automatically.
- Opt-in kinds appear only when configured (warp workflows, gemini/opencode skills-as-commands, copilot chatmodes). Aider has no native artifacts and gets no appendix.
- `AGNOSTIC_AI.md` itself never carries the appendix.

## Testing

- 12 new tests: render/strip/append idempotency in emit, cli flag on/off, shared-path sections, drift symmetry, import strip.
- Full suite: 1138 passed in 28 packages. `gofmt`, `go vet`, `golangci-lint` clean.
- Manual end-to-end: sync with flag on, `sync --check` exit 0, `import claude` strips appendix, post-import check exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
