### PR TITLE
feat(sync): note opt-in coverage gaps instead of silent skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `sync`: prints a `note:` line per opt-in coverage gap (a kind a target supports but emits only behind an `outputs.<target>.*` key, or source-dir only), so silently skipped content is visible. Covers gemini/opencode skills, warp agents and skills, aider agents and skills, and zed hooks. Suppressed when unchanged across runs. (#404)
+
 ### Changed
 
 ### Fixed

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -319,6 +319,29 @@ Fires when an adapter receives spec kinds it does not support (e.g. `hooks` for 
 | `error` | Fail the sync. |
 | `silent` | Skip without logging. |
 
+## Coverage notes
+
+A target may declare support for a kind yet emit it only behind an opt-in key, or not at all by default. The content is not dropped, but it does not reach the target until you set the key. `sync` prints a `note:` line per gap so the gap is visible:
+
+```
+  note: 2 skills reach gemini, opencode only via outputs.<target>.emit-skills-as-commands
+  note: 1 agent reaches warp only via outputs.warp.workflows-dir
+  note: 3 skills reach warp only in the source dir (no native skill surface)
+```
+
+A note fires only when specs of that kind are present and the opt-in is inactive. Setting the named key clears the note and emits the content. Notes that match the previous sync are suppressed; delete `.agnostic-ai/.sync-state` to re-show them.
+
+The instrumented gaps:
+
+| Target | Kind | Set this to emit |
+|--------|------|------------------|
+| `gemini` | skills | `outputs.gemini.emit-skills-as-commands` |
+| `opencode` | skills | `outputs.opencode.emit-skills-as-commands` |
+| `warp` | agents | `outputs.warp.workflows-dir` |
+| `warp` | skills | no key; Warp has no native skill surface (stays source-dir only) |
+| `aider` | agents, skills | `outputs.aider.rules-file` |
+| `zed` | hooks | `outputs.zed.tasks-file` |
+
 ## `gitignore`
 
 | Field | Default | Description |

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -45,6 +45,8 @@ Set `sync.target-overview: true` to append a generated section to each entry-poi
 | **opencode**    | `.opencode/commands/<name>.md` | `.opencode/commands/skill-<name>.md` w/ opt-in | inlined into `.opencode/AGENTS.md` (legacy concat via `outputs.opencode.rules-file`) | - | `opencode.json` (`mcp`) | - |
 | **antigravity** | as `.md` rule (`agent-<name>.md`) | `.agent/skills/<name>/SKILL.md` | `.agent/rules/*.md` (legacy merge via `outputs.antigravity.rules-file`) | - | - | - |
 
+Cells marked "w/ opt-in" or "source-dir only" do not emit by default. When specs of that kind are present, `sync` prints a `note:` line naming the key to set (or stating the content stays source-dir only). See [Coverage notes](configuration.md#coverage-notes).
+
 Cross-cutting kind notes:
 
 - **Skills**: only Claude Code executes them natively. On every other target they are reference material the agent or human reads and follows.

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -94,6 +94,23 @@ func CapabilityWarningsDigest() string { return emit.CapabilityWarningsDigest() 
 // (target, kind) capability warnings currently buffered.
 func PendingCapabilityWarningsCount() int { return emit.PendingCapabilityWarningsCount() }
 
+// ResetCoverageNotes clears buffered coverage notes without printing.
+// Used by tests and by `sync --watch` before each new pass.
+func ResetCoverageNotes() { emit.ResetCoverageNotes() }
+
+// FlushCoverageNotes prints any buffered coverage notes, grouped by
+// kind, then clears the buffer. Call once at the end of a sync pass.
+func FlushCoverageNotes() { emit.FlushCoverageNotes() }
+
+// CoverageNotesDigest returns a stable hex digest of the currently
+// buffered coverage notes, "" when none. Used by sync to suppress
+// unchanged note sets across runs.
+func CoverageNotesDigest() string { return emit.CoverageNotesDigest() }
+
+// PendingCoverageNotesCount returns the number of distinct
+// (target, kind, via) coverage notes currently buffered.
+func PendingCoverageNotesCount() int { return emit.PendingCoverageNotesCount() }
+
 // StartRecording begins collecting written paths alongside real writes.
 // Unlike capture mode it does not suppress IO. Used by `sync` to learn
 // every emitted path in a single pass for follow-up actions like

--- a/internal/adapters/aider/aider.go
+++ b/internal/adapters/aider/aider.go
@@ -61,6 +61,12 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 			return err
 		}
 		outFile = rulesFile
+	} else {
+		// Aider agents and skills reach the target only through the
+		// legacy merged document. Without rules-file set they stay
+		// source-dir only.
+		emit.NoteCoverageGap(target, spec.KindAgent, len(b.Agents), "outputs.aider.rules-file")
+		emit.NoteCoverageGap(target, spec.KindSkill, len(b.Skills), "outputs.aider.rules-file")
 	}
 	return emitConf(
 		emit.OutputConfFile(cfg, target, ""),

--- a/internal/adapters/aider/coverage_note_test.go
+++ b/internal/adapters/aider/coverage_note_test.go
@@ -1,0 +1,71 @@
+package aider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func swapNoteWarner(t *testing.T) *strings.Builder {
+	t.Helper()
+	buf := &strings.Builder{}
+	prev := emit.Warner
+	emit.Warner = buf
+	t.Cleanup(func() { emit.Warner = prev })
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+	return buf
+}
+
+func TestEmit_NotesAgentAndSkillGapWhenRulesFileUnset(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	if err := New().Emit(kitSinkBundle(), &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	out := buf.String()
+	if !strings.Contains(out, "agents reach aider only via outputs.aider.rules-file") {
+		t.Errorf("expected agent coverage note, got: %s", out)
+	}
+	if !strings.Contains(out, "skills reach aider only via outputs.aider.rules-file") {
+		t.Errorf("expected skill coverage note, got: %s", out)
+	}
+}
+
+func TestEmit_NoNotesWhenRulesFileSet(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"aider": {RulesFile: "CONVENTIONS.md"},
+	}}
+	if err := New().Emit(kitSinkBundle(), cfg, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	if strings.Contains(buf.String(), "reach aider") {
+		t.Errorf("rules-file set must suppress the notes, got: %s", buf.String())
+	}
+}
+
+func TestEmit_NoNotesWhenNoAgentsOrSkills(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindRule, Name: "r1", Path: "rules/r1.md", Body: "x"},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if got := emit.PendingCoverageNotesCount(); got != 0 {
+		t.Errorf("no agent/skill specs must buffer no note, count=%d", got)
+	}
+	emit.FlushCoverageNotes()
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}

--- a/internal/adapters/gemini/coverage_note_test.go
+++ b/internal/adapters/gemini/coverage_note_test.go
@@ -1,0 +1,68 @@
+package gemini
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func swapNoteWarner(t *testing.T) *strings.Builder {
+	t.Helper()
+	buf := &strings.Builder{}
+	prev := emit.Warner
+	emit.Warner = buf
+	t.Cleanup(func() { emit.Warner = prev })
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+	return buf
+}
+
+func TestEmit_NotesSkillGapWhenOptInUnset(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	if err := New().Emit(kitSinkBundle(), &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	want := "3 skills reach gemini only via outputs.gemini.emit-skills-as-commands"
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("expected coverage note %q, got: %s", want, buf.String())
+	}
+}
+
+func TestEmit_NoSkillNoteWhenOptInSet(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"gemini": {EmitSkillsAsCommands: true},
+	}}
+	if err := New().Emit(kitSinkBundle(), cfg, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	if strings.Contains(buf.String(), "reach gemini") {
+		t.Errorf("opt-in set must suppress the skill note, got: %s", buf.String())
+	}
+}
+
+func TestEmit_NoSkillNoteWhenNoSkills(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindAgent, Name: "alpha", Path: "agents/alpha.md", Body: "x"},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if got := emit.PendingCoverageNotesCount(); got != 0 {
+		t.Errorf("no skill specs must buffer no note, count=%d", got)
+	}
+	emit.FlushCoverageNotes()
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -60,6 +60,9 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		if err := emitSkillCommands(b.Skills, commandsDir, dryRun); err != nil {
 			return err
 		}
+	} else {
+		emit.NoteCoverageGap(target, spec.KindSkill, len(b.Skills),
+			"outputs.gemini.emit-skills-as-commands")
 	}
 	if err := emit.EmitLegacyRulesFile(b, cfg, target, emit.MergedOpts{Title: "GEMINI.md"}, dryRun); err != nil {
 		return err

--- a/internal/adapters/internal/emit/coverage_notes.go
+++ b/internal/adapters/internal/emit/coverage_notes.go
@@ -1,0 +1,152 @@
+package emit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// Coverage notes surface "opt-in gaps": a spec kind an adapter declares
+// support for (so no "unsupported" warning fires) but does not emit by
+// default. The content only materializes behind an `outputs.<target>.*`
+// key, or stays source-dir only. Without a note these kinds are silently
+// skipped and the user has no signal that content did not reach a target.
+//
+// The store mirrors the capability-warning buffer: adapters call
+// NoteCoverageGap at their skip site, sync flushes once via
+// FlushCoverageNotes, and a digest feeds the same sticky-suppression as
+// the capability warnings so unchanged notes do not repeat across runs.
+
+type pendingNote struct {
+	target string
+	kind   spec.Kind
+	count  int
+	// via is the user-facing hint: the config key to set so the content
+	// reaches the target, or a phrase like "source-dir only" when there
+	// is no key.
+	via string
+}
+
+var coverageNoteState struct {
+	mu      sync.Mutex
+	pending []pendingNote
+}
+
+// NoteCoverageGap records that count specs of kind reach target only via
+// the hint `via` (a config key such as
+// `outputs.gemini.emit-skills-as-commands`, or a phrase like
+// "source-dir only"). No-op when count is zero so a note never fires for
+// an absent kind. Notes buffer until FlushCoverageNotes renders them.
+func NoteCoverageGap(target string, kind spec.Kind, count int, via string) {
+	if count <= 0 {
+		return
+	}
+	coverageNoteState.mu.Lock()
+	coverageNoteState.pending = append(coverageNoteState.pending, pendingNote{
+		target: target, kind: kind, count: count, via: via,
+	})
+	coverageNoteState.mu.Unlock()
+}
+
+// FlushCoverageNotes prints one line per (kind, count, via) group across
+// all buffered targets and clears the buffer. Targets that share the same
+// (kind, count, via) join on one line. Safe to call when empty.
+func FlushCoverageNotes() {
+	coverageNoteState.mu.Lock()
+	defer coverageNoteState.mu.Unlock()
+	if len(coverageNoteState.pending) == 0 {
+		return
+	}
+	type key struct {
+		kind  spec.Kind
+		count int
+		via   string
+	}
+	order := []key{}
+	groups := map[key][]string{}
+	seen := map[string]bool{} // target+kind+via dedup within one flush
+	for _, p := range coverageNoteState.pending {
+		dedupKey := p.target + "\x00" + string(p.kind) + "\x00" + p.via
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+		k := key{p.kind, p.count, p.via}
+		if _, ok := groups[k]; !ok {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], p.target)
+	}
+	for _, k := range order {
+		targets := groups[k]
+		// A config-key hint reads as "only via outputs.x.y"; a free-text
+		// reason (no materialize key) reads as "only in the source dir (reason)".
+		tail := "via " + k.via
+		if !strings.HasPrefix(k.via, "outputs.") {
+			tail = "in the source dir (" + k.via + ")"
+		}
+		_, _ = fmt.Fprintf(Warner, "  note: %d %s %s %s only %s\n",
+			k.count, pluralizeKind(k.kind, k.count), reachVerb(k.count),
+			strings.Join(targets, ", "), tail)
+	}
+	coverageNoteState.pending = nil
+}
+
+// reachVerb agrees the verb with the subject count: "reaches" for a
+// single spec, "reach" for many.
+func reachVerb(n int) string {
+	if n == 1 {
+		return "reaches"
+	}
+	return "reach"
+}
+
+// ResetCoverageNotes clears buffered notes without printing. Used by
+// tests and by `sync --watch` between runs.
+func ResetCoverageNotes() {
+	coverageNoteState.mu.Lock()
+	coverageNoteState.pending = nil
+	coverageNoteState.mu.Unlock()
+}
+
+// CoverageNotesDigest returns a stable hex digest of the buffered notes,
+// suitable for comparing across sync runs to suppress unchanged repeats.
+// Returns "" when no notes are pending.
+func CoverageNotesDigest() string {
+	coverageNoteState.mu.Lock()
+	defer coverageNoteState.mu.Unlock()
+	if len(coverageNoteState.pending) == 0 {
+		return ""
+	}
+	seen := map[string]bool{}
+	keys := make([]string, 0, len(coverageNoteState.pending))
+	for _, p := range coverageNoteState.pending {
+		k := fmt.Sprintf("%s\x00%s\x00%d\x00%s", p.target, p.kind, p.count, p.via)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	sum := sha256.Sum256([]byte(strings.Join(keys, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// PendingCoverageNotesCount returns how many distinct (target, kind, via)
+// notes are currently buffered. Used to size the suppression notice when
+// sticky-suppressing unchanged repeats.
+func PendingCoverageNotesCount() int {
+	coverageNoteState.mu.Lock()
+	defer coverageNoteState.mu.Unlock()
+	seen := map[string]bool{}
+	for _, p := range coverageNoteState.pending {
+		seen[p.target+"\x00"+string(p.kind)+"\x00"+p.via] = true
+	}
+	return len(seen)
+}

--- a/internal/adapters/internal/emit/coverage_notes_test.go
+++ b/internal/adapters/internal/emit/coverage_notes_test.go
@@ -1,0 +1,134 @@
+package emit
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+func swapWarnerForNotes(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := Warner
+	Warner = buf
+	t.Cleanup(func() { Warner = prev })
+	ResetCoverageNotes()
+	t.Cleanup(ResetCoverageNotes)
+	return buf
+}
+
+func TestNoteCoverageGap_FlushRendersOneLinePerGroup(t *testing.T) {
+	buf := swapWarnerForNotes(t)
+	NoteCoverageGap("gemini", spec.KindSkill, 2, "outputs.gemini.emit-skills-as-commands")
+	if buf.Len() != 0 {
+		t.Fatalf("notes must buffer until flush, got early output: %s", buf)
+	}
+	FlushCoverageNotes()
+	got := buf.String()
+	want := "  note: 2 skills reach gemini only via outputs.gemini.emit-skills-as-commands\n"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestNoteCoverageGap_ZeroCountBuffersNothing(t *testing.T) {
+	buf := swapWarnerForNotes(t)
+	NoteCoverageGap("gemini", spec.KindSkill, 0, "outputs.gemini.emit-skills-as-commands")
+	if got := PendingCoverageNotesCount(); got != 0 {
+		t.Fatalf("zero-count note must not buffer, count=%d", got)
+	}
+	FlushCoverageNotes()
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for zero-count note, got: %s", buf)
+	}
+}
+
+func TestNoteCoverageGap_GroupsSharedKindCountViaAcrossTargets(t *testing.T) {
+	buf := swapWarnerForNotes(t)
+	NoteCoverageGap("gemini", spec.KindSkill, 2, "outputs.x.emit-skills-as-commands")
+	NoteCoverageGap("opencode", spec.KindSkill, 2, "outputs.x.emit-skills-as-commands")
+	FlushCoverageNotes()
+	got := buf.String()
+	want := "  note: 2 skills reach gemini, opencode only via outputs.x.emit-skills-as-commands\n"
+	if got != want {
+		t.Errorf("expected grouped targets on one line, got %q", got)
+	}
+}
+
+// A free-text reason (no `outputs.` key) renders as a source-dir clause
+// instead of "via <reason>".
+func TestNoteCoverageGap_FreeTextReasonRendersAsSourceDir(t *testing.T) {
+	buf := swapWarnerForNotes(t)
+	NoteCoverageGap("warp", spec.KindSkill, 1, "no native skill surface")
+	FlushCoverageNotes()
+	want := "  note: 1 skill reaches warp only in the source dir (no native skill surface)\n"
+	if got := buf.String(); got != want {
+		t.Errorf("expected source-dir clause, got %q", got)
+	}
+}
+
+func TestNoteCoverageGap_PluralizesSingular(t *testing.T) {
+	buf := swapWarnerForNotes(t)
+	NoteCoverageGap("zed", spec.KindHook, 1, "outputs.zed.tasks-file")
+	FlushCoverageNotes()
+	if !strings.Contains(buf.String(), "1 hook reaches zed only via outputs.zed.tasks-file") {
+		t.Errorf("expected singular kind for n=1, got: %s", buf)
+	}
+}
+
+func TestNoteCoverageGap_DedupSameTargetKindViaWithinFlush(t *testing.T) {
+	buf := swapWarnerForNotes(t)
+	for i := 0; i < 3; i++ {
+		NoteCoverageGap("gemini", spec.KindSkill, 2, "outputs.gemini.emit-skills-as-commands")
+	}
+	FlushCoverageNotes()
+	if strings.Count(buf.String(), "reach gemini") != 1 {
+		t.Errorf("expected a single line for repeat notes, got: %s", buf)
+	}
+}
+
+func TestCoverageNotesDigest_StableAcrossOrder(t *testing.T) {
+	swapWarnerForNotes(t)
+	NoteCoverageGap("gemini", spec.KindSkill, 2, "outputs.gemini.emit-skills-as-commands")
+	NoteCoverageGap("opencode", spec.KindSkill, 2, "outputs.opencode.emit-skills-as-commands")
+	first := CoverageNotesDigest()
+	ResetCoverageNotes()
+	NoteCoverageGap("opencode", spec.KindSkill, 2, "outputs.opencode.emit-skills-as-commands")
+	NoteCoverageGap("gemini", spec.KindSkill, 2, "outputs.gemini.emit-skills-as-commands")
+	second := CoverageNotesDigest()
+	if first == "" || first != second {
+		t.Errorf("digest must be stable across input order, got %q vs %q", first, second)
+	}
+}
+
+func TestCoverageNotesDigest_EmptyWhenNoPending(t *testing.T) {
+	swapWarnerForNotes(t)
+	if got := CoverageNotesDigest(); got != "" {
+		t.Errorf("expected empty digest with no pending notes, got %q", got)
+	}
+}
+
+func TestCoverageNotesDigest_ChangesWithCount(t *testing.T) {
+	swapWarnerForNotes(t)
+	NoteCoverageGap("gemini", spec.KindSkill, 1, "outputs.gemini.emit-skills-as-commands")
+	one := CoverageNotesDigest()
+	ResetCoverageNotes()
+	NoteCoverageGap("gemini", spec.KindSkill, 2, "outputs.gemini.emit-skills-as-commands")
+	two := CoverageNotesDigest()
+	if one == two {
+		t.Errorf("digest must change when count changes, got identical %q", one)
+	}
+}
+
+func TestFlushCoverageNotes_ClearsBuffer(t *testing.T) {
+	buf := swapWarnerForNotes(t)
+	NoteCoverageGap("gemini", spec.KindSkill, 2, "outputs.gemini.emit-skills-as-commands")
+	FlushCoverageNotes()
+	first := buf.String()
+	FlushCoverageNotes()
+	if buf.String() != first {
+		t.Errorf("second flush should be a no-op, got extra output: %s", buf)
+	}
+}

--- a/internal/adapters/opencode/coverage_note_test.go
+++ b/internal/adapters/opencode/coverage_note_test.go
@@ -1,0 +1,68 @@
+package opencode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func swapNoteWarner(t *testing.T) *strings.Builder {
+	t.Helper()
+	buf := &strings.Builder{}
+	prev := emit.Warner
+	emit.Warner = buf
+	t.Cleanup(func() { emit.Warner = prev })
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+	return buf
+}
+
+func TestEmit_NotesSkillGapWhenOptInUnset(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	if err := New().Emit(kitSinkBundle(), &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	want := "skills reach opencode only via outputs.opencode.emit-skills-as-commands"
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("expected coverage note %q, got: %s", want, buf.String())
+	}
+}
+
+func TestEmit_NoSkillNoteWhenOptInSet(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"opencode": {EmitSkillsAsCommands: true},
+	}}
+	if err := New().Emit(kitSinkBundle(), cfg, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	if strings.Contains(buf.String(), "reach opencode") {
+		t.Errorf("opt-in set must suppress the skill note, got: %s", buf.String())
+	}
+}
+
+func TestEmit_NoSkillNoteWhenNoSkills(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindAgent, Name: "alpha", Path: "agents/alpha.md", Body: "x"},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if got := emit.PendingCoverageNotesCount(); got != 0 {
+		t.Errorf("no skill specs must buffer no note, count=%d", got)
+	}
+	emit.FlushCoverageNotes()
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}

--- a/internal/adapters/opencode/opencode.go
+++ b/internal/adapters/opencode/opencode.go
@@ -67,6 +67,9 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		if err := emitSkillCommands(b.Skills, commandsDir, dryRun); err != nil {
 			return err
 		}
+	} else {
+		emit.NoteCoverageGap(target, spec.KindSkill, len(b.Skills),
+			"outputs.opencode.emit-skills-as-commands")
 	}
 	if err := emit.EmitLegacyRulesFile(b, cfg, target, emit.MergedOpts{Title: "AGENTS.md"}, dryRun); err != nil {
 		return err

--- a/internal/adapters/warp/coverage_note_test.go
+++ b/internal/adapters/warp/coverage_note_test.go
@@ -1,0 +1,76 @@
+package warp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func swapNoteWarner(t *testing.T) *strings.Builder {
+	t.Helper()
+	buf := &strings.Builder{}
+	prev := emit.Warner
+	emit.Warner = buf
+	t.Cleanup(func() { emit.Warner = prev })
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+	return buf
+}
+
+func TestEmit_NotesAgentGapWhenWorkflowsDirUnset(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	if err := New().Emit(kitSinkBundle(), &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	out := buf.String()
+	if !strings.Contains(out, "agents reach warp only via outputs.warp.workflows-dir") {
+		t.Errorf("expected agent coverage note, got: %s", out)
+	}
+	if !strings.Contains(out, "skills reach warp only in the source dir (no native skill surface)") {
+		t.Errorf("expected skill source-dir-only note, got: %s", out)
+	}
+}
+
+func TestEmit_NoAgentNoteWhenWorkflowsDirSet(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"warp": {WorkflowsDir: ".warp/workflows"},
+	}}
+	if err := New().Emit(kitSinkBundle(), cfg, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	out := buf.String()
+	if strings.Contains(out, "agents reach warp") {
+		t.Errorf("workflows-dir set must suppress the agent note, got: %s", out)
+	}
+	// Skills still never reach warp; the source-dir-only note stays.
+	if !strings.Contains(out, "skills reach warp only in the source dir (no native skill surface)") {
+		t.Errorf("expected skill source-dir-only note even with workflows-dir set, got: %s", out)
+	}
+}
+
+func TestEmit_NoNotesWhenNoAgentsOrSkills(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindRule, Name: "r1", Path: "rules/r1.md", Body: "x"},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if got := emit.PendingCoverageNotesCount(); got != 0 {
+		t.Errorf("no agent/skill specs must buffer no note, count=%d", got)
+	}
+	emit.FlushCoverageNotes()
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}

--- a/internal/adapters/warp/warp.go
+++ b/internal/adapters/warp/warp.go
@@ -73,8 +73,13 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 // agent body becomes the workflow `command:`; description and tags are
 // pulled from frontmatter when present.
 func emitWorkflows(b spec.Bundle, cfg *config.Config, dryRun bool) error {
+	// Warp has no native skill surface: skills never reach it regardless of
+	// workflows-dir, so note the gap unconditionally.
+	emit.NoteCoverageGap(target, spec.KindSkill, len(b.Skills), "no native skill surface")
 	dir := emit.OutputWorkflowsDir(cfg, target, "")
 	if dir == "" {
+		emit.NoteCoverageGap(target, spec.KindAgent, len(b.Agents),
+			"outputs.warp.workflows-dir")
 		return nil
 	}
 	for _, a := range b.Agents {

--- a/internal/adapters/zed/coverage_note_test.go
+++ b/internal/adapters/zed/coverage_note_test.go
@@ -1,0 +1,67 @@
+package zed
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func swapNoteWarner(t *testing.T) *strings.Builder {
+	t.Helper()
+	buf := &strings.Builder{}
+	prev := emit.Warner
+	emit.Warner = buf
+	t.Cleanup(func() { emit.Warner = prev })
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+	return buf
+}
+
+func TestEmit_NotesHookGapWhenTasksFileUnset(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	if err := New().Emit(kitSinkBundle(), &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	if !strings.Contains(buf.String(), "hooks reach zed only via outputs.zed.tasks-file") {
+		t.Errorf("expected hook coverage note, got: %s", buf.String())
+	}
+}
+
+func TestEmit_NoHookNoteWhenTasksFileSet(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	cfg := &config.Config{Outputs: map[string]config.Output{
+		"zed": {TasksFile: ".zed/tasks.json"},
+	}}
+	if err := New().Emit(kitSinkBundle(), cfg, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	emit.FlushCoverageNotes()
+	if strings.Contains(buf.String(), "reach zed") {
+		t.Errorf("tasks-file set must suppress the hook note, got: %s", buf.String())
+	}
+}
+
+func TestEmit_NoHookNoteWhenNoHooks(t *testing.T) {
+	testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindRule, Name: "r1", Path: "rules/r1.md", Body: "x"},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if got := emit.PendingCoverageNotesCount(); got != 0 {
+		t.Errorf("no hook specs must buffer no note, count=%d", got)
+	}
+	emit.FlushCoverageNotes()
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}

--- a/internal/adapters/zed/zed.go
+++ b/internal/adapters/zed/zed.go
@@ -68,7 +68,11 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 // whose label is the hook's name; the description (when present)
 // prefixes the label so it shows up in the command palette.
 func emitTasks(hooks []spec.Entry, path string, dryRun bool) error {
-	if path == "" || len(hooks) == 0 {
+	if path == "" {
+		emit.NoteCoverageGap(target, spec.KindHook, len(hooks), "outputs.zed.tasks-file")
+		return nil
+	}
+	if len(hooks) == 0 {
 		return nil
 	}
 	tasks := make([]map[string]any, 0, len(hooks))

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -24,6 +24,10 @@ type syncStateFile struct {
 	SyncedAt       time.Time `json:"synced_at"`
 	FilesChanged   int       `json:"files_changed"`
 	WarningsDigest string    `json:"warnings_digest,omitempty"`
+	// NotesDigest fingerprints the coverage notes from the previous
+	// sync so the next run can sticky-suppress an unchanged set, the
+	// same way WarningsDigest gates capability warnings.
+	NotesDigest string `json:"notes_digest,omitempty"`
 	// Outputs lists every file path the previous sync wrote (create or
 	// update or skip), relative to the project root. The next sync uses
 	// it to detect orphans: any path present in the prior ledger but
@@ -49,7 +53,7 @@ func readStateFile(projectRoot string) syncStateFile {
 	return s
 }
 
-func writeStateFile(projectRoot string, filesChanged int, warningsDigest string, outputs []string) error {
+func writeStateFile(projectRoot string, filesChanged int, warningsDigest, notesDigest string, outputs []string) error {
 	p := stateFilePath(projectRoot)
 	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(p), err)
@@ -59,6 +63,7 @@ func writeStateFile(projectRoot string, filesChanged int, warningsDigest string,
 		SyncedAt:       time.Now().UTC(),
 		FilesChanged:   filesChanged,
 		WarningsDigest: warningsDigest,
+		NotesDigest:    notesDigest,
 		Outputs:        outputs,
 	})
 	if err != nil {
@@ -70,6 +75,7 @@ func writeStateFile(projectRoot string, filesChanged int, warningsDigest string,
 func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFlag string) (retErr error) {
 	start := time.Now()
 	adapters.ResetCapabilityWarnings()
+	adapters.ResetCoverageNotes()
 	cfg, b, err := loadProject(root)
 	if err != nil {
 		return err
@@ -177,6 +183,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		summaryf("→ updated .gitignore\n")
 	}
 	digest := adapters.CapabilityWarningsDigest()
+	notesDigest := adapters.CoverageNotesDigest()
 	prev := readStateFile(root)
 	if digest != "" && digest == prev.WarningsDigest {
 		n := adapters.PendingCapabilityWarningsCount()
@@ -185,6 +192,14 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		adapters.ResetCapabilityWarnings()
 	} else {
 		adapters.FlushCapabilityWarnings()
+	}
+	if notesDigest != "" && notesDigest == prev.NotesDigest {
+		n := adapters.PendingCoverageNotesCount()
+		summaryf("  (%d coverage note%s unchanged since last sync; delete %s to re-show)\n",
+			n, plural(n), stateFilePath(root))
+		adapters.ResetCoverageNotes()
+	} else {
+		adapters.FlushCoverageNotes()
 	}
 	ledger := finalizeLedger(ledgerSession)
 	ledger = reconcilePartialLedger(ledger, prev.Outputs, coversAllConfiguredTargets(effectiveTargets, cfg.Targets))
@@ -205,7 +220,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		}
 	}
 	if !dryRun {
-		if err := writeStateFile(root, filesChanged, digest, ledger); err != nil {
+		if err := writeStateFile(root, filesChanged, digest, notesDigest, ledger); err != nil {
 			fmt.Fprintf(os.Stderr, "! state file: %v\n", err)
 		}
 	}
@@ -258,7 +273,9 @@ func shortDuration(d time.Duration) string {
 // file written, updated, or skipped per target.
 func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
 	adapters.ResetCapabilityWarnings()
+	adapters.ResetCoverageNotes()
 	defer adapters.ResetCapabilityWarnings()
+	defer adapters.ResetCoverageNotes()
 	cfg, b, err := loadProject(root)
 	if err != nil {
 		return err
@@ -346,9 +363,10 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 		out.Writes = append(out.Writes, fileRecord{Target: "agnostic-ai", Path: p, Action: "delete"})
 	}
 	if !dryRun {
-		// JSON path does not print warnings, so preserve the previous
-		// digest so the next non-JSON run can still sticky-suppress.
-		if err := writeStateFile(root, len(out.Writes), prev.WarningsDigest, ledger); err != nil {
+		// JSON path does not print warnings or notes, so preserve the
+		// previous digests so the next non-JSON run can still
+		// sticky-suppress.
+		if err := writeStateFile(root, len(out.Writes), prev.WarningsDigest, prev.NotesDigest, ledger); err != nil {
 			fmt.Fprintf(os.Stderr, "! state file: %v\n", err)
 		}
 	}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -110,6 +110,7 @@ func watchSyncFsnotify(ctx context.Context, root string, targets []string, dryRu
 		case <-fire:
 			printWatchEvent(lastEvent)
 			adapters.ResetCapabilityWarnings()
+			adapters.ResetCoverageNotes()
 			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
 				fmt.Fprintf(os.Stderr, "! sync: %v\n", err)
 			}


### PR DESCRIPTION
## Problem

A target can declare support for a kind (so no `unsupported` warning) yet emit it only behind an `outputs.<target>.*` opt-in key, or not at all. Those specs were silently skipped: the user had no signal the content did not reach the target. Example: a skill spec with `gemini` in targets and `emit-skills-as-commands` unset.

## Fix

`sync` buffers a `note:` line per gap and flushes it after the capability warnings, reusing the same sticky cross-run suppression (digest in `.agnostic-ai/.sync-state`).

```
  note: 1 skill reaches gemini only via outputs.gemini.emit-skills-as-commands
  note: 1 agent reaches warp only via outputs.warp.workflows-dir
  note: 1 skill reaches warp only in the source dir (no native skill surface)
  note: 1 agent reaches aider only via outputs.aider.rules-file
  note: 1 skill reaches opencode only via outputs.opencode.emit-skills-as-commands
```

Instrumented gaps (the matrix `○` cells only, not additive extras like cursor commands-dir or copilot chatmodes-dir): gemini/opencode skills, warp agents+skills, aider agents+skills, zed hooks.

## Implementation

- New `internal/adapters/internal/emit/coverage_notes.go`: buffered store + `NoteCoverageGap` / `FlushCoverageNotes` / `CoverageNotesDigest` / `ResetCoverageNotes`, mirroring the capability-warning buffer.
- Adapters call `NoteCoverageGap` at their skip site.
- `sync_run.go`: `NotesDigest` added to sync-state; flush + sticky-suppress alongside warnings; JSON path preserves prior digest.
- Notes go to stderr only: no emitted file changes, golden snapshots untouched.

## Tests

- Per-adapter: note fires when opt-in unset + specs present; suppressed when set; none when no gap-kind specs.
- emit unit tests: grouping, dedup, pluralization, free-text vs config-key rendering, digest stability.
- `go test ./...`: green (1176 passed). vet + gofmt clean.

## Docs

`docs/user/configuration.md` (new Coverage notes section), `docs/user/targets.md` (legend pointer), `CHANGELOG.md` Added entry.

Closes #404