### PR TITLE
docs: add --cask to brew upgrade hint

### DIFF
--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -417,7 +417,7 @@ agnostic-ai upgrade --run     # exec the detected upgrade command
 
 Detection:
 
-- `*/Cellar/*`, `*/Caskroom/*`, `/opt/homebrew/*`, `/home/linuxbrew/.linuxbrew/*` → `brew update && brew upgrade Chemaclass/tap/agnostic-ai`
+- `*/Cellar/*`, `*/Caskroom/*`, `/opt/homebrew/*`, `/home/linuxbrew/.linuxbrew/*` → `brew update && brew upgrade --cask Chemaclass/tap/agnostic-ai`
 - `$GOBIN` or `$GOPATH/bin` (defaults to `$HOME/go/bin`) → `go install github.com/chemaclass/agnostic-ai/cmd/agnostic-ai@latest`
 - Anything else → manual download from the [releases page](https://github.com/Chemaclass/agnostic-ai/releases).
 


### PR DESCRIPTION
cli-reference upgrade hint omitted `--cask`. GoReleaser ships a Homebrew cask, so upgrade is `brew upgrade --cask Chemaclass/tap/agnostic-ai`. Now matches the runtime hint (`upgrade.go`) and README.