### PR TITLE
fix(import): walk nested rule subdirectories for claude and copilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Fixed
 
 - `import cursor` now walks `.cursor/rules/**` recursively, preserving nested subdirectories, instead of importing only top-level `.mdc` files. (#411)
+- `import claude` and `import copilot` now walk their rule directories (`.claude/rules/**`, `.github/instructions/**`) recursively, preserving nested scope, so scoped rules emitted by sync round-trip back instead of being dropped. (#411)
 - Nested rule, agent, and skill specs now emit under the tool's rules directory (e.g. `.cursor/rules/backend/auth.mdc`, `.claude/rules/backend/auth.md`) instead of a stray `<scope>/.cursor/rules/` tree at the repo root. (#412)
 - `import` now quotes spec `description` frontmatter when the value carries a `: ` mapping indicator, quotes, or leading/trailing whitespace, so the imported spec passes `validate` instead of failing with a YAML mapping error. (#413)
 - The managed `.gitignore` block now ignores generated paths at the subdirectory level (`/.claude/rules/`) instead of the whole tool dir (`/.claude/`), so hand-authored siblings like `.claude/settings.json` or `.claude/hooks/` are no longer ignored. (#414)

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -64,7 +64,7 @@ agnostic-ai import continue       # .continue/rules/
 
 | Source | Becomes |
 |--------|---------|
-| `.claude/rules/*.md` (preferred) | `<rules>/<name>.md` (byte-identical copy) |
+| `.claude/rules/**/*.md` (preferred) | `<rules>/<sub>/<name>.md` (byte-identical copy, nested subdirectories preserved) |
 | `CLAUDE.md` (split on `## headings`) | `<rules>/<slug>.md` per section (only when `.claude/rules/` is absent) |
 | `CLAUDE.md` (no headings) | single `<rules>/<projectname>.md` (only when `.claude/rules/` is absent) |
 | `CLAUDE.md` (any form) | `.agnostic-ai/AGNOSTIC_AI.md` (byte-identical copy) |

--- a/internal/cli/import_claude.go
+++ b/internal/cli/import_claude.go
@@ -187,6 +187,37 @@ func copyMarkdownDir(srcDir, dstDir string) (int, error) {
 	return count, nil
 }
 
+// copyMarkdownTree copies every *.md file under srcDir into dstDir,
+// preserving the relative subdirectory path. Scoped rules now emit under
+// .claude/rules/<scope>/<name>.md, so a flat top-level copy would drop the
+// nested files; walking the tree round-trips them back into
+// <dstDir>/<scope>/<name>.md (#411, claude target). The agnostic-ai
+// provenance header is stripped per file. Caller ensures srcDir exists.
+func copyMarkdownTree(srcDir, dstDir string) (int, error) {
+	count := 0
+	err := filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("%s: %w", path, walkErr)
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if err := copyMarkdownFile(path, filepath.Join(dstDir, rel)); err != nil {
+			return err
+		}
+		count++
+		return nil
+	})
+	if err != nil {
+		return count, err
+	}
+	return count, nil
+}
+
 // copyMarkdownFile reads src, strips the agnostic-ai provenance header
 // when present, and writes the result to dst. Missing src is a no-op
 // so callers can probe optional paths without pre-checking existence.

--- a/internal/cli/import_claude_rules.go
+++ b/internal/cli/import_claude_rules.go
@@ -15,7 +15,7 @@ import (
 func importClaudeRules(root, dstDir string) (int, error) {
 	rulesDir := filepath.Join(root, claudeDir, "rules")
 	if dirExists(rulesDir) {
-		return copyMarkdownDir(rulesDir, dstDir)
+		return copyMarkdownTree(rulesDir, dstDir)
 	}
 	return sliceMainFileByH2(root, claudeMainFile, dstDir)
 }

--- a/internal/cli/import_copilot.go
+++ b/internal/cli/import_copilot.go
@@ -86,32 +86,34 @@ func importCopilotRules(root string, src config.Sources) (copilotCounts, error) 
 // `**` is dropped since it carries no scope.
 func importCopilotInstructions(src, root string, sources config.Sources) (copilotCounts, error) {
 	var c copilotCounts
-	entries, err := os.ReadDir(src)
-	if errors.Is(err, fs.ErrNotExist) {
-		return c, nil
-	}
-	if err != nil {
-		return c, fmt.Errorf("read %s: %w", src, err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), copilotInstructionSuffix) {
-			continue
-		}
-		full := filepath.Join(src, e.Name())
-		data, err := os.ReadFile(full)
+	walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return c, fmt.Errorf("read %s: %w", full, err)
+			return fmt.Errorf("%s: %w", path, err)
 		}
-		base := strings.TrimSuffix(e.Name(), copilotInstructionSuffix)
+		if d.IsDir() || !strings.HasSuffix(d.Name(), copilotInstructionSuffix) {
+			return nil
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		base := strings.TrimSuffix(d.Name(), copilotInstructionSuffix)
 		kind, name := classifyRulesDirFile(base + ".md")
 		dstDir := pickKindDir(kind, sources)
 		translated, err := translateCopilotInstruction(name, data)
 		if err != nil {
-			return c, fmt.Errorf("translate %s: %w", e.Name(), err)
+			return fmt.Errorf("translate %s: %w", rel, err)
 		}
-		out := filepath.Join(root, dstDir, name+".md")
+		out := filepath.Join(root, dstDir, scopeDir(rel), name+".md")
+		if err := importMkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return fmt.Errorf("%s: %w", filepath.Dir(out), err)
+		}
 		if err := importWriteFile(out, translated, 0o644); err != nil {
-			return c, fmt.Errorf("write %s: %w", out, err)
+			return fmt.Errorf("write %s: %w", out, err)
 		}
 		switch kind {
 		case "agents":
@@ -121,6 +123,13 @@ func importCopilotInstructions(src, root string, sources config.Sources) (copilo
 		default:
 			c.rules++
 		}
+		return nil
+	})
+	if errors.Is(walkErr, fs.ErrNotExist) {
+		return copilotCounts{}, nil
+	}
+	if walkErr != nil {
+		return c, walkErr
 	}
 	return c, nil
 }

--- a/internal/cli/import_nested_rules_test.go
+++ b/internal/cli/import_nested_rules_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// agnostic now emits scoped Claude rules under .claude/rules/<scope>/.
+// Importing them back must preserve the nesting instead of dropping the
+// subdirectory files (the #411 bug, for the claude target).
+func TestImportFromClaude_WalksNestedRuleSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	mustWrite(t, filepath.Join(dir, ".claude/rules/backend/api/auth.md"), "---\nname: auth\n---\n\nbackend rule\n")
+	mustWrite(t, filepath.Join(dir, ".claude/rules/top.md"), "---\nname: top\n---\n\ntop rule\n")
+
+	if err := importFromClaude(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules/backend/api/auth.md")); err != nil {
+		t.Errorf("nested rule not imported under rules/backend/api: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules/top.md")); err != nil {
+		t.Errorf("top-level rule missing: %v", err)
+	}
+}
+
+// Copilot emits scoped instructions under .github/instructions/<scope>/.
+// The importer must walk the tree and keep the scope, not flatten or drop
+// nested files.
+func TestImportFromCopilot_WalksNestedInstructionSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	mustWrite(t, filepath.Join(dir, ".github/instructions/backend/auth.instructions.md"), "---\nname: auth\n---\n\nbackend rule\n")
+	mustWrite(t, filepath.Join(dir, ".github/instructions/top.instructions.md"), "---\nname: top\n---\n\ntop rule\n")
+
+	if err := importFromCopilot(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules/backend/auth.md")); err != nil {
+		t.Errorf("nested instruction not imported under rules/backend: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rules/top.md")); err != nil {
+		t.Errorf("top-level instruction missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up generalizing #411 to the other targets whose adapters emit nested scoped rules.

- `sync` now emits scoped rules under `.claude/rules/<scope>/` and `.github/instructions/<scope>/` (after #412/#418), but `import claude` (`copyMarkdownDir`) and `import copilot` (`importCopilotInstructions`) read only the top level — so nested rules were silently dropped on round-trip.
- Both importers now walk their rule trees recursively and preserve the subdirectory as scope, matching the cursor importer. `import claude` keeps the byte-identical copy; `import copilot` keeps its `applyTo` → `globs` translation.

## Audit of the other recent fixes across targets

While here I checked whether #413/#414/#415 also needed generalizing:

- **#413** (description quoting): the other importers build frontmatter via `yaml.Marshal` / `yaml.NewEncoder` (codex-native, copilot, zed), which auto-quote; the only raw string-concat writers were already fixed. `globs:` is written raw but its value is always `<dir>/**` (never starts with `*`), so it is safe. No change needed.
- **#414** (gitignore subdir collapse): single shared, target-agnostic code path. Already general.
- **#415** (sibling entry-point warning): wired into the shared `mirrorMainFile`, used by every main-file importer. Already general.

Only #411 had a real gap (claude + copilot), fixed here.

## Test plan

- [x] go test ./... (1187 pass)
- [x] New tests: nested `.claude/rules/backend/api/auth.md` and `.github/instructions/backend/auth.instructions.md` import with scope preserved; top-level rules still imported
- [ ] agnostic-ai sync --check (not applicable; importer-only change)

## Refactor pass

The four rule-dir walkers (cursor, shared rules-dir, claude, copilot) each apply a different per-file transform, so they stay separate, matching the existing cursor/rules-dir pattern. Unifying them would be scope creep for a bug fix. The mandatory refactor pass surfaced zero changes.

Closes #411