### PR TITLE
feat(release): prune empty Unreleased subsections before promoting

### DIFF
--- a/.agnostic-ai/agents/release-cutter.md
+++ b/.agnostic-ai/agents/release-cutter.md
@@ -12,7 +12,7 @@ Steps:
 1. Confirm the working tree is clean and on `main`. Pull the latest.
 2. Run `make preflight` (fmt-check + vet + lint + test). Refuse to proceed on any failure.
 3. Decide the next version per semver. Patch for fixes, minor for additive features, major for breaking changes.
-4. Move every line under `## [Unreleased]` in `CHANGELOG.md` into a new dated `## vX.Y.Z - YYYY-MM-DD` section (no brackets). Reset `## [Unreleased]` to empty `Added`/`Changed`/`Fixed`/`Removed` subsections.
+4. Drop empty `### ` subsections from `## [Unreleased]` in `CHANGELOG.md`, then move the remaining lines into a new dated `## vX.Y.Z - YYYY-MM-DD` section (no brackets). The released section must never carry a `### ` heading with no entries. Reset `## [Unreleased]` to empty.
 5. Bump `version` in `cmd/agnostic-ai/main.go`.
 6. Commit `chore(release): vX.Y.Z`, GPG-signed.
 7. Tag with `git tag -s vX.Y.Z -m "vX.Y.Z"` so GoReleaser picks it up.

--- a/.agnostic-ai/skills/cut-release/SKILL.md
+++ b/.agnostic-ai/skills/cut-release/SKILL.md
@@ -19,7 +19,7 @@ The user asks to release, tag, ship, or cut a new version.
    - patch: bug fixes only
    - minor: additive features
    - major: breaking changes
-4. Update `CHANGELOG.md`: move every line under `## [Unreleased]` into a new dated `## vX.Y.Z - YYYY-MM-DD` section (no brackets). Reset `## [Unreleased]` to empty `Added` / `Changed` / `Fixed` / `Removed` subsections.
+4. Update `CHANGELOG.md`: drop empty `### ` subsections from `## [Unreleased]`, then move the remaining lines into a new dated `## vX.Y.Z - YYYY-MM-DD` section (no brackets). The released section must never carry a `### ` heading with no entries. Reset `## [Unreleased]` to empty.
 5. Bump `version` in `cmd/agnostic-ai/main.go`.
 6. Commit: `chore(release): vX.Y.Z`. GPG-signed.
 7. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Changed
 
+- `scripts/release.sh` drops empty `### ` subsections from `[Unreleased]` before promoting it, so a release never ships scaffolding headings with no entries.
+
 ### Fixed
 
 ### Removed

--- a/docs/internal/release-process.md
+++ b/docs/internal/release-process.md
@@ -17,7 +17,7 @@ The script:
 1. Validates: clean tree, on `main`, in sync with `origin/main`, tag absent.
 2. Runs `gofmt -s -l`, `go vet`, `go test ./...`, `agnostic-ai sync --check`.
 3. Bumps `version` in `cmd/agnostic-ai/main.go`.
-4. Promotes `[Unreleased]` to `## vX.Y.Z - YYYY-MM-DD` (no brackets), inserts a fresh empty `[Unreleased]` block.
+4. Drops empty `### ` subsections from `[Unreleased]`, then promotes it to `## vX.Y.Z - YYYY-MM-DD` (no brackets) and inserts a fresh empty `[Unreleased]` block.
 5. Commits `chore(release): vX.Y.Z`, creates annotated tag `vX.Y.Z`.
 6. Pushes `main` + tag. CI runs GoReleaser; release notes come from `scripts/release-notes.sh` against the matching `CHANGELOG.md` section.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,8 +15,9 @@
 #   1. Validate inputs and git state (clean tree, on main, in sync with origin).
 #   2. Run go vet, gofmt -s -l, go test ./..., agnostic-ai sync (drift gate).
 #   3. Bump `version` in cmd/agnostic-ai/main.go.
-#   4. Promote [Unreleased] in CHANGELOG.md to [vX.Y.Z] with today's date and
-#      insert a fresh [Unreleased] block above.
+#   4. Drop empty `### ` subsections from [Unreleased], then promote it in
+#      CHANGELOG.md to [vX.Y.Z] with today's date and insert a fresh
+#      [Unreleased] block above.
 #   5. Commit `chore(release): vX.Y.Z`.
 #   6. Create annotated tag vX.Y.Z.
 #   7. Push main and tag atomically. CI fires GoReleaser, which builds
@@ -101,6 +102,33 @@ unreleased_has_content() {
     }
     END { exit has ? 0 : 1 }
   ' "$file"
