### PR TITLE
fix(sync): inline rule bodies into entry-point targets without a rules dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- Rule specs now reach targets with no native rules directory. `codex`, `amp`, `warp`, `gemini`, `aider`, and `opencode` inline every rule body into their entry-point file (AGENTS.md, GEMINI.md, CONVENTIONS.md, ...) under a sentinel-marked block, so a default `sync` no longer drops them silently. `render` and `graph` show the rule reaching these targets; `import` strips the block so the AGNOSTIC_AI.md round-trip stays lossless. (#399)
+
 ### Removed
 
 ## v0.35.0 - 2026-06-09

--- a/README.md
+++ b/README.md
@@ -79,24 +79,24 @@ All 14 targets are first-class: author a spec once, `sync`, and it lands in each
 | Target              | Agents | Skills | Rules | Hooks | MCPs |
 |---------------------|:------:|:------:|:-----:|:-----:|:----:|
 | Claude Code         |   ✅    |   ✅    |   ✅   |   ✅   |  ✅   |
-| Codex CLI           |   ✅    |   ✅    |   ○   |   ✅   |  ✅   |
-| Gemini CLI          |   ✅    |   ○    |   ○   |   ✅   |  ✅   |
+| Codex CLI           |   ✅    |   ✅    |   ◐   |   ✅   |  ✅   |
+| Gemini CLI          |   ✅    |   ○    |   ◐   |   ✅   |  ✅   |
 | Cursor              |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
 | GitHub Copilot      |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
-| Aider               |   ○    |   ○    |   ○   |   -   |  -   |
+| Aider               |   ○    |   ○    |   ◐   |   -   |  -   |
 | Cline               |   ✅    |   ✅    |   ✅   |   -   |  -   |
 | Windsurf            |   ✅    |   ✅    |   ✅   |   -   |  -   |
 | Continue            |   ✅    |   ✅    |   ✅   |   -   |  ✅   |
-| Amp                 |   ✅    |   ✅    |   ○   |   -   |  ✅   |
+| Amp                 |   ✅    |   ✅    |   ◐   |   -   |  ✅   |
 | Zed                 |   ◐    |   ◐    |   ◐   |   ○   |  ✅   |
-| Warp                |   ○    |   ○    |   ○   |   -   |  ✅   |
-| OpenCode            |   ✅    |   ○    |   ○   |   -   |  ✅   |
+| Warp                |   ○    |   ○    |   ◐   |   -   |  ✅   |
+| OpenCode            |   ✅    |   ○    |   ◐   |   -   |  ✅   |
 | Google Antigravity  |   ✅    |   ✅    |   ✅   |   -   |  -   |
 
 Legend, in descending order of native support:
 
 - **✅ native** — written in the tool's own format at the path it auto-loads: one file per spec for agents/skills/rules, the tool's native settings/MCP file for hooks and MCPs.
-- **◐ bundled** — folded into the target's single entry-point or merged doc (no per-spec file). Zed's `.rules` is the only target that merges by default.
+- **◐ bundled** — folded into the target's single entry-point or merged doc (no per-spec file). Targets with no native rules directory (Codex, Gemini, Aider, Amp, Warp, OpenCode) inline rule bodies into their entry-point file; Zed merges agents, skills, and rules into `.rules`.
 - **○ opt-in / source-dir** — not emitted as a dedicated file by default; the spec stays in the source dir, referenced from the entry-point. Set the matching `outputs.<target>.*` key (e.g. `rules-file`, `workflows-dir`, `emit-skills-as-commands`) to materialize a file.
 - **- not supported** — the kind is skipped with a warning. Suppress with `on-unsupported: silent`.
 

--- a/cmd/agnostic-ai-wasm/main.go
+++ b/cmd/agnostic-ai-wasm/main.go
@@ -110,10 +110,18 @@ func render(_ js.Value, args []js.Value) any {
 		// when the target opted into a legacy concatenated rules-file
 		// (the adapter owns the entry-point write in that case).
 		if path := adapters.EntryPointPath(cfg, t); path != "" && !adapters.HasLegacyRulesFile(cfg, t) {
+			content := adapters.RenderEntryPoint(cfg)
+			// Targets with no native rules directory (codex, amp, warp,
+			// gemini, aider, opencode) inline the rule bodies into their
+			// entry-point file. Mirror that here so the playground shows
+			// the rule reaching the tool.
+			if adapters.InlinesRulesIntoEntryPoint(t) {
+				content = adapters.AppendRulesAppendix(content, adapters.RenderRulesAppendix(bundle))
+			}
 			files = append(files, map[string]any{
 				"target":  t,
 				"path":    path,
-				"content": adapters.RenderEntryPoint(cfg),
+				"content": content,
 			})
 		}
 	}

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -20,7 +20,9 @@ Each adapter emits in its tool's native format: separate files where the tool su
 
 Targets sharing a path (codex + amp + warp at `AGENTS.md`) write it once; dedup is automatic. Targets absent from the table above (cursor, cline, windsurf, continue, zed) have no root entry-point: they emit only per-file artifacts under their own directory.
 
-Set `outputs.<target>.rules-file: <path>` to use the legacy concatenated rules layout. The adapter writes a single merged document at `<path>` and `sync` skips the pointer-body write for that target so they do not collide.
+Targets with no native rules directory (codex, amp, warp, gemini, aider, opencode) inline every rule body into their entry-point file under a sentinel-marked `## Rules` block, after the pointer body. That file is the only always-on context surface these tools read, so the rule reaches them by default. The block is identical across targets that share a path, so the dedup still holds. `import` strips the block, keeping the AGNOSTIC_AI.md round-trip lossless.
+
+Set `outputs.<target>.rules-file: <path>` to use the legacy concatenated rules layout instead. The adapter writes a single merged document at `<path>` and `sync` skips the pointer-body write for that target so they do not collide.
 
 Set `sync.target-overview: true` to append a generated section to each entry-point file listing where that tool's generated artifacts live (rules dir, MCP file, ...). The canonical body stays identical across targets; only the appendix differs per file. See [configuration](configuration.md#synctarget-overview).
 
@@ -29,18 +31,18 @@ Set `sync.target-overview: true` to append a generated section to each entry-poi
 | Target          | Agents              | Skills | Rules                    | Hooks | MCPs | Commands |
 |-----------------|---------------------|--------|--------------------------|-------|------|----------|
 | **claude**      | `.claude/agents/`   | `.claude/skills/` | `.claude/rules/*.md`   | `.claude/settings.json` | `.mcp.json` | `.claude/commands/<name>.md` |
-| **codex**       | `.codex/agents/*.toml` | `.codex/skills/<name>/SKILL.md` | source-dir only (legacy concat via `outputs.codex.rules-file`) | `.codex/hooks.json` (per-event arrays) | `.codex/config.toml` (`[mcp_servers.<name>]`) | `.codex/prompts/<name>.md` |
-| **gemini**      | `.gemini/commands/<name>.toml` | `.gemini/commands/skill-<name>.toml` w/ opt-in | source-dir only (legacy concat via `outputs.gemini.rules-file`) | `.gemini/settings.json` (`hooks`) | `.gemini/settings.json` (`mcpServers`) | - |
+| **codex**       | `.codex/agents/*.toml` | `.codex/skills/<name>/SKILL.md` | inlined into `AGENTS.md` (legacy concat via `outputs.codex.rules-file`) | `.codex/hooks.json` (per-event arrays) | `.codex/config.toml` (`[mcp_servers.<name>]`) | `.codex/prompts/<name>.md` |
+| **gemini**      | `.gemini/commands/<name>.toml` | `.gemini/commands/skill-<name>.toml` w/ opt-in | inlined into `GEMINI.md` (legacy concat via `outputs.gemini.rules-file`) | `.gemini/settings.json` (`hooks`) | `.gemini/settings.json` (`mcpServers`) | - |
 | **cursor**      | as `.mdc` (alwaysApply: false) | as `.mdc` (`skill-<name>.mdc`) | `.cursor/rules/*.mdc` | - | `.cursor/mcp.json` | - |
 | **copilot**     | `.github/instructions/agent-<name>.instructions.md` | `.github/instructions/skill-<name>.instructions.md` | `.github/instructions/<name>.instructions.md` (scoped); always-on via `outputs.copilot.rules-file` | - | `.vscode/mcp.json` | - |
-| **aider**       | source-dir only (legacy merge via `outputs.aider.rules-file`) | source-dir only | source-dir only (`.aider.conf.yml` w/ opt-in) | - | - | - |
+| **aider**       | source-dir only (legacy merge via `outputs.aider.rules-file`) | source-dir only | inlined into `CONVENTIONS.md` (legacy merge via `outputs.aider.rules-file`) | - | - | - |
 | **cline**       | as `.md` rule (+ `.clinerules/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - | - |
 | **windsurf**    | as `.md` rule (+ `.windsurf/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.windsurf/rules/*.md`   | -     | - | - |
 | **continue**    | as `.md` rule (+ `.continue/assistants/<name>.yaml` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.continue/rules/*.md`   | -     | `.continue/mcpServers/*.yaml` | - |
-| **amp**         | `.agents/commands/<name>.md` | `.agents/skills/<name>/SKILL.md` | source-dir only (legacy concat via `outputs.amp.rules-file`) | - | `.amp/settings.json` (`amp.mcpServers`) | - |
+| **amp**         | `.agents/commands/<name>.md` | `.agents/skills/<name>/SKILL.md` | inlined into `AGENTS.md` (legacy concat via `outputs.amp.rules-file`) | - | `.amp/settings.json` (`amp.mcpServers`) | - |
 | **zed**         | merged in `.rules` | listed in `.rules` | `.rules` | `.zed/tasks.json` w/ opt-in | `.zed/settings.json` (`context_servers`) | - |
-| **warp**        | `.warp/workflows/<name>.yaml` w/ opt-in | source-dir only | source-dir only (legacy concat via `outputs.warp.rules-file`) | - | `.warp/.mcp.json` | - |
-| **opencode**    | `.opencode/commands/<name>.md` | `.opencode/commands/skill-<name>.md` w/ opt-in | source-dir only (legacy concat via `outputs.opencode.rules-file`) | - | `opencode.json` (`mcp`) | - |
+| **warp**        | `.warp/workflows/<name>.yaml` w/ opt-in | source-dir only | inlined into `AGENTS.md` (legacy concat via `outputs.warp.rules-file`) | - | `.warp/.mcp.json` | - |
+| **opencode**    | `.opencode/commands/<name>.md` | `.opencode/commands/skill-<name>.md` w/ opt-in | inlined into `.opencode/AGENTS.md` (legacy concat via `outputs.opencode.rules-file`) | - | `opencode.json` (`mcp`) | - |
 | **antigravity** | as `.md` rule (`agent-<name>.md`) | `.agent/skills/<name>/SKILL.md` | `.agent/rules/*.md` (legacy merge via `outputs.antigravity.rules-file`) | - | - | - |
 
 Cross-cutting kind notes:
@@ -94,7 +96,7 @@ AGENTS.md                                    # canonical entry-point pointer bod
 .codex/hooks.json                            # when hook entries exist
 ```
 
-- **Rules**: `sync` writes `AGENTS.md` with the pointer body. Codex loads rules from the spec source dir referenced there. Per-directory scoping (e.g. `src/AGENTS.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.codex.rules-file: AGENTS.md` for the legacy concatenated layout.
+- **Rules**: `sync` writes `AGENTS.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline. Codex reads `AGENTS.md` as always-on context, so the rules reach it by default. `import codex` strips that block (the canonical rules live under the source dir). Per-directory scoping (e.g. `src/AGENTS.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.codex.rules-file: AGENTS.md` for the legacy concatenated layout.
 - **Skills**: [Codex skills layout](https://developers.openai.com/codex/skills), one folder per skill with a required `SKILL.md` (frontmatter `name` + `description`, plus body). When the spec carries `x-codex.interface`, `x-codex.policy`, or `x-codex.dependencies`, an `agents/openai.yaml` is also written for UI customization and policy declarations.
 - **Hooks**: land in `.codex/hooks.json` (override via `outputs.codex.hooks-file`), routed by `event` frontmatter (`SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact`, `PostCompact`) into per-event arrays with `matcher` and `command`. The JSON form preserves matcher metadata the inline `[[hooks.<event>]]` TOML cannot.
 - **MCP**: lands in `.codex/config.toml`. Servers emit as `[mcp_servers.<name>]`: stdio uses `command`/`args`/`env`, HTTP/SSE uses `url`/`bearer_token_env_var`/`http_headers`. The project-tier config.toml is managed (overwritten each sync); put unmanaged Codex config in `~/.codex/config.toml`.
@@ -123,7 +125,7 @@ GEMINI.md                              # canonical entry-point pointer body (wri
 .gemini/settings.json                  # when MCP and/or hook entries exist (merged with existing user config)
 ```
 
-- **Rules**: `sync` writes `GEMINI.md` with the pointer body. Per-directory scoping (e.g. `src/GEMINI.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.gemini.rules-file: GEMINI.md` for the legacy concatenated layout.
+- **Rules**: `sync` writes `GEMINI.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline, so Gemini reads them as always-on context by default. Per-directory scoping (e.g. `src/GEMINI.md` from `globs: src/**`) is no longer emitted by default. Use `outputs.gemini.rules-file: GEMINI.md` for the legacy concatenated layout.
 - **Agents**: TOML slash commands under `.gemini/commands/` per [Gemini CLI custom commands](https://geminicli.com/docs/cli/custom-commands/). Skills default to source-only; set `outputs.gemini.emit-skills-as-commands: true` to emit one `skill-<name>.toml` per skill.
 - **MCP + hooks**: written into `.gemini/settings.json` (`mcpServers` map, `hooks` map). Gemini keys the endpoint by transport: streamable-HTTP servers (`type: http`) use `httpUrl`, SSE servers (`type: sse`) use `url`; the adapter routes each automatically. Hooks route by `event` frontmatter (`BeforeTool`, `AfterTool`, `SessionStart`); each entry is `{matcher, command}`. Pre-existing user keys survive syncs.
 
@@ -184,11 +186,11 @@ Verify with the real extension:
 ### Aider (`aider`)
 
 ```
-CONVENTIONS.md           # canonical entry-point pointer body (written by sync)
+CONVENTIONS.md           # pointer body + inlined rules block (written by sync)
 .aider.conf.yml          # only when conf-file is set
 ```
 
-By default the adapter emits only the conventions document; wire it in via `aider --read CONVENTIONS.md`. Set `outputs.aider.conf-file: .aider.conf.yml` to also merge a `read:` entry into Aider's [project config](https://aider.chat/docs/config/aider_conf.html) so the file auto-loads. `model` and `weak-model` propagate into the same file when set. Pre-existing keys are preserved; the `read:` list de-duplicates.
+`CONVENTIONS.md` carries the pointer body plus a sentinel-marked `## Rules` block with every rule body inline, so the conventions reach Aider by default; `import aider` strips that block. Wire the file in via `aider --read CONVENTIONS.md`. Set `outputs.aider.conf-file: .aider.conf.yml` to also merge a `read:` entry into Aider's [project config](https://aider.chat/docs/config/aider_conf.html) so the file auto-loads. `model` and `weak-model` propagate into the same file when set. Pre-existing keys are preserved; the `read:` list de-duplicates.
 
 Config keys: `outputs.aider.conf-file` (default empty, opt-in), `outputs.aider.model`, `outputs.aider.weak-model`, `outputs.aider.rules-file` (unset; writes a legacy merged document and skips the pointer-body write).
 
@@ -266,7 +268,7 @@ AGENTS.md                              # canonical entry-point pointer body (wri
 .amp/settings.json                     # when MCP entries exist (merged with existing user config)
 ```
 
-- **Rules**: `sync` writes `AGENTS.md` with the pointer body, shared byte-for-byte with codex and warp so the three coexist at the same path.
+- **Rules**: `sync` writes `AGENTS.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline, shared byte-for-byte with codex and warp so the three coexist at the same path.
 - **Skills**: one folder per skill under `.agents/skills/<name>/SKILL.md` (Amp's [native skills layout](https://ampcode.com/manual)). Amp [removed custom slash commands in favor of skills](https://ampcode.com/news/slashing-custom-commands), so skills no longer emit as `.agents/commands/skill-<name>.md`. The SKILL.md frontmatter carries `name` + `description`; sibling assets next to the source SKILL.md are copied byte-for-byte. Arbitrary `x-amp` keys pass through.
 - **Agents**: still emit as custom slash commands under `.agents/commands/<name>.md`. Amp has no documented per-agent file surface after the command removal; this path may be read for back-compat.
 - **MCP**: written into `.amp/settings.json` under `amp.mcpServers` (a single dotted key, not a nested object). Stdio emits `command`/`args`/`env`; HTTP/SSE emit `url`/`headers`. Pre-existing non-managed keys (theme, editor settings) are preserved; only `amp.mcpServers` is overwritten. Workspace MCPs require explicit approval on first open (Amp's safety model).
@@ -312,7 +314,7 @@ AGENTS.md                              # canonical entry-point pointer body (wri
 .warp/.mcp.json                        # when MCP entries exist
 ```
 
-- **Rules**: `sync` writes `AGENTS.md` with the pointer body, shared byte-for-byte with codex and amp so the three coexist at the same path.
+- **Rules**: `sync` writes `AGENTS.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline, shared byte-for-byte with codex and amp so the three coexist at the same path.
 - **Workflows**: when `outputs.warp.workflows-dir` is set, each agent emits as a [Warp Workflow](https://docs.warp.dev/features/warp-drive/workflows) YAML at `<dir>/<name>.yaml` (`name`/`command`/`description`/`tags`). The `command:` is the agent body verbatim; tailor it to a Warp-friendly shell snippet.
 - **Legacy rename**: Warp's current Rules docs specify `AGENTS.md` per the AGENTS.md standard. On first sync after upgrading, any agnostic-generated `WARP.md` at the configured root is renamed to `WARP.md.bak`. A user-authored `WARP.md` (no `Generated by agnostic-ai` marker) is left untouched.
 

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -232,6 +232,39 @@ func StripTargetOverview(body string) string {
 	return emit.StripTargetOverview(body)
 }
 
+// RulesStartMarker and RulesEndMarker mirror the emit-layer sentinels so
+// callers (and tests) outside the internal emit tree can detect and
+// extract the rules appendix block.
+const (
+	RulesStartMarker = emit.RulesStartMarker
+	RulesEndMarker   = emit.RulesEndMarker
+)
+
+// InlinesRulesIntoEntryPoint reports whether target delivers rule bodies
+// by inlining them into its entry-point file (re-exported from the emit
+// layer).
+func InlinesRulesIntoEntryPoint(target string) bool {
+	return emit.InlinesRulesIntoEntryPoint(target)
+}
+
+// RenderRulesAppendix renders the sentinel-marked rules block for an
+// entry-point file (re-exported from the emit layer).
+func RenderRulesAppendix(b spec.Bundle) string {
+	return emit.RenderRulesAppendix(b)
+}
+
+// AppendRulesAppendix appends a rendered rules block to body, stripping
+// any pre-existing block first (re-exported from the emit layer).
+func AppendRulesAppendix(body, appendix string) string {
+	return emit.AppendRulesAppendix(body, appendix)
+}
+
+// StripGeneratedAppendices removes every sentinel-marked block sync may
+// append to an entry-point file (re-exported from the emit layer).
+func StripGeneratedAppendices(body string) string {
+	return emit.StripGeneratedAppendices(body)
+}
+
 // Adapter is the contract every target implementation satisfies.
 type Adapter interface {
 	// Name returns the target identifier used in config and CLI flags.

--- a/internal/adapters/internal/emit/overview.go
+++ b/internal/adapters/internal/emit/overview.go
@@ -99,20 +99,29 @@ func AppendTargetOverview(body, overview string) string {
 // marker on, which matches how a truncated generated block should heal
 // on the next sync.
 func StripTargetOverview(body string) string {
-	start := strings.Index(body, OverviewStartMarker)
+	return stripMarkedBlock(body, OverviewStartMarker, OverviewEndMarker)
+}
+
+// stripMarkedBlock removes the block delimited by startMarker/endMarker
+// (markers included) from body. Returns body unchanged when startMarker
+// is absent. A start marker without an end marker drops everything from
+// the start marker on, which matches how a truncated generated block
+// should heal on the next sync.
+func stripMarkedBlock(body, startMarker, endMarker string) string {
+	start := strings.Index(body, startMarker)
 	if start < 0 {
 		return body
 	}
 	head := strings.TrimRight(body[:start], "\n")
-	rest := body[start+len(OverviewStartMarker):]
-	end := strings.Index(rest, OverviewEndMarker)
+	rest := body[start+len(startMarker):]
+	end := strings.Index(rest, endMarker)
 	if end < 0 {
 		if head == "" {
 			return ""
 		}
 		return head + "\n"
 	}
-	tail := strings.TrimLeft(rest[end+len(OverviewEndMarker):], "\n")
+	tail := strings.TrimLeft(rest[end+len(endMarker):], "\n")
 	if head == "" {
 		return tail
 	}

--- a/internal/adapters/internal/emit/rules_appendix.go
+++ b/internal/adapters/internal/emit/rules_appendix.go
@@ -1,0 +1,88 @@
+package emit
+
+import (
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// Sentinel markers delimiting the generated rules appendix inside an
+// entry-point file. Targets with no native rules directory (codex, amp,
+// warp, gemini, aider, opencode) read their always-on context from a
+// single entry-point file (AGENTS.md, GEMINI.md, CONVENTIONS.md, ...),
+// so sync inlines every rule body here. Import strips the block before
+// mirroring the body to AGNOSTIC_AI.md, keeping the canonical body free
+// of target-specific rule copies.
+const (
+	RulesStartMarker = "<!-- agnostic-ai:rules:start -->"
+	RulesEndMarker   = "<!-- agnostic-ai:rules:end -->"
+)
+
+// RenderRulesAppendix renders the sentinel-marked rules block for an
+// entry-point file. Each rule contributes a "### <name>" section with
+// its source provenance comment, optional description, and full body.
+// Returns "" when the bundle has no rules, so callers can append the
+// result unconditionally.
+func RenderRulesAppendix(b spec.Bundle) string {
+	if len(b.Rules) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString(RulesStartMarker)
+	sb.WriteString("\n\n## Rules\n\n")
+	for _, r := range b.Rules {
+		WriteSection(&sb, r.Name, r)
+	}
+	sb.WriteString(RulesEndMarker)
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// AppendRulesAppendix returns body with the rendered rules block appended
+// after one blank line, stripping any pre-existing rules block first so
+// repeated syncs never stack appendixes. Returns body unchanged when
+// appendix is empty.
+func AppendRulesAppendix(body, appendix string) string {
+	if appendix == "" {
+		return body
+	}
+	body = StripRulesAppendix(body)
+	return strings.TrimRight(body, "\n") + "\n\n" + appendix
+}
+
+// StripRulesAppendix removes the sentinel-marked rules block (markers
+// included) from body. Returns body unchanged when no block is present.
+func StripRulesAppendix(body string) string {
+	return stripMarkedBlock(body, RulesStartMarker, RulesEndMarker)
+}
+
+// StripGeneratedAppendices removes every sentinel-marked block sync may
+// append to an entry-point file (rules + target-overview), leaving the
+// canonical pointer body. Import uses it so the AGNOSTIC_AI.md round-trip
+// stays lossless regardless of which appendixes a target carried.
+func StripGeneratedAppendices(body string) string {
+	return StripRulesAppendix(StripTargetOverview(body))
+}
+
+// inlineRulesTargets are the entry-point targets whose underlying CLI has
+// no native rules directory: their only always-on context surface is the
+// single entry-point file, so sync inlines rule bodies there. Targets
+// that emit a real per-rule destination (claude .claude/rules/, cursor
+// .cursor/rules/, cline/continue/windsurf/antigravity .agent/rules/, zed
+// .rules) are absent: they deliver rules without polluting the pointer.
+var inlineRulesTargets = map[string]bool{
+	"codex":    true,
+	"amp":      true,
+	"warp":     true,
+	"gemini":   true,
+	"aider":    true,
+	"opencode": true,
+}
+
+// InlinesRulesIntoEntryPoint reports whether target delivers rule bodies
+// by inlining them into its entry-point file. The legacy concatenated
+// rules-file layout (outputs.<target>.rules-file) overrides this: the
+// adapter owns that write and the central inline is skipped.
+func InlinesRulesIntoEntryPoint(target string) bool {
+	return inlineRulesTargets[target]
+}

--- a/internal/adapters/internal/emit/rules_appendix_test.go
+++ b/internal/adapters/internal/emit/rules_appendix_test.go
@@ -1,0 +1,81 @@
+package emit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+func ruleBundle() spec.Bundle {
+	return spec.Bundle{Rules: []spec.Entry{
+		{Kind: spec.KindRule, Name: "r1", Path: "rules/r1.md", Body: "rule one body"},
+		{Kind: spec.KindRule, Name: "r2", Path: "rules/r2.md", Body: "rule two body"},
+	}}
+}
+
+func TestRenderRulesAppendix_EmitsEachRuleBody(t *testing.T) {
+	got := RenderRulesAppendix(ruleBundle())
+	for _, want := range []string{
+		RulesStartMarker, RulesEndMarker,
+		"## Rules", "### r1", "rule one body", "### r2", "rule two body",
+		"<!-- source: rules/r1.md -->",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("appendix missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderRulesAppendix_EmptyWhenNoRules(t *testing.T) {
+	if got := RenderRulesAppendix(spec.Bundle{}); got != "" {
+		t.Errorf("want empty appendix for ruleless bundle, got %q", got)
+	}
+}
+
+func TestAppendRulesAppendix_DoesNotStack(t *testing.T) {
+	body := "# Pointer body\n"
+	app := RenderRulesAppendix(ruleBundle())
+	once := AppendRulesAppendix(body, app)
+	twice := AppendRulesAppendix(once, app)
+	if once != twice {
+		t.Errorf("re-appending stacked the block:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+	if n := strings.Count(twice, RulesStartMarker); n != 1 {
+		t.Errorf("want exactly one rules block, got %d", n)
+	}
+}
+
+func TestStripRulesAppendix_RoundTrips(t *testing.T) {
+	body := "# Pointer body\n"
+	withRules := AppendRulesAppendix(body, RenderRulesAppendix(ruleBundle()))
+	if got := StripRulesAppendix(withRules); got != body {
+		t.Errorf("strip did not restore body.\nwant %q\ngot  %q", body, got)
+	}
+}
+
+func TestStripGeneratedAppendices_RemovesRulesAndOverview(t *testing.T) {
+	body := "# Pointer body\n"
+	withRules := AppendRulesAppendix(body, RenderRulesAppendix(ruleBundle()))
+	withBoth := AppendTargetOverview(withRules, RenderTargetOverview([]TargetArtifacts{
+		{Target: "codex", Artifacts: []NativeArtifact{{Label: "Agents", Location: ".codex/agents/"}}},
+	}))
+	if got := StripGeneratedAppendices(withBoth); got != body {
+		t.Errorf("strip did not restore canonical body.\nwant %q\ngot  %q", body, got)
+	}
+}
+
+func TestInlinesRulesIntoEntryPoint(t *testing.T) {
+	inline := []string{"codex", "amp", "warp", "gemini", "aider", "opencode"}
+	for _, tgt := range inline {
+		if !InlinesRulesIntoEntryPoint(tgt) {
+			t.Errorf("%s should inline rules into its entry-point", tgt)
+		}
+	}
+	// Targets with a native rules destination must not inline.
+	for _, tgt := range []string{"claude", "cursor", "cline", "continue", "windsurf", "antigravity", "zed", "copilot"} {
+		if InlinesRulesIntoEntryPoint(tgt) {
+			t.Errorf("%s has a native rules destination and must not inline", tgt)
+		}
+	}
+}

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
 // driftReport summarizes per-target drift between source specs and on-disk
@@ -70,7 +71,7 @@ func collectDrift(targets []string) ([]driftReport, error) {
 		}
 		reports = append(reports, rep)
 	}
-	epRep, err := collectEntryPointDrift(cfg, targets)
+	epRep, err := collectEntryPointDrift(cfg, b, targets)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func collectDrift(targets []string) ([]driftReport, error) {
 // target's native entry-point file (CLAUDE.md, AGENTS.md, etc.) match what
 // sync would write. The body source is AGNOSTIC_AI.md when it exists;
 // otherwise the template body is used.
-func collectEntryPointDrift(cfg *config.Config, targets []string) (driftReport, error) {
+func collectEntryPointDrift(cfg *config.Config, b spec.Bundle, targets []string) (driftReport, error) {
 	rep := driftReport{Target: "agnostic-ai"}
 
 	data, err := os.ReadFile(adapters.AgnosticEntryPointPath)
@@ -100,7 +101,7 @@ func collectEntryPointDrift(cfg *config.Config, targets []string) (driftReport, 
 		return rep, fmt.Errorf("%s: %w", adapters.AgnosticEntryPointPath, err)
 	}
 
-	for _, f := range renderEntryPointFiles(cfg, targets, body) {
+	for _, f := range renderEntryPointFiles(cfg, b, targets, body) {
 		disk, err := os.ReadFile(f.Path)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
 // writeAgnosticEntryPoints distributes the canonical entry-point body to
@@ -29,12 +30,12 @@ import (
 // triggers a one-line warning before the overwrite so the user knows
 // their content is about to be replaced. This is the same heuristic
 // the importer uses to skip files it did not write.
-func writeAgnosticEntryPoints(cfg *config.Config, targets []string, dryRun bool) error {
+func writeAgnosticEntryPoints(cfg *config.Config, b spec.Bundle, targets []string, dryRun bool) error {
 	body, err := resolveAgnosticBody(cfg, dryRun)
 	if err != nil {
 		return err
 	}
-	for _, f := range renderEntryPointFiles(cfg, targets, body) {
+	for _, f := range renderEntryPointFiles(cfg, b, targets, body) {
 		warnOnHandAuthoredEntryPoint(f.Path)
 		if err := adapters.WriteFile(f.Path, f.Content, dryRun); err != nil {
 			return fmt.Errorf("write entry-point %s: %w", f.Path, err)
@@ -60,8 +61,16 @@ type entryPointFile struct {
 // sentinel-marked appendix listing the native artifact locations of
 // every target consuming that path (a shared AGENTS.md lists each
 // consumer separately).
-func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []entryPointFile {
-	body = adapters.StripTargetOverview(body)
+//
+// Targets with no native rules directory (codex, amp, warp, gemini,
+// aider, opencode) get the rule bodies inlined into their entry-point
+// file via a second sentinel-marked block, since that file is their
+// only always-on context surface. The block is identical across the
+// consumers of a shared path (rules are global), so the deduplicated
+// write stays collision-free.
+func renderEntryPointFiles(cfg *config.Config, b spec.Bundle, targets []string, body string) []entryPointFile {
+	body = adapters.StripGeneratedAppendices(body)
+	rulesAppendix := adapters.RenderRulesAppendix(b)
 	var order []string
 	consumers := map[string][]string{}
 	for _, t := range targets {
@@ -81,6 +90,9 @@ func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []
 	files := make([]entryPointFile, 0, len(order))
 	for _, path := range order {
 		content := body
+		if pathInlinesRules(consumers[path]) {
+			content = adapters.AppendRulesAppendix(content, rulesAppendix)
+		}
 		if cfg.Sync.TargetOverview {
 			var sections []adapters.TargetArtifacts
 			for _, t := range consumers[path] {
@@ -89,7 +101,7 @@ func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []
 					Artifacts: adapters.NativeArtifactsFor(t, cfg),
 				})
 			}
-			content = adapters.AppendTargetOverview(body, adapters.RenderTargetOverview(sections))
+			content = adapters.AppendTargetOverview(content, adapters.RenderTargetOverview(sections))
 		}
 		files = append(files, entryPointFile{
 			Path:    path,
@@ -97,6 +109,18 @@ func renderEntryPointFiles(cfg *config.Config, targets []string, body string) []
 		})
 	}
 	return files
+}
+
+// pathInlinesRules reports whether any target consuming an entry-point
+// path inlines rule bodies into it. A shared path (AGENTS.md) inlines
+// when at least one consumer needs it; the block is identical for all.
+func pathInlinesRules(consumers []string) bool {
+	for _, t := range consumers {
+		if adapters.InlinesRulesIntoEntryPoint(t) {
+			return true
+		}
+	}
+	return false
 }
 
 // entryPointPaths returns the entry-point files sync distributes: the

--- a/internal/cli/entrypoint_overview_test.go
+++ b/internal/cli/entrypoint_overview_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
@@ -25,7 +26,7 @@ func TestWriteAgnosticEntryPoints_TargetOverviewAppendsAppendix(t *testing.T) {
 		},
 	}
 
-	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -59,7 +60,7 @@ func TestWriteAgnosticEntryPoints_TargetOverviewOffByDefault(t *testing.T) {
 	writeAgnosticFile(t, "# Project\n")
 	cfg := &config.Config{Targets: []string{"claude"}}
 
-	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
@@ -79,7 +80,7 @@ func TestWriteAgnosticEntryPoints_TargetOverviewSharedPathListsEachConsumer(t *t
 		Sync:    config.SyncConfig{TargetOverview: true},
 	}
 
-	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
@@ -107,10 +108,10 @@ func TestCollectEntryPointDrift_NoDriftAfterSyncWithOverview(t *testing.T) {
 		Sync:    config.SyncConfig{TargetOverview: true},
 	}
 
-	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	rep, err := collectEntryPointDrift(cfg, cfg.Targets)
+	rep, err := collectEntryPointDrift(cfg, spec.Bundle{}, cfg.Targets)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/cli/entrypoint_test.go
+++ b/internal/cli/entrypoint_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
@@ -31,7 +32,7 @@ func TestWriteAgnosticEntryPoints_WarnsBeforeOverwritingHandAuthored(t *testing.
 	defer func() { logOut = prev }()
 
 	cfg := &config.Config{Targets: []string{"claude"}}
-	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), "CLAUDE.md appears hand-authored") {
@@ -55,7 +56,7 @@ func TestWriteAgnosticEntryPoints_NoWarnWhenGeneratedHeaderPresent(t *testing.T)
 	defer func() { logOut = prev }()
 
 	cfg := &config.Config{Targets: []string{"claude"}}
-	if err := writeAgnosticEntryPoints(cfg, cfg.Targets, false); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(buf.String(), "appears hand-authored") {
@@ -123,7 +124,7 @@ func TestWriteAgnosticEntryPoints_DistributesBodyToTargets(t *testing.T) {
 	writeAgnosticFile(t, custom)
 	cfg := &config.Config{Targets: []string{"claude", "codex"}}
 
-	if err := writeAgnosticEntryPoints(cfg, []string{"claude", "codex"}, false); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, []string{"claude", "codex"}, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, path := range []string{"CLAUDE.md", "AGENTS.md"} {
@@ -142,7 +143,7 @@ func TestWriteAgnosticEntryPoints_AgnosticFileNotOverwrittenWhenExists(t *testin
 	custom := "# My instructions\n"
 	writeAgnosticFile(t, custom)
 
-	if err := writeAgnosticEntryPoints(&config.Config{}, nil, false); err != nil {
+	if err := writeAgnosticEntryPoints(&config.Config{}, spec.Bundle{}, nil, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(adapters.AgnosticEntryPointPath)

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -122,6 +122,9 @@ func computeGraphEdges(b spec.Bundle, cfg *config.Config) ([]graphEdge, error) {
 			if err != nil {
 				return nil, fmt.Errorf("%s: %w", t, err)
 			}
+			if extra, ok := entryPointRuleFile(cfg, t, e, single); ok {
+				captured = append(captured, extra)
+			}
 			seen := make(map[string]struct{}, len(captured))
 			for _, f := range captured {
 				p := filepath.ToSlash(f.Path)

--- a/internal/cli/graph_test.go
+++ b/internal/cli/graph_test.go
@@ -90,6 +90,37 @@ func runGraph(t *testing.T, args ...string) string {
 	return out.String()
 }
 
+func TestGraph_CodexRuleEdgeToAgentsMd(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(p, body string) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(filepath.Join(dir, "agnostic-ai.yaml"), "version: 1\nsources:\n  rules: rules\ntargets:\n  - codex\n")
+	mustWrite(filepath.Join(dir, "rules", "no-console-log.md"), "---\nname: no-console-log\ndescription: No console.log.\n---\n\nBody.\n")
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	out := runGraph(t, "--format", "json")
+	var edges []graphEdge
+	if err := json.Unmarshal([]byte(out), &edges); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	found := false
+	for _, e := range edges {
+		if e.Target == "codex" && e.Kind == "rule" && e.Path == "AGENTS.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected rule → codex → AGENTS.md edge, got:\n%s", out)
+	}
+}
+
 func TestGraph_TextMatrixIncludesSpecsAndTargets(t *testing.T) {
 	dir := setupGraphFixture(t)
 	testutil.Chdir(t, dir)

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -136,10 +136,11 @@ func mirrorClaudeMainFile(root string) (wrote bool, srcName string, promotedNest
 // copy under the managed directory. Later imports overwrite earlier
 // mirrors (last-import wins).
 //
-// The generated target-overview appendix (sync.target-overview) is
-// stripped before the write: it is per-entry-point derived output, not
-// part of the canonical body, and carrying it back would duplicate it
-// on the next sync.
+// The generated appendices (inlined rules + target-overview) are
+// stripped before the write: they are per-entry-point derived output,
+// not part of the canonical body, and carrying them back would
+// duplicate them on the next sync (and leak target-specific rule copies
+// into every other target's entry-point).
 func mirrorMainFile(root, srcName string) (bool, error) {
 	src := filepath.Join(root, srcName)
 	dst := filepath.Join(root, agnosticMainFile)
@@ -150,7 +151,7 @@ func mirrorMainFile(root, srcName string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("mirror %s: %w", srcName, err)
 	}
-	body := adapters.StripTargetOverview(string(data))
+	body := adapters.StripGeneratedAppendices(string(data))
 	if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -131,6 +131,9 @@ func importFromCodexWithOpts(root string, src config.Sources, opts importCodexOp
 // child does (e.g. the `## Conventions` listing).
 var codexUnwrapHeadings = map[string]bool{
 	"conventions": true,
+	// The sync-generated rules appendix wraps each rule under a `## Rules`
+	// H2; its `### <name>` children are the real rules.
+	"rules": true,
 }
 
 // codexSkipHeadings are H2 sections produced by the codex emitter as
@@ -159,10 +162,14 @@ func importCodexRules(root, dstDir string, src config.Sources, opts importCodexO
 	used := map[string]int{}
 	count := 0
 	for _, f := range files {
-		data, err := os.ReadFile(f.path)
+		raw, err := os.ReadFile(f.path)
 		if err != nil {
 			return count, fmt.Errorf("read %s: %w", f.path, err)
 		}
+		// When sync inlined the rules into a sentinel block, rebuild the
+		// specs from that block alone and ignore the regenerable pointer
+		// body. A no-op on hand-authored AGENTS.md files.
+		data := []byte(reduceToGeneratedRules(string(raw)))
 		if !opts.shredEnabled() {
 			body := strings.TrimSpace(string(data))
 			if body == "" {

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -7,8 +7,35 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
+
+func TestImportFromCodex_StripsGeneratedRulesAppendix(t *testing.T) {
+	dir := t.TempDir()
+	pointer := "# AI Project Conventions\n\nPointer body.\n"
+	agents := pointer + "\n" + adapters.RenderRulesAppendix(spec.Bundle{Rules: []spec.Entry{
+		{Kind: spec.KindRule, Name: "conventions", Path: "rules/conventions.md", Body: "Inlined rule body."},
+	}})
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), agents)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, agnosticMainFile))
+	if err != nil {
+		t.Fatalf("missing %s: %v", agnosticMainFile, err)
+	}
+	if strings.Contains(string(got), adapters.RulesStartMarker) {
+		t.Errorf("AGNOSTIC_AI.md must not carry the generated rules block:\n%s", got)
+	}
+	if strings.Contains(string(got), "Inlined rule body.") {
+		t.Errorf("AGNOSTIC_AI.md must not leak inlined rule body:\n%s", got)
+	}
+	if string(got) != pointer {
+		t.Errorf("AGNOSTIC_AI.md should equal the pointer body.\nwant %q\ngot  %q", pointer, got)
+	}
+}
 
 func TestImportFromCodex_NoAgentsMd(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cli/import_shared_md.go
+++ b/internal/cli/import_shared_md.go
@@ -8,7 +8,27 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
 )
+
+// reduceToGeneratedRules returns the inner content of the sync-generated
+// rules appendix when the sentinel markers are present, so importers
+// reconstruct rule specs from the inlined block and discard the
+// regenerable pointer body and target-overview. Returns body unchanged
+// when no rules block is present: hand-authored entry-points and legacy
+// concatenated rules-files slice in full.
+func reduceToGeneratedRules(body string) string {
+	start := strings.Index(body, adapters.RulesStartMarker)
+	if start < 0 {
+		return body
+	}
+	inner := body[start+len(adapters.RulesStartMarker):]
+	if end := strings.Index(inner, adapters.RulesEndMarker); end >= 0 {
+		inner = inner[:end]
+	}
+	return inner
+}
 
 // extractLeadingItalic returns the inner text of a `_..._` paragraph
 // at the start of body (no surrounding whitespace) and the body with
@@ -97,16 +117,22 @@ func sliceMainFileByH2(root, srcName, dstDir string) (int, error) {
 		return 0, fmt.Errorf("read %s: %w", src, err)
 	}
 
-	preamble, sections := splitH2Sections(string(data))
+	// When sync inlined the rules into a sentinel block, reconstruct the
+	// specs from that block alone and ignore the regenerable pointer
+	// body (and target-overview). A no-op on hand-authored or legacy
+	// concatenated files, which slice in full as before.
+	body := reduceToGeneratedRules(string(data))
+
+	preamble, sections := splitH2Sections(body)
 	preamble = stripMergedDocPreamble(preamble)
 	if len(sections) == 0 {
-		body := strings.TrimSpace(string(data))
-		if body == "" {
+		flat := strings.TrimSpace(body)
+		if flat == "" {
 			return 0, nil
 		}
 		name := projectSlug(root)
 		path := filepath.Join(dstDir, name+".md")
-		if err := writeRule(path, name, body); err != nil {
+		if err := writeRule(path, name, flat); err != nil {
 			return 0, err
 		}
 		return 1, nil

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -57,6 +57,9 @@ func newRenderCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("%s: %w", t, err)
 				}
+				if extra, ok := entryPointRuleFile(cfg, t, entry, single); ok {
+					captured = append(captured, extra)
+				}
 				if len(captured) == 0 {
 					_, _ = fmt.Fprintf(out, "# target: %s — (no output for kind %s)\n", t, entry.Kind)
 					continue
@@ -116,6 +119,32 @@ func findSpecEntry(input string, b spec.Bundle) (spec.Entry, error) {
 		return spec.Entry{}, fmt.Errorf("spec %q not found. Did you mean: %s", input, strings.Join(hints, ", "))
 	}
 	return spec.Entry{}, fmt.Errorf("spec %q not found", input)
+}
+
+// entryPointRuleFile returns the entry-point contribution a rule spec
+// makes for a target that inlines rules into its entry-point file
+// (codex, amp, warp, gemini, aider, opencode). The adapter's Emit does
+// not produce this output: rule inlining happens in the central sync
+// layer, so render and graph reconstruct it here to mirror what `sync`
+// actually writes. Returns ok=false for non-rule specs, non-inlining
+// targets, and targets on the legacy concatenated rules-file layout
+// (where the adapter owns the entry-point write instead).
+func entryPointRuleFile(cfg *config.Config, target string, entry spec.Entry, single spec.Bundle) (adapters.CapturedFile, bool) {
+	if entry.Kind != spec.KindRule {
+		return adapters.CapturedFile{}, false
+	}
+	if !adapters.InlinesRulesIntoEntryPoint(target) || adapters.HasLegacyRulesFile(cfg, target) {
+		return adapters.CapturedFile{}, false
+	}
+	path := adapters.EntryPointPath(cfg, target)
+	if path == "" {
+		return adapters.CapturedFile{}, false
+	}
+	appendix := adapters.RenderRulesAppendix(single)
+	if appendix == "" {
+		return adapters.CapturedFile{}, false
+	}
+	return adapters.CapturedFile{Path: path, Content: appendix}, true
 }
 
 // singleEntryBundle returns a Bundle that contains only the given entry,

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -69,6 +69,30 @@ func TestRender_SingleTargetCursor(t *testing.T) {
 	}
 }
 
+func TestRender_CodexRuleInlinesIntoAgentsMd(t *testing.T) {
+	dir := setupRenderFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"render", "rules/no-console-log.md", "--target", "codex"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Contains(got, "(no output for kind rule)") {
+		t.Errorf("codex rule render must not report no output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "# target: codex — AGENTS.md") {
+		t.Errorf("expected codex AGENTS.md header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Do not commit console.log statements.") {
+		t.Errorf("expected rule body inlined for codex, got:\n%s", got)
+	}
+}
+
 func TestRender_MultiTarget(t *testing.T) {
 	dir := setupRenderFixture(t)
 	testutil.Chdir(t, dir)

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -129,7 +129,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 			}
 		}
 		adapters.StartDetailedRecording()
-		if err := writeAgnosticEntryPoints(cfg, effectiveTargets, dryRun); err != nil {
+		if err := writeAgnosticEntryPoints(cfg, b, effectiveTargets, dryRun); err != nil {
 			adapters.StopDetailedRecording()
 			if gitignoreOn {
 				adapters.StopRecording()
@@ -161,7 +161,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 				return fmt.Errorf("%s: %w", t, err)
 			}
 		}
-		if err := writeAgnosticEntryPoints(cfg, effectiveTargets, dryRun); err != nil {
+		if err := writeAgnosticEntryPoints(cfg, b, effectiveTargets, dryRun); err != nil {
 			if gitignoreOn {
 				adapters.StopRecording()
 			}
@@ -307,7 +307,7 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 	}
 
 	adapters.StartDetailedRecording()
-	if err := writeAgnosticEntryPoints(cfg, effectiveTargets, dryRun); err != nil {
+	if err := writeAgnosticEntryPoints(cfg, b, effectiveTargets, dryRun); err != nil {
 		adapters.StopDetailedRecording()
 		out.Errors = append(out.Errors, errorRecord{Target: "agnostic-ai", Message: err.Error()})
 	} else {

--- a/tests/integration/fixtures/golden/aider/CONVENTIONS.md
+++ b/tests/integration/fixtures/golden/aider/CONVENTIONS.md
@@ -22,3 +22,17 @@ Per-target configuration that does not fit the agnostic spec kinds above lives u
 - Author specs under the directories above.
 - Run `agnostic-ai sync` to regenerate per-target output files.
 - Edit only the source specs; the per-target files (including this one) are overwritten on each sync.
+
+<!-- agnostic-ai:rules:start -->
+
+## Rules
+
+### sample-rule
+
+<!-- source: .agnostic-ai/rules/sample-rule.md -->
+_A sample rule for golden snapshot tests._
+
+Be terse. Lead with the action.
+
+
+<!-- agnostic-ai:rules:end -->

--- a/tests/integration/fixtures/golden/amp/AGENTS.md
+++ b/tests/integration/fixtures/golden/amp/AGENTS.md
@@ -22,3 +22,17 @@ Per-target configuration that does not fit the agnostic spec kinds above lives u
 - Author specs under the directories above.
 - Run `agnostic-ai sync` to regenerate per-target output files.
 - Edit only the source specs; the per-target files (including this one) are overwritten on each sync.
+
+<!-- agnostic-ai:rules:start -->
+
+## Rules
+
+### sample-rule
+
+<!-- source: .agnostic-ai/rules/sample-rule.md -->
+_A sample rule for golden snapshot tests._
+
+Be terse. Lead with the action.
+
+
+<!-- agnostic-ai:rules:end -->

--- a/tests/integration/fixtures/golden/codex/AGENTS.md
+++ b/tests/integration/fixtures/golden/codex/AGENTS.md
@@ -22,3 +22,17 @@ Per-target configuration that does not fit the agnostic spec kinds above lives u
 - Author specs under the directories above.
 - Run `agnostic-ai sync` to regenerate per-target output files.
 - Edit only the source specs; the per-target files (including this one) are overwritten on each sync.
+
+<!-- agnostic-ai:rules:start -->
+
+## Rules
+
+### sample-rule
+
+<!-- source: .agnostic-ai/rules/sample-rule.md -->
+_A sample rule for golden snapshot tests._
+
+Be terse. Lead with the action.
+
+
+<!-- agnostic-ai:rules:end -->

--- a/tests/integration/fixtures/golden/gemini/GEMINI.md
+++ b/tests/integration/fixtures/golden/gemini/GEMINI.md
@@ -22,3 +22,17 @@ Per-target configuration that does not fit the agnostic spec kinds above lives u
 - Author specs under the directories above.
 - Run `agnostic-ai sync` to regenerate per-target output files.
 - Edit only the source specs; the per-target files (including this one) are overwritten on each sync.
+
+<!-- agnostic-ai:rules:start -->
+
+## Rules
+
+### sample-rule
+
+<!-- source: .agnostic-ai/rules/sample-rule.md -->
+_A sample rule for golden snapshot tests._
+
+Be terse. Lead with the action.
+
+
+<!-- agnostic-ai:rules:end -->

--- a/tests/integration/fixtures/golden/opencode/.opencode/AGENTS.md
+++ b/tests/integration/fixtures/golden/opencode/.opencode/AGENTS.md
@@ -22,3 +22,17 @@ Per-target configuration that does not fit the agnostic spec kinds above lives u
 - Author specs under the directories above.
 - Run `agnostic-ai sync` to regenerate per-target output files.
 - Edit only the source specs; the per-target files (including this one) are overwritten on each sync.
+
+<!-- agnostic-ai:rules:start -->
+
+## Rules
+
+### sample-rule
+
+<!-- source: .agnostic-ai/rules/sample-rule.md -->
+_A sample rule for golden snapshot tests._
+
+Be terse. Lead with the action.
+
+
+<!-- agnostic-ai:rules:end -->

--- a/tests/integration/fixtures/golden/warp/AGENTS.md
+++ b/tests/integration/fixtures/golden/warp/AGENTS.md
@@ -22,3 +22,17 @@ Per-target configuration that does not fit the agnostic spec kinds above lives u
 - Author specs under the directories above.
 - Run `agnostic-ai sync` to regenerate per-target output files.
 - Edit only the source specs; the per-target files (including this one) are overwritten on each sync.
+
+<!-- agnostic-ai:rules:start -->
+
+## Rules
+
+### sample-rule
+
+<!-- source: .agnostic-ai/rules/sample-rule.md -->
+_A sample rule for golden snapshot tests._
+
+Be terse. Lead with the action.
+
+
+<!-- agnostic-ai:rules:end -->

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/cli"
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
@@ -41,8 +42,11 @@ func TestSync_EmitsAllTargets(t *testing.T) {
 			t.Errorf("missing expected output %s: %v", f, err)
 		}
 	}
-	// Every per-target entry-point shares the canonical pointer body
-	// (byte-identical to AGNOSTIC_AI.md).
+	// Every per-target entry-point shares the canonical pointer body.
+	// Targets with no native rules directory (codex/amp/warp/gemini/
+	// aider/opencode) append an inlined rules block, so the invariant is
+	// "strip the generated appendices and the body is byte-identical to
+	// AGNOSTIC_AI.md". Claude and Copilot carry no appendix here.
 	body, err := os.ReadFile(filepath.Join(dir, ".agnostic-ai/AGNOSTIC_AI.md"))
 	if err != nil {
 		t.Fatalf("read AGNOSTIC_AI.md: %v", err)
@@ -52,9 +56,17 @@ func TestSync_EmitsAllTargets(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", f, err)
 		}
-		if string(got) != string(body) {
-			t.Errorf("%s body should match AGNOSTIC_AI.md byte-for-byte", f)
+		if stripped := adapters.StripGeneratedAppendices(string(got)); stripped != string(body) {
+			t.Errorf("%s body should match AGNOSTIC_AI.md after stripping appendices", f)
 		}
+	}
+	// AGENTS.md (codex) must surface the always-on rule body inline.
+	agents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(agents), "Be terse. Avoid filler.") {
+		t.Errorf("AGENTS.md should inline the always-on rule body, got:\n%s", agents)
 	}
 }
 

--- a/tests/integration/zero_drift_after_import_test.go
+++ b/tests/integration/zero_drift_after_import_test.go
@@ -84,6 +84,43 @@ func TestZeroDrift_AfterCodexImportSync(t *testing.T) {
 	}
 }
 
+// TestZeroDrift_CodexReimportAfterRulesInlined guards the round-trip
+// introduced when codex began inlining rule bodies into AGENTS.md
+// (#399). A sync writes the generated rules block; a subsequent
+// `import codex` must strip that block instead of re-deriving rules
+// from it, so the rules source stays a single file and sync --check
+// still reports zero drift.
+func TestZeroDrift_CodexReimportAfterRulesInlined(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	must(t, os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"),
+		[]byte(codexOnlyConfig), 0o644))
+	must(t, os.MkdirAll(filepath.Join(dir, ".agnostic-ai", "rules"), 0o755))
+	must(t, os.WriteFile(filepath.Join(dir, ".agnostic-ai", "rules", "conventions.md"),
+		[]byte("---\nname: conventions\ndescription: Project conventions.\n---\n\nBe terse.\n"), 0o644))
+
+	runCmd(t, "sync", "-t", "codex")
+	// AGENTS.md now carries the generated rules block.
+	runCmd(t, "import", "codex")
+
+	// Exactly one rule file survives: no duplicate re-derived from the
+	// generated block.
+	entries, err := os.ReadDir(filepath.Join(dir, ".agnostic-ai", "rules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected 1 rule after re-import, got %d: %v", len(entries), names)
+	}
+
+	runCmd(t, "sync", "--check", "-t", "codex")
+}
+
 // TestZeroDrift_AfterClaudeAndCodexImportSync runs import + sync for
 // both adapters in the same project, then sync --check. Catches drift
 // triggered only when both overlays coexist (e.g. a path collision the


### PR DESCRIPTION
## Summary

- `codex`, `amp`, `warp`, `gemini`, `aider`, `opencode` advertised `KindRule` but emitted **no** rule content on a default `sync`. Their entry-point file (AGENTS.md, GEMINI.md, CONVENTIONS.md, ...) held only the pointer body, so rule specs reached the tool nowhere. The drop was silent (kind listed as supported, no `on-unsupported` warning).
- Fix: inline every rule body into the entry-point file under a sentinel-marked `## Rules` block (after the pointer body), centrally in the sync layer. That file is these tools' only always-on context surface. The block is identical across targets sharing a path, so the dedup holds.
- `render` and `graph` reconstruct the contribution (they run adapters, which don't own the central entry-point write). `import` strips the block, keeping the `AGNOSTIC_AI.md` round-trip lossless. Playground (wasm) mirrors the inline.

Closes #399

## Acceptance

- [x] `render <rule> --target codex` produces the rule body (`TestRender_CodexRuleInlinesIntoAgentsMd`)
- [x] After `sync`, a default codex project surfaces rules in `AGENTS.md` (`TestSync_EmitsAllTargets`, golden snapshots)
- [x] `graph` shows a `codex` column for rule specs (`TestGraph_CodexRuleEdgeToAgentsMd`)
- [x] Scope extended to all six entry-point-only rule targets (codex, amp, warp, gemini, aider, opencode)

## Round-trip safety

`import` extracts rules from the generated sentinel block and discards the regenerable pointer body, so `sync -> import -> sync` stays byte-stable (`TestZeroDrift_CodexReimportAfterRulesInlined`, `TestAiderRoundTrip_*`).

## Test plan

- [x] `go test ./...` (1148 pass)
- [x] `gofmt` / `go vet` clean
- [x] `agnostic-ai sync --check` clean on this repo
- [x] golden snapshots regenerated (6 entry-point files)
- [x] playground wasm rebuilt

## Final review

Re-reviewed every touched file: all new exports/helpers are used, no dead branches, no cross-adapter imports (rule inlining lives in the central sync layer + shared `emit` package). No further changes surfaced; folded into the feature commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)