### PR TITLE
fix(explain): credit entry-point-inlined rule contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- `explain` and `why` now credit rule bodies inlined into entry-point files (`AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, ...). `explain <rule>` lists the codex/gemini/aider/amp/warp/opencode contributions it previously omitted, and `why AGENTS.md` traces the inlined rule specs instead of reporting "not tracked". (#405)
 - `copilot`: always-on rules (no `globs`) now emit as catch-all `applyTo:"**"` instruction files instead of being silently dropped; they reach Copilot by default without setting `outputs.copilot.rules-file`. (#403)
 
 ### Removed

--- a/docs/user/why.md
+++ b/docs/user/why.md
@@ -29,10 +29,14 @@ $ agnostic-ai why .cursor/rules/no-console-log.mdc
 
 | Field | Meaning |
 |-------|---------|
-| `adapter` | Target whose adapter wrote the file. |
+| `adapter` | Target whose adapter wrote the file. For a shared entry-point file (`AGENTS.md`), the first consuming target in registry order. |
 | `output keys` | Every `outputs.<target>.*` key whose value appears in the path. `(adapter defaults)` when no overrides match. |
 | `last sync` | UTC timestamp from `.agnostic-ai/.sync-state`. `unknown` when the state file is missing. |
 | `sources` | Every spec that contributes. Mode is `full` (spec owns the file) or `section` (one of many merged into a shared document). |
+
+## Entry-point files
+
+Targets with no native rules directory (codex, gemini, aider, amp, warp, opencode) inline rule bodies into their entry-point file (`AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, ...) under a sentinel `## Rules` block. That file is written by sync's entry-point distribution, not by an adapter, so `why` traces it specially: it lists every inlined rule spec as a `section` source and attributes the file to the first consuming target.
 
 ## Errors
 

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -184,9 +184,51 @@ func computeContributions(e spec.Entry, b spec.Bundle, cfg *config.Config) ([]co
 			}
 		}
 	}
+	// Rule bodies inlined into an entry-point file (AGENTS.md, GEMINI.md,
+	// CONVENTIONS.md, ...) are written by sync's entry-point distribution,
+	// not by any adapter's Emit, so the capture sweep above never sees
+	// them. Credit them explicitly.
+	if e.Kind == spec.KindRule && ruleReachesAppendix(b, e) {
+		for path, tgts := range inlinedRuleEntryPoints(cfg, adapters.Names()) {
+			for _, t := range tgts {
+				addContribution(&configured, &extra, configuredSet, contribution{
+					Target: t, Path: path, Section: e.Name, Mode: "section",
+				})
+			}
+		}
+	}
+
 	sortContribs(configured)
 	sortContribs(extra)
 	return configured, extra, nil
+}
+
+// ruleReachesAppendix reports whether removing e changes the inlined rules
+// appendix, i.e. the rule contributes a body to entry-point inliners. A
+// rule with neither globs nor scope always does; the diff guards against
+// a spec somehow absent from the bundle.
+func ruleReachesAppendix(b spec.Bundle, e spec.Entry) bool {
+	return adapters.RenderRulesAppendix(b) != adapters.RenderRulesAppendix(bundleWithout(b, e))
+}
+
+// inlinedRuleEntryPoints maps each entry-point path to the targets that
+// inline rule bodies into it (codex/gemini/aider/amp/warp/opencode). A
+// shared path like AGENTS.md lists every consumer. Targets on the legacy
+// rules-file layout are skipped: the adapter owns that write, so the
+// capture sweep already credits it.
+func inlinedRuleEntryPoints(cfg *config.Config, targets []string) map[string][]string {
+	out := map[string][]string{}
+	for _, t := range targets {
+		if !adapters.InlinesRulesIntoEntryPoint(t) || adapters.HasLegacyRulesFile(cfg, t) {
+			continue
+		}
+		p := adapters.EntryPointPath(cfg, t)
+		if p == "" || p == adapters.AgnosticEntryPointPath {
+			continue
+		}
+		out[p] = append(out[p], t)
+	}
+	return out
 }
 
 func addContribution(configured, extra *[]contribution, configuredSet map[string]struct{}, c contribution) {

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -254,3 +254,30 @@ You review code.
 		t.Errorf("expected claude per-agent file as full contribution: %s", got)
 	}
 }
