### PR TITLE
feat(import): warn when a sibling entry-point holds uncaptured content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - Nested rule, agent, and skill specs now emit under the tool's rules directory (e.g. `.cursor/rules/backend/auth.mdc`, `.claude/rules/backend/auth.md`) instead of a stray `<scope>/.cursor/rules/` tree at the repo root. (#412)
 - `import` now quotes spec `description` frontmatter when the value carries a `: ` mapping indicator, quotes, or leading/trailing whitespace, so the imported spec passes `validate` instead of failing with a YAML mapping error. (#413)
 - The managed `.gitignore` block now ignores generated paths at the subdirectory level (`/.claude/rules/`) instead of the whole tool dir (`/.claude/`), so hand-authored siblings like `.claude/settings.json` or `.claude/hooks/` are no longer ignored. (#414)
+- `import` now warns when another target's root entry-point (e.g. a distinct `AGENTS.md` next to `CLAUDE.md`) holds unique hand-authored content that the next `sync` would overwrite, so the loss is no longer silent. (#415)
 
 ## v0.37.0 - 2026-06-14
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -56,6 +56,7 @@ agnostic-ai import continue       # .continue/rules/
 - Touches only spec files under `sources:`. Never modifies `targets:` or other config.
 - Re-running overwrites by filename. Run after `init`, in the same project root.
 - Multiple sources import in order. Each mirrors its target's top-level instructions file to `.agnostic-ai/AGNOSTIC_AI.md`; with multiple sources, the last argument wins.
+- When another target's entry-point exists with different hand-authored content (e.g. a distinct `AGENTS.md` alongside `CLAUDE.md`), import warns that it holds unique content the next `sync` would overwrite. Merge that content into `.agnostic-ai/AGNOSTIC_AI.md` before syncing to keep it.
 - `all` cannot combine with other sources. It auto-detects every CLI present in the project.
 - Valid sources: `claude`, `codex`, `cursor`, `aider`, `amp`, `warp`, `gemini`, `copilot`, `opencode`, `zed`, `antigravity`, `continue`, `cline`, `windsurf`, plus `all`.
 

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -174,6 +174,13 @@ func EntryPointPath(cfg *config.Config, target string) string {
 	return emit.EntryPointPath(cfg, target)
 }
 
+// ConventionalEntryPointPaths returns the distinct conventional root
+// entry-point files across every known target, sorted. Used by import to
+// detect a sibling entry-point that sync would overwrite.
+func ConventionalEntryPointPaths() []string {
+	return emit.ConventionalEntryPointPaths()
+}
+
 // HasLegacyRulesFile reports whether the user opted into the legacy
 // concatenated rules-file layout for target.
 func HasLegacyRulesFile(cfg *config.Config, target string) bool {

--- a/internal/adapters/internal/emit/entrypoint.go
+++ b/internal/adapters/internal/emit/entrypoint.go
@@ -1,6 +1,7 @@
 package emit
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -27,6 +28,25 @@ var entryPointPaths = map[string]string{
 	"copilot":     ".github/copilot-instructions.md",
 	"opencode":    ".opencode/AGENTS.md",
 	"antigravity": ".agent/AGENTS.md",
+}
+
+// ConventionalEntryPointPaths returns the distinct conventional root
+// entry-point files across every known target (CLAUDE.md, AGENTS.md,
+// GEMINI.md, ...), sorted for stable output. Output-path overrides are
+// ignored: the set drives import's detection of a hand-authored sibling
+// entry-point that sync would otherwise overwrite (#415).
+func ConventionalEntryPointPaths() []string {
+	seen := make(map[string]struct{}, len(entryPointPaths))
+	out := make([]string, 0, len(entryPointPaths))
+	for _, p := range entryPointPaths {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // EntryPointPath returns the project-relative entry-point file for

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -158,6 +158,7 @@ func mirrorMainFile(root, srcName string) (bool, error) {
 	if err := importWriteFile(dst, []byte(body), 0o644); err != nil {
 		return false, fmt.Errorf("write %s: %w", dst, err)
 	}
+	warnUncapturedEntryPoints(root, srcName, body)
 	return true, nil
 }
 

--- a/internal/cli/import_entrypoint_warn.go
+++ b/internal/cli/import_entrypoint_warn.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
+)
+
+// warnUncapturedEntryPoints prints a warning for every target root
+// entry-point file that exists in the project, is hand-authored (no
+// agnostic-ai header), and holds content different from the body just
+// captured into AGNOSTIC_AI.md from mirroredSrc.
+//
+// import mirrors a single source entry-point into the shared body. A
+// sibling entry-point with unique content (e.g. a project keeping both a
+// rich CLAUDE.md and a distinct AGENTS.md) would otherwise be overwritten
+// by the next sync with no notice, silently discarding real instructions
+// (#415). Surfacing it lets the user merge that content into
+// AGNOSTIC_AI.md before syncing.
+//
+// Generated siblings (carrying the agnostic-ai header) are skipped: sync
+// rewrites them with the same body, so nothing is lost.
+func warnUncapturedEntryPoints(root, mirroredSrc, capturedBody string) {
+	want := strings.TrimSpace(capturedBody)
+	for _, rel := range adapters.ConventionalEntryPointPaths() {
+		if rel == mirroredSrc {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			continue
+		}
+		if header.Has(string(data)) {
+			continue
+		}
+		body := strings.TrimSpace(adapters.StripGeneratedAppendices(string(data)))
+		if body == "" || body == want {
+			continue
+		}
+		summaryf("  ! %s has unique content not captured by this import — sync will overwrite it with the shared body. Merge it into %s first to keep it.\n",
+			rel, agnosticMainFile)
+	}
+}

--- a/internal/cli/import_entrypoint_warn_test.go
+++ b/internal/cli/import_entrypoint_warn_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// A project with a rich CLAUDE.md plus a distinct, hand-authored AGENTS.md
+// must not lose the AGENTS.md content silently: import mirrors CLAUDE.md
+// into the shared body and warns that AGENTS.md holds unique content sync
+// would overwrite (#415).
+func TestImportFromClaude_WarnsAboutDivergentSiblingEntryPoint(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	buf := captureSummary(t)
+
+	mustWrite(t, filepath.Join(dir, "CLAUDE.md"), "# Claude guide\n\nFull instructions.\n")
+	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n\nUnique codex-only notes.\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "AGENTS.md") || !strings.Contains(out, "unique content") {
+		t.Errorf("expected a warning naming AGENTS.md, got:\n%s", out)
+	}
+	// The captured body still comes from CLAUDE.md.
+	got := mustRead(t, filepath.Join(dir, agnosticMainFile))
+	if !strings.Contains(got, "Full instructions.") {
+		t.Errorf("AGNOSTIC_AI.md should hold the CLAUDE.md body, got:\n%s", got)
+	}
+}
+
+// When the sibling entry-point holds the same content as the mirrored
+// source (already in sync), no warning fires: sync would rewrite it with
+// an identical body, so nothing is lost.
+func TestImportFromClaude_NoWarnWhenSiblingMatches(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	buf := captureSummary(t)
+
+	body := "# Shared\n\nIdentical body.\n"
+	mustWrite(t, filepath.Join(dir, "CLAUDE.md"), body)
+	mustWrite(t, filepath.Join(dir, "AGENTS.md"), body)
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "unique content") {
+		t.Errorf("did not expect a divergence warning, got:\n%s", buf.String())
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary

- `import` mirrors a single source entry-point into `.agnostic-ai/AGNOSTIC_AI.md`. A project with a rich `CLAUDE.md` plus a separate, distinct `AGENTS.md` lost the unique `AGENTS.md` content on the next `sync`, which overwrote it with the shared body and only printed a generic hand-authored warning.
- After mirroring, import now scans every target's conventional root entry-point. When a hand-authored sibling holds content that differs from the captured body, it warns by name so the user can merge it into `AGNOSTIC_AI.md` before syncing. The loss is no longer silent.
- Generated siblings (carrying the agnostic-ai header) and siblings already matching the body are skipped, so the warning only fires on real divergence. The hook lives in the shared `mirrorMainFile`, so every importer benefits.

## Test plan

- [x] go test ./... (1185 pass)
- [x] New tests: warns on a divergent `AGENTS.md`, stays quiet when the sibling matches
- [ ] agnostic-ai sync --check (not applicable; only a new exported helper added, no emission change)

## Refactor pass

Re-reviewed the touched files. The warn helper is single-concern and the adapters facade matches the existing wrapper pattern; no duplication worth extracting (the sync-side `warnOnHandAuthoredEntryPoint` has a different message and does no body comparison). The mandatory refactor pass surfaced zero changes.

Closes #415