+}
+
+# prune_empty_unreleased_sections <CHANGELOG path> — drops every
+# `### Heading` subsection inside `## [Unreleased]` that carries no entry,
+# so a release never ships scaffolding headings (`### Changed` with
+# nothing under it). Subsections with at least one non-blank line survive
+# untouched, blank spacing and all. A no-op when every subsection has
+# content.
+prune_empty_unreleased_sections() {
+  local file="$1" tmp="$1.tmp"
+  trap 'rm -f "${tmp:-}"' RETURN
+  awk '
+    function flush() {
+      if (pending != "" && have) printf "%s", pending
+      pending=""; have=0
+    }
+    /^## \[Unreleased\]/ { in_unrel=1; print; next }
+    in_unrel && /^## /   { flush(); in_unrel=0; print; next }
+    in_unrel && /^### /  { flush(); pending=$0 "\n"; next }
+    in_unrel && pending != "" {
+      pending = pending $0 "\n"
+      if ($0 !~ /^[[:space:]]*$/) have=1
+      next
+    }
+    { print }
+    END { flush() }
+  ' "$file" > "$tmp" && mv "$tmp" "$file"
 }
 
 # promote_changelog <CHANGELOG path> <vX.Y.Z> <YYYY-MM-DD> — promotes the
@@ -231,6 +259,8 @@ main() {
   note "bump: $current -> $plain"
   if [[ $DRY_RUN -eq 0 ]]; then
     bump_version_in_file "$main_file" "$plain"
+    note "changelog: prune empty [Unreleased] subsections"
+    prune_empty_unreleased_sections "$changelog"
     note "changelog: promote [Unreleased] -> [$VERSION] $date"
     promote_changelog "$changelog" "$VERSION" "$date"
   else

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -152,6 +152,93 @@ function test_promote_changelog_errors_without_unreleased() {
   rm -f "$tmp"
 }
 
+# ---- prune_empty_unreleased_sections ----------------------------------------
+
+function test_prune_drops_empty_subsections_keeps_populated() {
+  local tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- a new thing
+
+### Changed
+
+### Fixed
+- a fix
+
+### Removed
+
+## v0.1.0 - 2026-01-01
+
+### Changed
+- old change
+EOF
+  prune_empty_unreleased_sections "$tmp"
+  local out
+  out="$(cat "$tmp")"
+  assert_contains "### Added" "$out"
+  assert_contains "- a new thing" "$out"
+  assert_contains "### Fixed" "$out"
+  assert_contains "- a fix" "$out"
+  assert_not_contains "### Changed"$'\n\n'"### " "$out"
+  assert_not_contains "### Removed" "$out"
+  # Released sections below are untouched.
+  assert_contains "- old change" "$out"
+  rm -f "$tmp"
+}
+
+function test_prune_is_noop_when_all_populated() {
+  local tmp before after
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- one
+
+### Fixed
+- two
+
+## v0.1.0 - 2026-01-01
+EOF
+  before="$(cat "$tmp")"
+  prune_empty_unreleased_sections "$tmp"
+  after="$(cat "$tmp")"
+  assert_equals "$before" "$after"
+  rm -f "$tmp"
+}
+
+function test_prune_preserves_released_empty_subsections() {
+  local tmp
+  tmp="$(mktemp)"
+  cat > "$tmp" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Removed
+
+## v0.1.0 - 2026-01-01
+
+### Removed
+EOF
+  prune_empty_unreleased_sections "$tmp"
+  local out
+  out="$(cat "$tmp")"
+  # The Unreleased empty section is gone; the released one stays.
+  local removed_count
+  removed_count="$(grep -c '^### Removed$' "$tmp")"
+  assert_equals 1 "$removed_count"
+  assert_contains "## v0.1.0 - 2026-01-01" "$out"
+  rm -f "$tmp"
+}
+
 # ---- unreleased_has_content --------------------------------------------------
 
 function test_unreleased_has_content_detects_bullet() {


### PR DESCRIPTION
## Summary

- `scripts/release.sh` now drops empty `### ` subsections from `## [Unreleased]` before promoting it to the dated release section. A `### ` heading with at least one entry is kept verbatim (spacing and all); a heading with no content is removed.
- Stops releases from shipping scaffolding headings (`### Changed` with nothing under it) when a cycle only touched some categories.
- Wired into `main` between the version bump and `promote_changelog`. No effect on the released body when every subsection already has content.

## Behavior

```
## [Unreleased]        ## [Unreleased]
### Added              ### Added
- real entry     -->   - real entry
### Changed            ### Fixed
### Fixed              - a fix
- a fix
### Removed
```

Empty `Changed` / `Removed` gone; populated `Added` / `Fixed` kept.

## Also updated

- `cut-release` skill and `release-cutter` agent specs (step 4) to describe the prune. Per-target copies regenerated via `agnostic-ai sync`.
- `docs/internal/release-process.md`.

## Test plan

- [x] bashunit scripts/release_test.sh (39 passed) — 3 new prune tests: drops empty, no-op when all populated, leaves released sections untouched
- [x] agnostic-ai sync --check (no drift)