### PR TITLE
fix(spec): treat extra markdown in a skill folder as a bundled asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - `import` strips the agnostic-ai provenance header when seeding `.agnostic-ai/AGNOSTIC_AI.md` from a generated entry-point (CLAUDE.md, AGENTS.md, ...), so the source you edit no longer gains a "Do not edit" banner and the import->sync round-trip stays byte-stable. (#429)
 - `import cursor` drops the catch-all `globs: "**/*"` and empty `description` the cursor adapter emits by default, so an always-apply rule round-trips to a stable source instead of flipping its `globs` representation each cycle. (#429)
 - `sync` warns when a skill bundles sibling files (scripts, assets) the Cursor target cannot represent, since Cursor flattens each skill to a single `.mdc` rule. The payloads were dropped silently before. (#430)
+- An extra markdown file inside a folder-based skill (e.g. `skills/<name>/examples.md`) is now treated as a bundled asset instead of being loaded as its own phantom skill. The spurious top-level skill it used to emit is gone. (#431)
 
 ## v0.39.0 - 2026-06-16
 

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -99,7 +99,7 @@ skills/yaml-validator/SKILL.md
 skills/yaml-validator/schema.yaml
 ```
 
-Only `SKILL.md` and flat `*.md` are parsed. Other files in a nested skill directory (scripts, templates, fixtures, subdirectories) copy verbatim to the same relative location under each target's skills dir. Ship a `check.mjs`, `templates/*.tpl`, or `fixtures/*.json` the skill body references. Executable bits are preserved both directions through import + sync.
+Only `SKILL.md` and flat `skills/*.md` are parsed as skills. Every other file inside a nested skill directory (scripts, templates, fixtures, subdirectories, and extra `*.md` such as `examples.md`) is a bundled asset: it copies verbatim to the same relative location under each target's skills dir and is never promoted to its own skill. Ship a `check.mjs`, `templates/*.tpl`, or `fixtures/*.json` the skill body references. Executable bits are preserved both directions through import + sync.
 
 ```markdown
 ---

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -545,6 +545,22 @@ func Filter(entries []Entry, kind Kind) []Entry {
 	return out
 }
 
+// insideFolderSkill reports whether a markdown file at path lives within a
+// folder-based skill: an ancestor directory, up to and including root, that
+// holds a SKILL.md. Such files are bundled assets of that skill, not skills
+// of their own. Flat-file skills (`skills/<name>.md`, including scoped ones
+// like `skills/backend/foo.md`) have no SKILL.md ancestor and return false.
+func insideFolderSkill(path, root string) bool {
+	for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
+			return true
+		}
+		if dir == root || dir == filepath.Dir(dir) {
+			return false
+		}
+	}
+}
+
 func walkDir(dir, ext string, kind Kind, parse func(string) (Entry, error)) ([]Entry, error) {
 	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
@@ -555,6 +571,12 @@ func walkDir(dir, ext string, kind Kind, parse func(string) (Entry, error)) ([]E
 			return walkErr
 		}
 		if d.IsDir() || filepath.Ext(path) != ext {
+			return nil
+		}
+		if kind == KindSkill && d.Name() != "SKILL.md" && insideFolderSkill(path, dir) {
+			// A non-SKILL.md markdown file inside a folder-based skill is a
+			// bundled asset, copied verbatim by the adapters. Promoting it
+			// to its own skill spawns a phantom skill (#431).
 			return nil
 		}
 		entry, err := parse(path)

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -141,6 +141,63 @@ func TestLoadAll_SkillNameFromParentDirWhenFrontmatterMissing(t *testing.T) {
 	}
 }
 
+// A markdown asset that lives next to a folder-based skill's SKILL.md is a
+// bundled asset, not a skill of its own. It must not be promoted to a
+// top-level skill (#431).
+func TestLoadAll_MarkdownAssetInsideSkillNotPromoted(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "skills", "alpha", "SKILL.md"), "---\nname: alpha\n---\nskill body")
+	mustWrite(t, filepath.Join(dir, "skills", "alpha", "examples.md"), "extra markdown asset")
+	mustWrite(t, filepath.Join(dir, "skills", "alpha", "docs", "notes.md"), "nested markdown asset")
+
+	cfg := defaultsForTest()
+	entries, err := LoadAll(dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	skills := Filter(entries, KindSkill)
+	if len(skills) != 1 {
+		names := make([]string, len(skills))
+		for i, s := range skills {
+			names[i] = s.Name
+		}
+		t.Fatalf("expected 1 skill, got %d: %v", len(skills), names)
+	}
+	if skills[0].Name != "alpha" {
+		t.Errorf("expected skill alpha, got %q", skills[0].Name)
+	}
+}
+
+// Flat-file skills, including ones nested in a scope subdir, stay skills.
+// They have no SKILL.md ancestor, so the asset-detection must not eat them.
+func TestLoadAll_FlatFileSkillsSurviveAssetDetection(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "skills", "alpha.md"), "flat skill")
+	mustWrite(t, filepath.Join(dir, "skills", "backend", "loader.md"), "scoped flat skill")
+	mustWrite(t, filepath.Join(dir, "skills", "beta", "SKILL.md"), "folder skill")
+
+	cfg := defaultsForTest()
+	cfg.Sources.Skills = "skills"
+	entries, err := LoadAll(dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]bool{}
+	for _, s := range Filter(entries, KindSkill) {
+		got[s.Name] = true
+	}
+	for _, name := range []string{"alpha", "loader", "beta"} {
+		if !got[name] {
+			t.Errorf("expected skill %q to load, got %v", name, got)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("expected exactly 3 skills, got %d: %v", len(got), got)
+	}
+}
+
 func TestLoadAll_MissingDirsAreSkipped(t *testing.T) {
 	dir := t.TempDir()
 	cfg := defaultsForTest()


### PR DESCRIPTION
## Summary
- A non-`SKILL.md` markdown file inside a folder-based skill (e.g. `skills/<name>/examples.md`) was loaded as its own skill, spawning a phantom top-level skill whose body was the asset content.
- The load walk now skips markdown files that live inside a folder-based skill; they stay copied verbatim by the adapters.
- Flat-file skills, including scoped ones (`skills/backend/foo.md`), are unaffected (no `SKILL.md` ancestor).

## Test plan
- [x] go test ./...
- [x] agnostic-ai sync --check (clean)

## Refactor pass
Final review of touched files surfaced no changes. No separate `ref(...)` commit.

Closes #431