+
+// A rule inlined into an entry-point file (codex AGENTS.md, gemini
+// GEMINI.md, ...) must be credited even though no adapter's Emit writes
+// that file: sync's entry-point distribution does.
+func TestExplain_RuleCreditsEntryPointInliners(t *testing.T) {
+	dir := setupExplainFixture(t) // targets: claude, codex
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"explain", "rules/no-console-log.md"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	// codex is configured and inlines the rule into AGENTS.md.
+	if !strings.Contains(got, `[codex] AGENTS.md (section "no-console-log")`) {
+		t.Errorf("expected codex AGENTS.md section contribution: %s", got)
+	}
+	// gemini is not configured but also inlines: it belongs under
+	// "would emit if enabled".
+	if !strings.Contains(got, `[gemini] GEMINI.md (section "no-console-log")`) {
+		t.Errorf("expected gemini GEMINI.md in would-emit-if-enabled: %s", got)
+	}
+}

--- a/internal/cli/why.go
+++ b/internal/cli/why.go
@@ -96,6 +96,13 @@ func traceFile(input string, cfg *config.Config, b spec.Bundle, projectRoot stri
 		return whyOutput{}, err
 	}
 	if target == "" {
+		// Entry-point files (AGENTS.md, GEMINI.md, CONVENTIONS.md, ...) are
+		// written by sync's entry-point distribution, not by any adapter,
+		// so findEmittingAdapter never matches them. Recognize the inlined
+		// rules appendix and credit each rule spec as a section source.
+		if report, ok := traceEntryPointFile(rel, cfg, b, projectRoot); ok {
+			return report, nil
+		}
 		return whyOutput{}, whyNotTrackedError(input, projectRoot)
 	}
 
@@ -118,6 +125,51 @@ func traceFile(input string, cfg *config.Config, b spec.Bundle, projectRoot stri
 		LastSync:   lastSyncTimestamp(projectRoot),
 	}
 	return out, nil
+}
+
+// traceEntryPointFile reports the rule specs inlined into an entry-point
+// file. Returns false when rel is not an entry-point that inlines rules.
+// A shared path (AGENTS.md) is attributed to its first consuming target
+// in registry order, listing every inlined rule as a section source.
+func traceEntryPointFile(rel string, cfg *config.Config, b spec.Bundle, projectRoot string) (whyOutput, bool) {
+	if len(b.Rules) == 0 {
+		return whyOutput{}, false
+	}
+	relSlash := filepath.ToSlash(rel)
+	byPath := inlinedRuleEntryPoints(cfg, cfg.Targets)
+	tgts, ok := byPath[rel]
+	if !ok {
+		// Fall back to a slash-normalized scan so Windows separators match.
+		for p, ts := range byPath {
+			if filepath.ToSlash(p) == relSlash {
+				tgts, ok = ts, true
+				break
+			}
+		}
+	}
+	if !ok || len(tgts) == 0 {
+		return whyOutput{}, false
+	}
+	sort.Strings(tgts)
+	sources := make([]whySource, 0, len(b.Rules))
+	for _, r := range b.Rules {
+		sources = append(sources, whySource{
+			Kind: string(r.Kind),
+			Name: r.Name,
+			Path: filepath.ToSlash(r.Path),
+			Mode: "section",
+		})
+	}
+	sort.SliceStable(sources, func(i, j int) bool { return sources[i].Name < sources[j].Name })
+	return whyOutput{
+		Version:    "1",
+		Command:    "why",
+		File:       relSlash,
+		Target:     tgts[0],
+		OutputKeys: nil,
+		Sources:    sources,
+		LastSync:   lastSyncTimestamp(projectRoot),
+	}, true
 }
 
 // normalizeInputPath returns the absolute path and the project-relative

