### PR TITLE
chore: enable model invocation for gh-issue and gh-issues skills

### DIFF
--- a/.agnostic-ai/skills/gh-issue/SKILL.md
+++ b/.agnostic-ai/skills/gh-issue/SKILL.md
@@ -2,7 +2,7 @@
 name: gh-issue
 description: Fetch a GitHub issue, create a branch, implement with TDD, and open a PR
 argument-hint: "[issue-number]"
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # GitHub Issue Workflow

--- a/.agnostic-ai/skills/gh-issues/SKILL.md
+++ b/.agnostic-ai/skills/gh-issues/SKILL.md
@@ -2,7 +2,7 @@
 name: gh-issues
 description: Walk over all open GitHub issues that are unassigned or assigned to the current user, and process each one via the gh-issue skill, sequentially.
 argument-hint: "[--limit N] [--label foo] [--dry-run]"
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: "Read, Bash(gh *), Bash(git *), Bash(go *), Bash(make *), Bash(./agnostic-ai *), Skill(gh-issue)"
 ---
 


### PR DESCRIPTION
## Summary

- The source specs `.agnostic-ai/skills/gh-issue` and `gh-issues` carried `disable-model-invocation: true` while their generated `.claude` copies were `false`, leaving the project in a source/generated drift state (`sync --check` failed).
- Flip the source to `false` and re-sync so the generated copies match. The two skills stay model-invocable and `sync --check` is clean.

## Test plan

- [x] agnostic-ai sync --check (clean)