### PR TITLE
feat(sync): resolve @-import lines per target with sync.resolve-imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Added
 
 - `outputs.claude.rules-mode: import` wires the emitted `.claude/rules/*.md` files into the `CLAUDE.md` pointer body via sentinel-marked `@`-imports, so Claude Code loads them without losing the pointer body. (#424)
+- `sync.resolve-imports` (`passthrough` | `strip` | `inline`) controls how `@path` file-import lines in the shared entry-point body reach targets that cannot resolve them, instead of always copying dead reference lines verbatim. (#425)
 
 ### Changed
 

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -392,6 +392,9 @@
         },
         "target-overview": {
           "type": "boolean"
+        },
+        "resolve-imports": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -289,6 +289,22 @@ sync:
 
 The canonical body stays identical across every target; only the appendix differs per file. An entry-point shared by several targets (codex, amp, and warp all read `AGENTS.md`) lists each consumer in its own section. The appendix sits between `<!-- agnostic-ai:target-overview:start -->` and `<!-- agnostic-ai:target-overview:end -->` markers; `import` strips it, so the `AGNOSTIC_AI.md` round-trip stays lossless. `.agnostic-ai/AGNOSTIC_AI.md` itself never carries the appendix. Do not hand-edit the block: every sync regenerates it.
 
+### `sync.resolve-imports`
+
+Controls how `@path` file-import lines in the shared entry-point body (`AGNOSTIC_AI.md`) reach targets whose CLI does not resolve them. Claude resolves `@`-imports natively, so `CLAUDE.md` always keeps them verbatim. Every other target (codex and the rest reading `AGENTS.md`, `GEMINI.md`, ...) would otherwise carry a dead reference line.
+
+```yaml
+# In agnostic-ai.yaml
+sync:
+  resolve-imports: inline   # passthrough (default) | strip | inline
+```
+
+- `passthrough` (default): copy the `@`-line verbatim. The non-resolving target carries a dead reference, but nothing is dropped. Backward-compatible.
+- `strip`: drop the `@`-line for non-resolving targets so the file is not littered with unfollowable references.
+- `inline`: replace the `@`-line with the referenced file's content for non-resolving targets, wrapped between `<!-- agnostic-ai:import:start <path> -->` and `<!-- agnostic-ai:import:end -->`. `import` restores the lone `@`-line, so the `AGNOSTIC_AI.md` round-trip stays lossless. A missing or unreadable referenced file fails the sync.
+
+Only a line that is a lone `@path` token is treated as an import; an `@mention` inside a sentence is left untouched. Paths resolve relative to the project root.
+
 Targets whose artifacts all flow through the entry-point pointer (aider) get no appendix. External adapters (`agnostic-ai-adapter-<name>` binaries) have no native-artifacts protocol yet, so their section is absent from the appendix.
 
 ## `import`

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -303,6 +303,19 @@ func StripGeneratedAppendices(body string) string {
 	return emit.StripGeneratedAppendices(body)
 }
 
+// SupportsFileImports reports whether target's CLI resolves `@path`
+// file-import lines in its entry-point file (re-exported from the emit
+// layer).
+func SupportsFileImports(target string) bool {
+	return emit.SupportsFileImports(target)
+}
+
+// ApplyImportMode rewrites `@path` file-import lines in body per mode for
+// a target that cannot resolve them (re-exported from the emit layer).
+func ApplyImportMode(body, mode string) (string, error) {
+	return emit.ApplyImportMode(body, mode)
+}
+
 // Adapter is the contract every target implementation satisfies.
 type Adapter interface {
 	// Name returns the target identifier used in config and CLI flags.

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -297,8 +297,9 @@ func AppendRulesAppendix(body, appendix string) string {
 	return emit.AppendRulesAppendix(body, appendix)
 }
 
-// StripGeneratedAppendices removes every sentinel-marked block sync may
-// append to an entry-point file (re-exported from the emit layer).
+// StripGeneratedAppendices reverses every sentinel-marked edit sync may
+// make to an entry-point file, leaving the canonical body (re-exported
+// from the emit layer).
 func StripGeneratedAppendices(body string) string {
 	return emit.StripGeneratedAppendices(body)
 }

--- a/internal/adapters/internal/emit/imports.go
+++ b/internal/adapters/internal/emit/imports.go
@@ -1,0 +1,107 @@
+package emit
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// File-import resolution modes for the shared entry-point body. They
+// govern how `@path` lines reach targets that cannot follow them. See
+// config.SyncConfig.ResolveImports.
+const (
+	ImportModePassthrough = "passthrough"
+	ImportModeStrip       = "strip"
+	ImportModeInline      = "inline"
+)
+
+// fileImportTargets names targets whose CLI resolves `@path` file-import
+// lines in its entry-point file. They always receive the body verbatim;
+// the resolve-imports modes apply only to the rest.
+var fileImportTargets = map[string]bool{
+	"claude": true,
+}
+
+// SupportsFileImports reports whether target's CLI resolves `@path`
+// file-import lines in its entry-point file.
+func SupportsFileImports(target string) bool {
+	return fileImportTargets[target]
+}
+
+// importLineRe matches a line that is a lone `@path` file-import token:
+// optional surrounding whitespace, a leading `@`, then a single non-space
+// path. Prose `@mentions` embedded in a sentence never match because the
+// whole line must be the token.
+var importLineRe = regexp.MustCompile(`^[ \t]*@(\S+)[ \t]*$`)
+
+// Sentinel markers wrapping a resolved import in inline mode. The start
+// marker carries the original `@path` so import can rebuild the lone
+// `@path` line, keeping the AGNOSTIC_AI.md round-trip lossless.
+const (
+	importInlineStartFmt = "<!-- agnostic-ai:import:start %s -->"
+	importInlineEnd      = "<!-- agnostic-ai:import:end -->"
+)
+
+// importInlineBlockRe matches a sentinel-wrapped resolved import, capturing
+// the original path from the start marker.
+var importInlineBlockRe = regexp.MustCompile(`(?s)<!-- agnostic-ai:import:start (\S+) -->\n.*?\n<!-- agnostic-ai:import:end -->`)
+
+// ApplyImportMode rewrites lone `@path` file-import lines in body per mode
+// for a target that cannot resolve them. passthrough (and any unknown
+// mode) returns body unchanged. strip drops the lines. inline replaces
+// each with the referenced file's content wrapped in a sentinel block
+// that import restores to the original `@path` line.
+func ApplyImportMode(body, mode string) (string, error) {
+	switch mode {
+	case ImportModeStrip:
+		return stripImportLines(body), nil
+	case ImportModeInline:
+		return inlineImportLines(body)
+	default:
+		return body, nil
+	}
+}
+
+// stripImportLines drops every lone `@path` import line from body.
+func stripImportLines(body string) string {
+	lines := strings.Split(body, "\n")
+	out := lines[:0]
+	for _, ln := range lines {
+		if importLineRe.MatchString(ln) {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.Join(out, "\n")
+}
+
+// inlineImportLines replaces each lone `@path` import line with the
+// referenced file's content, wrapped in sentinel markers. A missing or
+// unreadable file is a hard error: the user opted into inlining, so a
+// dangling reference must surface rather than ship silently.
+func inlineImportLines(body string) (string, error) {
+	lines := strings.Split(body, "\n")
+	for i, ln := range lines {
+		m := importLineRe.FindStringSubmatch(ln)
+		if m == nil {
+			continue
+		}
+		path := m[1]
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", path, err)
+		}
+		content := strings.TrimRight(string(data), "\n")
+		lines[i] = fmt.Sprintf(importInlineStartFmt, path) + "\n" + content + "\n" + importInlineEnd
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+// RestoreImportInlines rewrites every sentinel-wrapped resolved import
+// back to its lone `@path` line, so an entry-point emitted in inline mode
+// round-trips to the canonical body on import. Returns body unchanged
+// when it carries no inline blocks.
+func RestoreImportInlines(body string) string {
+	return importInlineBlockRe.ReplaceAllString(body, "@$1")
+}

--- a/internal/adapters/internal/emit/imports.go
+++ b/internal/adapters/internal/emit/imports.go
@@ -98,10 +98,10 @@ func inlineImportLines(body string) (string, error) {
 	return strings.Join(lines, "\n"), nil
 }
 
-// RestoreImportInlines rewrites every sentinel-wrapped resolved import
+// restoreImportInlines rewrites every sentinel-wrapped resolved import
 // back to its lone `@path` line, so an entry-point emitted in inline mode
 // round-trips to the canonical body on import. Returns body unchanged
 // when it carries no inline blocks.
-func RestoreImportInlines(body string) string {
+func restoreImportInlines(body string) string {
 	return importInlineBlockRe.ReplaceAllString(body, "@$1")
 }

--- a/internal/adapters/internal/emit/imports_test.go
+++ b/internal/adapters/internal/emit/imports_test.go
@@ -1,0 +1,117 @@
+package emit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func TestSupportsFileImports(t *testing.T) {
+	if !SupportsFileImports("claude") {
+		t.Error("claude resolves @-imports and should report support")
+	}
+	for _, tgt := range []string{"codex", "amp", "warp", "gemini", "aider", "opencode"} {
+		if SupportsFileImports(tgt) {
+			t.Errorf("%s does not resolve @-imports and must not report support", tgt)
+		}
+	}
+}
+
+func TestApplyImportMode_PassthroughLeavesBodyUnchanged(t *testing.T) {
+	body := "# Project\n\n@docs/architecture.md\n@docs/errors.md\n"
+	for _, mode := range []string{ImportModePassthrough, "", "bogus"} {
+		got, err := ApplyImportMode(body, mode)
+		if err != nil {
+			t.Fatalf("mode %q: unexpected error: %v", mode, err)
+		}
+		if got != body {
+			t.Errorf("mode %q changed body:\n%s", mode, got)
+		}
+	}
+}
+
+func TestApplyImportMode_StripDropsImportLines(t *testing.T) {
+	body := "# Project\n\nGuidance.\n\n@docs/architecture.md\n@docs/errors.md\n"
+	got, err := ApplyImportMode(body, ImportModeStrip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "@docs/") {
+		t.Errorf("strip left an import line:\n%s", got)
+	}
+	if !strings.Contains(got, "Guidance.") {
+		t.Errorf("strip dropped prose:\n%s", got)
+	}
+}
+
+func TestApplyImportMode_StripKeepsEmailLikeProse(t *testing.T) {
+	// A lone @token is an import; an @mention inside a sentence is not.
+	body := "Ping @alice for review.\n@docs/architecture.md\n"
+	got, err := ApplyImportMode(body, ImportModeStrip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "Ping @alice for review.") {
+		t.Errorf("strip removed prose @mention:\n%s", got)
+	}
+	if strings.Contains(got, "@docs/architecture.md") {
+		t.Errorf("strip left the import line:\n%s", got)
+	}
+}
+
+func TestApplyImportMode_InlineEmbedsFileContent(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	mustWrite(t, filepath.Join(dir, "docs", "architecture.md"), "# Architecture\n\nLayered.\n")
+
+	body := "# Project\n\n@docs/architecture.md\n"
+	got, err := ApplyImportMode(body, ImportModeInline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Layered.", "agnostic-ai:import:start docs/architecture.md", "agnostic-ai:import:end"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("inline missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "@docs/architecture.md\n") {
+		t.Errorf("inline left the raw import line:\n%s", got)
+	}
+}
+
+func TestApplyImportMode_InlineErrorsOnMissingFile(t *testing.T) {
+	testutil.TempCwd(t)
+	_, err := ApplyImportMode("@docs/missing.md\n", ImportModeInline)
+	if err == nil {
+		t.Fatal("want error for missing import target")
+	}
+	if !strings.Contains(err.Error(), "docs/missing.md") {
+		t.Errorf("error should name the path, got: %v", err)
+	}
+}
+
+func TestRestoreImportInlines_RoundTripsInlineMode(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	mustWrite(t, filepath.Join(dir, "docs", "architecture.md"), "# Architecture\n\nLayered.\n")
+
+	body := "# Project\n\n@docs/architecture.md\n\nMore.\n"
+	inlined, err := ApplyImportMode(body, ImportModeInline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := RestoreImportInlines(inlined); got != body {
+		t.Errorf("round-trip mismatch.\nwant %q\ngot  %q", body, got)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/adapters/internal/emit/imports_test.go
+++ b/internal/adapters/internal/emit/imports_test.go
@@ -101,7 +101,7 @@ func TestRestoreImportInlines_RoundTripsInlineMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := RestoreImportInlines(inlined); got != body {
+	if got := restoreImportInlines(inlined); got != body {
 		t.Errorf("round-trip mismatch.\nwant %q\ngot  %q", body, got)
 	}
 }

--- a/internal/adapters/internal/emit/rules_appendix.go
+++ b/internal/adapters/internal/emit/rules_appendix.go
@@ -61,12 +61,14 @@ func StripRulesAppendix(body string) string {
 	return stripMarkedBlock(body, RulesStartMarker, RulesEndMarker)
 }
 
-// StripGeneratedAppendices removes every sentinel-marked block sync may
-// append to an entry-point file (rules + target-overview), leaving the
-// canonical pointer body. Import uses it so the AGNOSTIC_AI.md round-trip
-// stays lossless regardless of which appendixes a target carried.
+// StripGeneratedAppendices reverses every sentinel-marked edit sync may
+// make to an entry-point file, leaving the canonical pointer body. It
+// removes the rules and target-overview appendices and restores resolved
+// `@`-imports (inline mode) to their lone `@path` lines. Import uses it
+// so the AGNOSTIC_AI.md round-trip stays lossless regardless of which
+// transforms a target carried.
 func StripGeneratedAppendices(body string) string {
-	return StripRulesAppendix(StripTargetOverview(body))
+	return RestoreImportInlines(StripRulesAppendix(StripTargetOverview(body)))
 }
 
 // inlineRulesTargets are the entry-point targets whose underlying CLI has

--- a/internal/adapters/internal/emit/rules_appendix.go
+++ b/internal/adapters/internal/emit/rules_appendix.go
@@ -68,7 +68,7 @@ func StripRulesAppendix(body string) string {
 // so the AGNOSTIC_AI.md round-trip stays lossless regardless of which
 // transforms a target carried.
 func StripGeneratedAppendices(body string) string {
-	return RestoreImportInlines(StripRulesAppendix(StripTargetOverview(body)))
+	return restoreImportInlines(StripRulesAppendix(StripTargetOverview(body)))
 }
 
 // inlineRulesTargets are the entry-point targets whose underlying CLI has

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -101,7 +101,11 @@ func collectEntryPointDrift(cfg *config.Config, b spec.Bundle, targets []string)
 		return rep, fmt.Errorf("%s: %w", adapters.AgnosticEntryPointPath, err)
 	}
 
-	for _, f := range renderEntryPointFiles(cfg, b, targets, body) {
+	files, err := renderEntryPointFiles(cfg, b, targets, body)
+	if err != nil {
+		return rep, err
+	}
+	for _, f := range files {
 		disk, err := os.ReadFile(f.Path)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -35,7 +35,11 @@ func writeAgnosticEntryPoints(cfg *config.Config, b spec.Bundle, targets []strin
 	if err != nil {
 		return err
 	}
-	for _, f := range renderEntryPointFiles(cfg, b, targets, body) {
+	files, err := renderEntryPointFiles(cfg, b, targets, body)
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
 		warnOnHandAuthoredEntryPoint(f.Path)
 		if err := adapters.WriteFile(f.Path, f.Content, dryRun); err != nil {
 			return fmt.Errorf("write entry-point %s: %w", f.Path, err)
@@ -68,7 +72,7 @@ type entryPointFile struct {
 // only always-on context surface. The block is identical across the
 // consumers of a shared path (rules are global), so the deduplicated
 // write stays collision-free.
-func renderEntryPointFiles(cfg *config.Config, b spec.Bundle, targets []string, body string) []entryPointFile {
+func renderEntryPointFiles(cfg *config.Config, b spec.Bundle, targets []string, body string) ([]entryPointFile, error) {
 	body = adapters.StripGeneratedAppendices(body)
 	rulesAppendix := adapters.RenderRulesAppendix(b)
 	var order []string
@@ -90,6 +94,13 @@ func renderEntryPointFiles(cfg *config.Config, b spec.Bundle, targets []string, 
 	files := make([]entryPointFile, 0, len(order))
 	for _, path := range order {
 		content := body
+		if !pathSupportsFileImports(consumers[path]) {
+			resolved, err := adapters.ApplyImportMode(content, cfg.Sync.ResolveImports)
+			if err != nil {
+				return nil, fmt.Errorf("resolve imports for %s: %w", path, err)
+			}
+			content = resolved
+		}
 		if pathInlinesRules(consumers[path]) {
 			content = adapters.AppendRulesAppendix(content, rulesAppendix)
 		} else if importer := pathRulesImporter(cfg, consumers[path]); importer != "" {
@@ -110,7 +121,7 @@ func renderEntryPointFiles(cfg *config.Config, b spec.Bundle, targets []string, 
 			Content: header.With(content, header.FormatMarkdown),
 		})
 	}
-	return files
+	return files, nil
 }
 
 // pathInlinesRules reports whether any target consuming an entry-point
@@ -123,6 +134,20 @@ func pathInlinesRules(consumers []string) bool {
 		}
 	}
 	return false
+}
+
+// pathSupportsFileImports reports whether every target consuming an
+// entry-point path resolves `@path` file-imports natively. When false,
+// sync applies the resolve-imports mode so non-resolving targets do not
+// carry dead reference lines. Claude's CLAUDE.md has a single resolving
+// consumer; shared paths (AGENTS.md) have none.
+func pathSupportsFileImports(consumers []string) bool {
+	for _, t := range consumers {
+		if !adapters.SupportsFileImports(t) {
+			return false
+		}
+	}
+	return true
 }
 
 // pathRulesImporter returns the first consumer of an entry-point path

--- a/internal/cli/entrypoint_test.go
+++ b/internal/cli/entrypoint_test.go
@@ -205,6 +205,68 @@ func TestWriteAgnosticEntryPoints_DefaultClaudeOmitsRulesBlock(t *testing.T) {
 	}
 }
 
+func TestWriteAgnosticEntryPoints_StripImportsForNonResolvingTargets(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	writeAgnosticFile(t, "# Project\n\nGuidance.\n\n@docs/architecture.md\n")
+	cfg := &config.Config{
+		Targets: []string{"claude", "codex"},
+		Sync:    config.SyncConfig{ResolveImports: "strip"},
+	}
+
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	claudeBody := readFile(t, filepath.Join(dir, "CLAUDE.md"))
+	if !strings.Contains(claudeBody, "@docs/architecture.md") {
+		t.Errorf("claude resolves imports; CLAUDE.md must keep the @-line:\n%s", claudeBody)
+	}
+	codexBody := readFile(t, filepath.Join(dir, "AGENTS.md"))
+	if strings.Contains(codexBody, "@docs/architecture.md") {
+		t.Errorf("codex cannot resolve imports; AGENTS.md should drop the @-line:\n%s", codexBody)
+	}
+}
+
+func TestWriteAgnosticEntryPoints_InlineImportsForNonResolvingTargets(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	if err := os.MkdirAll(filepath.Join(dir, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docs", "architecture.md"), []byte("Layered design.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAgnosticFile(t, "# Project\n\n@docs/architecture.md\n")
+	cfg := &config.Config{
+		Targets: []string{"claude", "codex"},
+		Sync:    config.SyncConfig{ResolveImports: "inline"},
+	}
+
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if claudeBody := readFile(t, filepath.Join(dir, "CLAUDE.md")); !strings.Contains(claudeBody, "@docs/architecture.md") {
+		t.Errorf("CLAUDE.md must keep the @-line for native resolution:\n%s", claudeBody)
+	}
+	codexBody := readFile(t, filepath.Join(dir, "AGENTS.md"))
+	if !strings.Contains(codexBody, "Layered design.") {
+		t.Errorf("AGENTS.md should inline the referenced content:\n%s", codexBody)
+	}
+}
+
+func TestWriteAgnosticEntryPoints_DefaultPassesImportsThrough(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	writeAgnosticFile(t, "# Project\n\n@docs/architecture.md\n")
+	cfg := &config.Config{Targets: []string{"codex"}}
+
+	if err := writeAgnosticEntryPoints(cfg, spec.Bundle{}, cfg.Targets, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body := readFile(t, filepath.Join(dir, "AGENTS.md")); !strings.Contains(body, "@docs/architecture.md") {
+		t.Errorf("default mode must pass @-lines through verbatim:\n%s", body)
+	}
+}
+
 func writeAgnosticFile(t *testing.T, content string) {
 	t.Helper()
 	if err := os.MkdirAll(".agnostic-ai", 0o755); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,15 @@ type SyncConfig struct {
 	// is stripped on `import` so the AGNOSTIC_AI.md round-trip stays
 	// lossless. AGNOSTIC_AI.md itself never carries the appendix.
 	TargetOverview bool `yaml:"target-overview,omitempty" json:"target-overview,omitempty"`
+	// ResolveImports controls how `@path` file-import lines in the shared
+	// entry-point body reach targets whose CLI does not resolve them
+	// (every target except claude). Accepted values:
+	//   passthrough (default) copy the @-line verbatim; the target carries a dead reference
+	//   strip       drop the @-line so the file is not littered with unfollowable references
+	//   inline      replace the @-line with the referenced file's content, wrapped in a
+	//               sentinel block that `import` restores to the original @-line
+	// Targets that resolve imports natively (claude) always pass through.
+	ResolveImports string `yaml:"resolve-imports,omitempty" json:"resolve-imports,omitempty"`
 }
 
 // ProvenanceHeaderEnabled returns whether the named target should write


### PR DESCRIPTION
## Summary

- `@path` file-import lines in the shared `AGNOSTIC_AI.md` body were copied verbatim to every target. Only Claude resolves them, so codex and the rest carried dead reference lines and never received the referenced content.
- New `sync.resolve-imports` knob controls the behavior for non-resolving targets:
  - `passthrough` (default): keep the `@`-line verbatim. Backward-compatible, no drift.
  - `strip`: drop the `@`-line so the file is not littered with unfollowable references.
  - `inline`: embed the referenced file's content, wrapped in `<!-- agnostic-ai:import:start <path> -->` / `:end` sentinels that `import` restores to the original `@`-line (lossless round-trip).
- Claude's `CLAUDE.md` always passes through; it resolves `@`-imports natively. Only a lone `@path` line is treated as an import; `@mentions` in prose are left untouched.

## Implementation

- `internal/config`: new `SyncConfig.ResolveImports` field (`resolve-imports`).
- `internal/adapters/internal/emit/imports.go`: `SupportsFileImports`, `ApplyImportMode` (strip/inline/passthrough), sentinel restore folded into `StripGeneratedAppendices` so `import` round-trips.
- `internal/cli`: `renderEntryPointFiles` applies the mode per entry-point path for targets that cannot resolve imports; error threads through `sync` and `check`.
- Docs (`configuration.md`), `config.schema.json` (regenerated), CHANGELOG.

## Refactor pass

Reviewed every touched file. Unexported `restoreImportInlines` (used only inside `StripGeneratedAppendices`) and corrected the stale "removes blocks" doc comment. No other changes surfaced.

## Test plan

- [x] go test ./...
- [x] agnostic-ai sync --check (no drift, passthrough default)
- [x] gofmt + go vet clean

Closes #425