### PR TITLE
fix(import): quote description frontmatter that needs YAML escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 - `import cursor` now walks `.cursor/rules/**` recursively, preserving nested subdirectories, instead of importing only top-level `.mdc` files. (#411)
 - Nested rule, agent, and skill specs now emit under the tool's rules directory (e.g. `.cursor/rules/backend/auth.mdc`, `.claude/rules/backend/auth.md`) instead of a stray `<scope>/.cursor/rules/` tree at the repo root. (#412)
+- `import` now quotes spec `description` frontmatter when the value carries a `: ` mapping indicator, quotes, or leading/trailing whitespace, so the imported spec passes `validate` instead of failing with a YAML mapping error. (#413)
 
 ## v0.37.0 - 2026-06-14
 

--- a/internal/cli/import_codex.go
+++ b/internal/cli/import_codex.go
@@ -414,7 +414,7 @@ func writeCodexRule(dstDir, name, description, globs, body string) error {
 	var fm strings.Builder
 	fm.WriteString("---\nname: " + name + "\n")
 	if description != "" {
-		fm.WriteString("description: " + description + "\n")
+		fm.WriteString(yamlFrontmatterLine("description", description))
 	}
 	if globs != "" {
 		fm.WriteString("globs: " + globs + "\n")

--- a/internal/cli/import_shared_md.go
+++ b/internal/cli/import_shared_md.go
@@ -241,7 +241,7 @@ func writeAgentMD(path, name, description string, tags []string, body string) er
 	var sb strings.Builder
 	sb.WriteString("---\nname: " + name + "\n")
 	if description != "" {
-		sb.WriteString("description: " + description + "\n")
+		sb.WriteString(yamlFrontmatterLine("description", description))
 	}
 	if len(tags) > 0 {
 		sb.WriteString("tags: [" + strings.Join(tags, ", ") + "]\n")

--- a/internal/cli/import_yaml_scalar.go
+++ b/internal/cli/import_yaml_scalar.go
@@ -22,18 +22,13 @@ func yamlFrontmatterLine(key, value string) string {
 // encodeYAMLScalar returns value as a YAML scalar, quoting or block-folding
 // only when the raw form would be ambiguous. The yaml encoder decides the
 // representation; we strip the document's trailing newline so the caller can
-// place it after a `key: ` prefix.
+// place it after a `key: ` prefix. Encoding a plain string never fails, so
+// the error is intentionally discarded.
 func encodeYAMLScalar(value string) string {
 	var b bytes.Buffer
 	enc := yaml.NewEncoder(&b)
 	enc.SetIndent(2)
-	if err := enc.Encode(value); err != nil {
-		// Encoding a plain string never fails; fall back to a
-		// double-quoted scalar so the line stays valid YAML.
-		escaped := strings.ReplaceAll(value, `\`, `\\`)
-		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
-		return `"` + escaped + `"`
-	}
+	_ = enc.Encode(value)
 	_ = enc.Close()
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/cli/import_yaml_scalar.go
+++ b/internal/cli/import_yaml_scalar.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yamlFrontmatterLine renders a `key: value` frontmatter line whose value
+// is YAML-safe. The value is encoded through yaml.v3 so scalars carrying a
+// `: ` mapping indicator, quotes, leading/trailing whitespace, or other
+// indicator characters come out quoted (or as a block scalar) instead of as
+// a bare scalar that the tool's own parser would reject (#413).
+//
+// The returned line ends in a newline. Plain values that need no quoting
+// pass through unchanged, so simple slugs stay readable.
+func yamlFrontmatterLine(key, value string) string {
+	return key + ": " + encodeYAMLScalar(value) + "\n"
+}
+
+// encodeYAMLScalar returns value as a YAML scalar, quoting or block-folding
+// only when the raw form would be ambiguous. The yaml encoder decides the
+// representation; we strip the document's trailing newline so the caller can
+// place it after a `key: ` prefix.
+func encodeYAMLScalar(value string) string {
+	var b bytes.Buffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	if err := enc.Encode(value); err != nil {
+		// Encoding a plain string never fails; fall back to a
+		// double-quoted scalar so the line stays valid YAML.
+		escaped := strings.ReplaceAll(value, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		return `"` + escaped + `"`
+	}
+	_ = enc.Close()
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/cli/import_yaml_scalar_test.go
+++ b/internal/cli/import_yaml_scalar_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// trickyDescriptions are values that break an unquoted YAML scalar: a
+// colon-space mapping indicator, embedded double quotes, and leading
+// whitespace. Each must round-trip through writeAgentMD / writeCodexRule
+// into a spec that the parser accepts (#413).
+var trickyDescriptions = []string{
+	`Re-explain the answer. Use when the user says "simpler" or "ELI5". Find the middle ground: keep it readable.`,
+	`key: value pair inside a description`,
+	`  leading and trailing spaces  `,
+	`has #hash and "quotes" and : colon`,
+}
+
+func TestWriteAgentMD_QuotesDescriptionSoSpecParses(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	for i, desc := range trickyDescriptions {
+		path := filepath.Join(dir, "agent.md")
+		if err := writeAgentMD(path, "example", desc, nil, "body"); err != nil {
+			t.Fatalf("case %d: writeAgentMD: %v", i, err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("case %d: read: %v", i, err)
+		}
+		entry, err := spec.ParseMarkdownBytes(spec.KindAgent, data)
+		if err != nil {
+			t.Fatalf("case %d: spec did not parse: %v\n--- file ---\n%s", i, err, data)
+		}
+		if got, _ := entry.Meta["description"].(string); got != desc {
+			t.Errorf("case %d: description round-trip mismatch\n got: %q\nwant: %q", i, got, desc)
+		}
+	}
+}
+
+func TestWriteCodexRule_QuotesDescriptionSoSpecParses(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	for i, desc := range trickyDescriptions {
+		sub := filepath.Join(dir, "rules", "case")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		name := "rule"
+		if err := writeCodexRule(sub, name, desc, "", "body"); err != nil {
+			t.Fatalf("case %d: writeCodexRule: %v", i, err)
+		}
+		data, err := os.ReadFile(filepath.Join(sub, name+".md"))
+		if err != nil {
+			t.Fatalf("case %d: read: %v", i, err)
+		}
+		entry, err := spec.ParseMarkdownBytes(spec.KindRule, data)
+		if err != nil {
+			t.Fatalf("case %d: spec did not parse: %v\n--- file ---\n%s", i, err, data)
+		}
+		if got, _ := entry.Meta["description"].(string); got != desc {
+			t.Errorf("case %d: description round-trip mismatch\n got: %q\nwant: %q", i, got, desc)
+		}
+		_ = os.RemoveAll(sub)
+	}
+}


### PR DESCRIPTION
## Summary

- `import` wrote a source `description` into spec frontmatter as a bare YAML scalar. Values with a `: ` mapping indicator, embedded quotes, or leading/trailing whitespace then broke the tool's own `validate`/`sync`, so the import → sync round-trip was not stable.
- New `yamlFrontmatterLine` helper encodes the value through yaml.v3, so it is quoted or block-folded only when needed (plain slugs stay unquoted).
- Wired into both raw-write sites: `writeAgentMD` (agents) and `writeCodexRule` (codex rules).
- Final refactor pass: dropped the unreachable encode-error branch in the helper.

## Test plan

- [x] go test ./... (1182 pass)
- [x] New round-trip tests feed colon-space / quote / whitespace descriptions through `writeAgentMD` and `writeCodexRule` and assert the result parses via `spec.ParseMarkdownBytes`
- [ ] agnostic-ai sync --check (not applicable; no specs/adapters touched)

Closes #413