### PR TITLE
fix(ci): follow redirects when installing bashunit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Install bashunit
         run: |
-          curl -s https://bashunit.typeddevs.com/install.sh | bash -s -- /usr/local/bin
+          curl -sSL https://bashunit.typeddevs.com/install.sh | bash -s -- /usr/local/bin
 
       - name: Run release.sh tests
         run: bashunit scripts/release_test.sh


### PR DESCRIPTION
## Summary

- The bashunit install endpoint now returns `301 Moved Permanently`. `curl -s` without `-L` piped the redirect HTML into bash, failing the `Shell tests` job at setup on every PR.
- Add `-sSL` so curl follows the redirect and fetches the real script.

## Test plan

- [x] This PR's own `Shell tests` job exercises the fixed install step.