--- a/internal/cli/why_test.go
+++ b/internal/cli/why_test.go
@@ -216,3 +216,47 @@ outputs:
 		t.Errorf("expected outputs.cursor.rules-dir in keys, got %v", got.OutputKeys)
 	}
 }
+
+// why on an entry-point file (AGENTS.md) credits the rule specs inlined
+// into it, even though no adapter's Emit writes that file.
+func TestWhy_EntryPointFileCreditsInlinedRules(t *testing.T) {
+	dir := setupWhyFixture(t)
+	cfg := `version: 1
+sources:
+  rules: rules
+targets:
+  - codex
+`
+	if err := os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"why", "AGENTS.md", "--format", "json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var got whyOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if got.Target != "codex" {
+		t.Errorf("expected codex as the entry-point consumer, got %q", got.Target)
+	}
+	names := map[string]bool{}
+	for _, s := range got.Sources {
+		names[s.Name] = true
+		if s.Mode != "section" {
+			t.Errorf("inlined rule must be a section source, got %q for %s", s.Mode, s.Name)
+		}
+	}
+	for _, want := range []string{"no-console-log", "other"} {
+		if !names[want] {
+			t.Errorf("expected inlined rule %q in sources, got %v", want, got.Sources)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`explain` and `why` build provenance by diffing each adapter's `Emit` output. But rule bodies inlined into entry-point files (`AGENTS.md`, `GEMINI.md`, `CONVENTIONS.md`, `.opencode/AGENTS.md`) are written by sync's entry-point distribution, not by any adapter. So both views were blind to them:

```
$ agnostic-ai explain rules/style.md
  [claude] ...  [cursor] ...  [copilot] ...
  # codex / gemini / aider / amp / warp / opencode MISSING

$ agnostic-ai why AGENTS.md
AGENTS.md: not synced or not tracked by any adapter
```

…yet `grep 'Use tabs' AGENTS.md` = 1. (Found while validating the README target matrix; original #405 asked to *add* `sync --explain`, but `explain` already exists, so the issue was repurposed to this real gap.)

## Fix

- `explain <rule>`: credit every entry-point inliner (codex/gemini/aider/amp/warp/opencode) as a `section` contribution at the entry-point path. Configured targets land in the main list; the rest under "would emit if enabled".
- `why <entry-point-file>`: recognize the inlined `## Rules` block, list each inlined rule spec as a `section` source, attribute the file to the first consuming target.
- Shared helper `inlinedRuleEntryPoints` maps entry-point path → consuming targets; legacy `rules-file` targets are excluded (the adapter owns that write, already captured).

## After

```
$ agnostic-ai explain .agnostic-ai/rules/style.md
  [aider] CONVENTIONS.md (section "style")
  [amp] AGENTS.md (section "style")
  [codex] AGENTS.md (section "style")
  [gemini] GEMINI.md (section "style")
  [opencode] .opencode/AGENTS.md (section "style")
  [warp] AGENTS.md (section "style")
  ... (claude/cursor/cline/continue/windsurf/zed as before)

$ agnostic-ai why AGENTS.md
  adapter: amp
  sources:
    [rule] style (.agnostic-ai/rules/style.md): section
```

## Tests
- `TestExplain_RuleCreditsEntryPointInliners`: codex AGENTS.md section + gemini GEMINI.md under would-emit.
- `TestWhy_EntryPointFileCreditsInlinedRules`: `why AGENTS.md` → codex, inlined rule specs as sections.
- `go test ./...`: green (1178). vet + gofmt clean.

## Docs
`docs/user/why.md` (new Entry-point files section + adapter-field note), `CHANGELOG.md` Fixed entry.

Closes #405