### PR TITLE
fix(cursor): note bundled skill payloads Cursor cannot emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 - `import` strips the agnostic-ai provenance header when seeding `.agnostic-ai/AGNOSTIC_AI.md` from a generated entry-point (CLAUDE.md, AGENTS.md, ...), so the source you edit no longer gains a "Do not edit" banner and the import->sync round-trip stays byte-stable. (#429)
 - `import cursor` drops the catch-all `globs: "**/*"` and empty `description` the cursor adapter emits by default, so an always-apply rule round-trips to a stable source instead of flipping its `globs` representation each cycle. (#429)
+- `sync` warns when a skill bundles sibling files (scripts, assets) the Cursor target cannot represent, since Cursor flattens each skill to a single `.mdc` rule. The payloads were dropped silently before. (#430)
 
 ## v0.39.0 - 2026-06-16
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -152,6 +152,7 @@ Verify with the real CLI:
 
 - Rules emit with `alwaysApply: true`; agents as rules with `alwaysApply: false`. Override in spec frontmatter.
 - When `outputs.cursor.commands-dir` is set, each agent also emits as a [Cursor Custom Command](https://docs.cursor.com/agent/custom-commands): Markdown with optional `description` and `model` frontmatter. The rule-form emission still happens.
+- Skills flatten to a single `.mdc` rule, so a skill that bundles sibling files (scripts, assets) cannot carry them to Cursor. `sync` prints a note for each such skill instead of dropping the payloads silently. (#430)
 
 Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.cursor.commands-dir` (default empty, opt-in), `outputs.cursor.mcp-file` (default `.cursor/mcp.json`).
 

--- a/internal/adapters/cursor/coverage_note_test.go
+++ b/internal/adapters/cursor/coverage_note_test.go
@@ -1,0 +1,85 @@
+package cursor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+func swapNoteWarner(t *testing.T) *strings.Builder {
+	t.Helper()
+	buf := &strings.Builder{}
+	prev := emit.Warner
+	emit.Warner = buf
+	t.Cleanup(func() { emit.Warner = prev })
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+	return buf
+}
+
+// A skill that bundles a non-markdown payload cannot be represented in
+// Cursor's flat .mdc rule, so the payload is dropped. The user must be
+// told instead of losing the files silently (#430).
+func TestEmit_NotesGapWhenSkillBundlesAssets(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+
+	skillDir := filepath.Join(dir, "skills", "alpha")
+	if err := os.MkdirAll(filepath.Join(skillDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "scripts", "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindSkill, Name: "alpha", Path: filepath.Join(skillDir, "SKILL.md"), Body: "body"},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	emit.FlushCoverageNotes()
+	want := "1 skill reaches cursor only in the source dir"
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("expected coverage note %q, got: %s", want, buf.String())
+	}
+}
+
+// A skill with no sibling payload loses nothing on Cursor, so no note fires.
+func TestEmit_NoGapWhenSkillHasNoAssets(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	buf := swapNoteWarner(t)
+
+	skillDir := filepath.Join(dir, "skills", "alpha")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindSkill, Name: "alpha", Path: filepath.Join(skillDir, "SKILL.md"), Body: "body"},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	if got := emit.PendingCoverageNotesCount(); got != 0 {
+		t.Errorf("skill without assets must buffer no note, count=%d", got)
+	}
+	emit.FlushCoverageNotes()
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}

--- a/internal/adapters/cursor/cursor.go
+++ b/internal/adapters/cursor/cursor.go
@@ -52,6 +52,7 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	}, dryRun); err != nil {
 		return err
 	}
+	noteDroppedSkillAssets(b)
 	if commandsDir := emit.OutputCommandsDir(cfg, target, ""); commandsDir != "" {
 		for _, a := range b.Agents {
 			path := commandsDir + "/" + a.Name + ".md"
@@ -82,6 +83,20 @@ func command(e spec.Entry) string {
 	b.WriteString("---\n\n")
 	b.WriteString(e.Body)
 	return b.String()
+}
+
+// noteDroppedSkillAssets surfaces a coverage note for every folder-based
+// skill that bundles sibling files. Cursor flattens each skill to a single
+// `.cursor/rules/skill-<name>.mdc`, so attached scripts and assets have no
+// native home and would otherwise vanish without a trace (#430).
+func noteDroppedSkillAssets(b spec.Bundle) {
+	n := 0
+	for _, s := range b.Skills {
+		if emit.SkillHasBundledAssets(s, emit.SkipSKILLMd) {
+			n++
+		}
+	}
+	emit.NoteCoverageGap(target, spec.KindSkill, n, "Cursor flattens skills to .mdc; bundled files are not emitted")
 }
 
 func mdc(e spec.Entry, alwaysApplyDefault bool) string {

--- a/internal/adapters/internal/emit/skill_assets.go
+++ b/internal/adapters/internal/emit/skill_assets.go
@@ -1,6 +1,7 @@
 package emit
 
 import (
+	"io/fs"
 	"path/filepath"
 
 	"github.com/chemaclass/agnostic-ai/internal/spec"
@@ -30,6 +31,37 @@ func PropagateSkillAssets(s spec.Entry, dstDir string, skip func(rel string) boo
 // re-rendered SKILL.md and copies everything else verbatim. Adapters that
 // need extra exclusions (e.g. codex-only assets) pass their own predicate.
 func SkipSKILLMd(rel string) bool { return rel == "SKILL.md" }
+
+// SkillHasBundledAssets reports whether a folder-based skill carries
+// sibling files beyond the ones the adapter re-renders itself (those
+// matched by skip, typically SKILL.md). Flat-file skills and in-memory
+// specs (empty Path) never have bundled assets.
+//
+// Adapters that flatten a skill to a single file (e.g. Cursor emits one
+// `.mdc` rule per skill) cannot represent attached payloads, so they call
+// this to surface a coverage note instead of dropping the files silently.
+func SkillHasBundledAssets(s spec.Entry, skip func(rel string) bool) bool {
+	if !FolderBasedSkill(s) {
+		return false
+	}
+	root := filepath.Dir(s.Path)
+	found := false
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		if skip != nil && skip(filepath.ToSlash(rel)) {
+			return nil
+		}
+		found = true
+		return filepath.SkipAll
+	})
+	return found
+}
 
 // FolderBasedSkill reports whether the skill spec owns its own directory
 // (`<name>/SKILL.md`) rather than living as a flat file (`<name>.md`).

--- a/internal/adapters/internal/emit/skill_assets_test.go
+++ b/internal/adapters/internal/emit/skill_assets_test.go
@@ -84,3 +84,45 @@ func TestPropagateSkillAssets_FolderCopiesSiblings(t *testing.T) {
 }
 
 func skipNothing(string) bool { return false }
+
+func TestSkillHasBundledAssets(t *testing.T) {
+	dir := t.TempDir()
+
+	withAssets := filepath.Join(dir, "skills", "alpha")
+	if err := os.MkdirAll(filepath.Join(withAssets, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(withAssets, "SKILL.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(withAssets, "scripts", "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lone := filepath.Join(dir, "skills", "beta")
+	if err := os.MkdirAll(lone, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(lone, "SKILL.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"folder skill with sibling asset", filepath.Join(withAssets, "SKILL.md"), true},
+		{"folder skill with only SKILL.md", filepath.Join(lone, "SKILL.md"), false},
+		{"flat-file skill", filepath.Join(dir, "skills", "beta.md"), false},
+		{"in-memory spec", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := spec.Entry{Kind: spec.KindSkill, Name: "x", Path: tc.path}
+			if got := SkillHasBundledAssets(s, SkipSKILLMd); got != tc.want {
+				t.Errorf("SkillHasBundledAssets = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Cursor flattens each skill to a single `.cursor/rules/skill-<name>.mdc` rule, so a skill bundling sibling files (scripts, assets) lost them with no signal.
- `sync` now prints a coverage note per affected skill instead of dropping the payloads silently.
- Adds `emit.SkillHasBundledAssets` helper to detect folder-based skills carrying non-SKILL.md siblings.

## Test plan
- [x] go test ./...
- [x] agnostic-ai sync --check (clean, no drift)

## Refactor pass
Final review of touched files surfaced no changes: no duplication, dead branches, or naming drift. No separate `ref(...)` commit.

Closes #430