### PR TITLE
fix(validate): list all command-emitting targets in orphan-kind map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- `validate` / `lint` no longer flag `command` specs as orphaned when only Gemini, OpenCode, Amp, or Cursor are enabled. The orphan-kind map now lists every target that emits commands, matching the adapters. (#436)
 - `import` strips the agnostic-ai provenance header when seeding `.agnostic-ai/AGNOSTIC_AI.md` from a generated entry-point (CLAUDE.md, AGENTS.md, ...), so the source you edit no longer gains a "Do not edit" banner and the import->sync round-trip stays byte-stable. (#429)
 - `import cursor` drops the catch-all `globs: "**/*"` and empty `description` the cursor adapter emits by default, so an always-apply rule round-trips to a stable source instead of flipping its `globs` representation each cycle. (#429)
 - `sync` warns when a skill bundles sibling files (scripts, assets) the Cursor target cannot represent, since Cursor flattens each skill to a single `.mdc` rule. The payloads were dropped silently before. (#430)

--- a/internal/cli/native_capabilities.go
+++ b/internal/cli/native_capabilities.go
@@ -47,7 +47,7 @@ var targetsSupportingKind = map[spec.Kind]map[string]struct{}{
 	spec.KindRule:        setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity"),
 	spec.KindHook:        setOf("claude", "codex", "gemini", "zed"),
 	spec.KindMCP:         setOf("claude", "codex", "gemini", "cursor", "copilot", "continue", "amp", "zed", "warp", "opencode"),
-	spec.KindCommand:     setOf("claude", "codex"),
+	spec.KindCommand:     setOf("claude", "codex", "gemini", "opencode", "amp", "cursor"),
 	spec.KindSettings:    setOf("claude"),
 	spec.KindReview:      setOf("cursor"),
 	spec.KindEnvironment: setOf("cursor"),


### PR DESCRIPTION
## Summary

- #436 wired command emission into Gemini, OpenCode, Amp, and Cursor but left `targetsSupportingKind[KindCommand]` in `internal/cli/native_capabilities.go` listing only `claude` and `codex`.
- That map backs the orphan-kind validator in `validate` / `lint`: a project enabling only one of the new targets with `command` specs was wrongly told the specs were dead weight. Now the map matches the adapters.

## Test plan

- [x] go test ./...

Related to #436