### PR TITLE
fix(emit): nest scoped specs under the rules directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Fixed
 
 - `import cursor` now walks `.cursor/rules/**` recursively, preserving nested subdirectories, instead of importing only top-level `.mdc` files. (#411)
+- Nested rule, agent, and skill specs now emit under the tool's rules directory (e.g. `.cursor/rules/backend/auth.mdc`, `.claude/rules/backend/auth.md`) instead of a stray `<scope>/.cursor/rules/` tree at the repo root. (#412)
 
 ## v0.37.0 - 2026-06-14
 

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -381,7 +381,7 @@ func writeRules(rules []spec.Entry, cfg *config.Config, dryRun bool) error {
 	}
 	rulesDir := emit.OutputRulesDir(cfg, target, defaultRulesDir)
 	for _, r := range rules {
-		path := filepath.Join(rulesDir, r.Name+".md")
+		path := filepath.Join(rulesDir, r.EffectiveScope(), r.Name+".md")
 		body := emit.WithHeader(emit.DocumentStyled(r.Meta, r.MetaKeys, r.MetaStyles, r.Body, target), emit.FormatMarkdown)
 		if err := emit.WriteFile(path, body, dryRun); err != nil {
 			return err

--- a/internal/adapters/claude/claude_test.go
+++ b/internal/adapters/claude/claude_test.go
@@ -337,6 +337,24 @@ func TestEmit_WritesRulesPerFile(t *testing.T) {
 	}
 }
 
+func TestEmit_NestedRuleScopePreservedUnderRulesDir(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindRule, Name: "auth", Scope: "backend/api", Body: "rule"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude/rules/backend/api/auth.md")); err != nil {
+		t.Errorf("expected nested rule under .claude/rules/backend/api: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude/rules/auth.md")); !os.IsNotExist(err) {
+		t.Errorf("expected no flattened rule file, err=%v", err)
+	}
+}
+
 func TestEmit_RuleWithoutMetaHasNoLeadingBlankLineOrSyntheticHeading(t *testing.T) {
 	dir := t.TempDir()
 	testutil.Chdir(t, dir)

--- a/internal/adapters/cline/cline_test.go
+++ b/internal/adapters/cline/cline_test.go
@@ -44,8 +44,11 @@ func TestEmit_NestedScopeRoutesUnderSubdir(t *testing.T) {
 	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "backend/api/.clinerules/auth.md")); err != nil {
-		t.Errorf("expected nested clinerules: %v", err)
+	if _, err := os.Stat(filepath.Join(dir, ".clinerules/backend/api/auth.md")); err != nil {
+		t.Errorf("expected nested clinerules under .clinerules/backend/api: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "backend/api/.clinerules/auth.md")); !os.IsNotExist(err) {
+		t.Errorf("expected no stray scope dir at repo root, err=%v", err)
 	}
 }
 

--- a/internal/adapters/cursor/cursor_test.go
+++ b/internal/adapters/cursor/cursor_test.go
@@ -68,8 +68,11 @@ func TestEmit_NestedScopeRoutesUnderSubdir(t *testing.T) {
 	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "backend/.cursor/rules/auth.mdc")); err != nil {
-		t.Errorf("expected nested file: %v", err)
+	if _, err := os.Stat(filepath.Join(dir, ".cursor/rules/backend/auth.mdc")); err != nil {
+		t.Errorf("expected nested file under .cursor/rules/backend: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "backend/.cursor/rules/auth.mdc")); !os.IsNotExist(err) {
+		t.Errorf("expected no stray scope dir at repo root, err=%v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".cursor/rules/auth.mdc")); !os.IsNotExist(err) {
 		t.Errorf("expected no root file when scope set, err=%v", err)

--- a/internal/adapters/internal/emit/rules_dir.go
+++ b/internal/adapters/internal/emit/rules_dir.go
@@ -38,10 +38,11 @@ type RulesDirOpts struct {
 // RulesDirectory writes one file per rule, agent, and skill into a directory.
 // Used by Cursor (with custom formatters), Cline, Windsurf, and Continue.
 //
-// Entries with a non-empty Scope are nested under that scope:
-// `<scope>/<Dir>/<name><Ext>`. Tools that load rules from `.cursor/rules/`,
-// `.clinerules/`, etc. at any nesting level pick up the scoped output
-// automatically; tools that only read at root will see the root entries.
+// Entries with a non-empty Scope nest under the rules directory:
+// `<Dir>/<scope>/<name><Ext>` (e.g. `.cursor/rules/backend/auth.mdc`).
+// Tools that load rules recursively from `.cursor/rules/`, `.clinerules/`,
+// etc. pick up the scoped output automatically, and the output stays inside
+// the tool directory instead of leaking a `<scope>/` tree at the repo root.
 func RulesDirectory(b spec.Bundle, opts RulesDirOpts, dryRun bool) error {
 	if opts.Ext == "" {
 		opts.Ext = ".md"
@@ -84,11 +85,13 @@ func RulesDirectory(b spec.Bundle, opts RulesDirOpts, dryRun bool) error {
 	return nil
 }
 
-// scopedDir returns `<scope>/<dir>` when the entry has a non-empty
-// EffectiveScope, otherwise `dir` unchanged.
+// scopedDir returns `<dir>/<scope>` when the entry has a non-empty
+// EffectiveScope, otherwise `dir` unchanged. The scope nests inside the
+// rules directory so output stays under the tool dir (e.g.
+// `.cursor/rules/backend`) rather than at the repo root.
 func scopedDir(dir string, e spec.Entry) string {
 	if s := e.EffectiveScope(); s != "" {
-		return filepath.Join(s, dir)
+		return filepath.Join(dir, s)
 	}
 	return dir
 }


### PR DESCRIPTION
## Summary

- Nested rule/agent/skill specs now emit under the tool's rules dir (`.cursor/rules/backend/auth.mdc`) instead of a stray `backend/.cursor/rules/auth.mdc` tree at the repo root. Fixes Cursor, Cline, Windsurf, and Continue via the shared `scopedDir` helper.
- The Claude adapter no longer flattens nested rules; it preserves the scope under `.claude/rules/<scope>/<name>.md`.
- The managed `.gitignore` consequently lists the real output paths, not the stray root dir.
- Final refactor pass: no changes (the fix is a path-join flip plus the Claude nesting).

## Test plan

- [x] go test ./...
- [x] agnostic-ai sync --check (no drift)
- [x] Updated cursor/cline scope tests to the corrected paths; added a Claude nested-rule test

Closes #412