### PR TITLE
fix(import): walk nested .cursor/rules subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ## [Unreleased]
 
+### Fixed
+
+- `import cursor` now walks `.cursor/rules/**` recursively, preserving nested subdirectories, instead of importing only top-level `.mdc` files. (#411)
+
 ## v0.37.0 - 2026-06-14
 
 ### Added

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -105,9 +105,10 @@ Slug collisions across files are deduplicated (`style.md`, `style-2.md`). The wa
 | Source | Becomes |
 |--------|---------|
 | `.cursor/rules/<name>.mdc` | `<rules>/<name>.md` with frontmatter (`description`, `globs`, `alwaysApply`, plus any custom keys) preserved verbatim |
+| `.cursor/rules/<sub>/<name>.mdc` | `<rules>/<sub>/<name>.md`, nested subdirectories preserved |
 | (no `name:` in frontmatter) | `name:` injected from the filename |
 
-Round-trips cleanly: a later `sync` regenerates equivalent `.cursor/rules/*.mdc`.
+Reads `.cursor/rules/**` recursively, so nested rule directories are imported too. Round-trips cleanly: a later `sync` regenerates equivalent `.cursor/rules/*.mdc`.
 
 `import cline`, `import windsurf`, `import continue` read the matching rules directory (`.clinerules/`, `.windsurf/rules/`, `.continue/rules/`) and reclassify each file by filename prefix:
 

--- a/internal/cli/import_cursor.go
+++ b/internal/cli/import_cursor.go
@@ -30,39 +30,52 @@ func importFromCursor(root string, src config.Sources) error {
 	return nil
 }
 
-// importCursorRules translates each .cursor/rules/*.mdc into <dstDir>/<name>.md.
-// Frontmatter keys (description, globs, alwaysApply, plus any custom keys)
-// pass through verbatim; a name field derived from the filename is injected
-// when missing.
+// importCursorRules translates each .cursor/rules/**/*.mdc into a matching
+// <dstDir>/**/<name>.md, walking the tree so nested rule directories
+// (which Cursor reads recursively) are preserved. Frontmatter keys
+// (description, globs, alwaysApply, plus any custom keys) pass through
+// verbatim; a name field derived from the filename is injected when missing.
 func importCursorRules(root, dstDir string) (int, error) {
 	src := filepath.Join(root, ".cursor", "rules")
-	entries, err := os.ReadDir(src)
-	if errors.Is(err, fs.ErrNotExist) {
+	if _, err := os.Stat(src); errors.Is(err, fs.ErrNotExist) {
 		return 0, nil
-	}
-	if err != nil {
-		return 0, fmt.Errorf("read %s: %w", src, err)
+	} else if err != nil {
+		return 0, fmt.Errorf("%s: %w", src, err)
 	}
 
 	count := 0
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".mdc") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(src, e.Name()))
+	walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return count, fmt.Errorf("read %s: %w", e.Name(), err)
+			return fmt.Errorf("%s: %w", path, err)
 		}
-		name := strings.TrimSuffix(e.Name(), ".mdc")
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".mdc") {
+			return nil
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		name := strings.TrimSuffix(d.Name(), ".mdc")
 		translated, err := translateCursorRule(name, data)
 		if err != nil {
-			return count, fmt.Errorf("translate %s: %w", e.Name(), err)
+			return fmt.Errorf("translate %s: %w", rel, err)
 		}
-		dst := filepath.Join(dstDir, name+".md")
+		dst := filepath.Join(dstDir, strings.TrimSuffix(rel, ".mdc")+".md")
+		if err := importMkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("%s: %w", filepath.Dir(dst), err)
+		}
 		if err := importWriteFile(dst, translated, 0o644); err != nil {
-			return count, fmt.Errorf("write %s: %w", dst, err)
+			return fmt.Errorf("write %s: %w", dst, err)
 		}
 		count++
+		return nil
+	})
+	if walkErr != nil {
+		return count, walkErr
 	}
 	return count, nil
 }

--- a/internal/cli/import_cursor_test.go
+++ b/internal/cli/import_cursor_test.go
@@ -42,6 +42,38 @@ Use ` + "`feat:`" + `, ` + "`fix:`" + `, etc.
 	}
 }
 
+func TestImportFromCursor_WalksNestedSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "basics", "product.mdc"),
+		"---\ndescription: product basics\n---\n\nproduct body\n")
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "best-practices", "frontend.mdc"),
+		"---\ndescription: frontend practices\n---\n\nfrontend body\n")
+	writeFile(t, filepath.Join(dir, ".cursor", "rules", "top.mdc"),
+		"---\ndescription: top level\n---\n\ntop body\n")
+
+	if err := importFromCursor(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string][]string{
+		filepath.Join("rules", "basics", "product.md"):          {"name: product", "product body"},
+		filepath.Join("rules", "best-practices", "frontend.md"): {"name: frontend", "frontend body"},
+		filepath.Join("rules", "top.md"):                        {"name: top", "top body"},
+	}
+	for rel, wants := range cases {
+		out, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("missing %s: %v", rel, err)
+		}
+		got := string(out)
+		for _, want := range wants {
+			if !strings.Contains(got, want) {
+				t.Errorf("%s: expected %q, got:\n%s", rel, want, got)
+			}
+		}
+	}
+}
+
 func TestImportFromCursor_NoFrontmatter(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".cursor", "rules", "loose.mdc"), "Just plain body.\n")


### PR DESCRIPTION
## Summary

- `import cursor` now walks `.cursor/rules/**` recursively instead of scanning only the top level, so nested `.mdc` rule files are no longer silently dropped.
- Nested layout is preserved: `.cursor/rules/basics/product.mdc` imports to `rules/basics/product.md`.
- Final refactor pass: no changes (the walk is minimal and matches surrounding conventions).

## Test plan

- [x] go test ./...
- [x] New test `TestImportFromCursor_WalksNestedSubdirectories` covers nested + top-level rules
- [ ] agnostic-ai sync --check (not applicable; no specs/adapters touched)

