### PR TITLE
feat(cursor): emit hook specs as native .cursor/hooks.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - New `environment` spec kind (`.agnostic-ai/environments/*.yaml`) single-sources dev-env bootstrap. Cursor emits it as `.cursor/environment.json`; other targets report the kind as unsupported. (#434)
 - New `ignore` spec kind (`.agnostic-ai/ignore/*.md`) single-sources agent ignore patterns. Emits each tool's native ignore file from one list: Cursor `.cursorignore`, Gemini `.aiexclude`, Aider `.aiderignore`. (#435)
 - The `command` spec kind now emits each target's native command/prompt format without opt-in flags: Gemini `.gemini/commands/<name>.toml`, OpenCode `.opencode/commands/<name>.md`, and Amp `.agents/commands/<name>.md` join Claude and Codex. Cursor emits Custom Commands when `outputs.cursor.commands-dir` is set. (#436)
+- Cursor hooks: the `hook` spec kind now emits `.cursor/hooks.json` ([Cursor Hooks](https://cursor.com/docs/hooks), `version` + per-event arrays), closing the parity gap with Claude/Codex/Gemini. Cursor uses its own camelCase event names (`beforeShellExecution`, `afterFileEdit`, ...), passed through verbatim; override the path via `outputs.cursor.hooks-file`. (#438)
 
 ### Fixed
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -109,6 +109,7 @@ outputs:
     review-file: BUGBOT.md       # default. Per-scope Cursor Bugbot review guidance.
     environment-file: .cursor/environment.json  # default. Background-agent bootstrap config.
     ignore-file: .cursorignore   # default. Agent ignore patterns (gitignore syntax).
+    hooks-file: .cursor/hooks.json  # default. version + per-event arrays ({command, matcher?}).
     # commands-dir: .cursor/commands  # opt-in: also emit each agent and command spec as a Cursor Custom Command.
   copilot:
     instructions-dir: .github/instructions  # default. One .instructions.md per scoped rule, agent, skill.

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -243,7 +243,7 @@ target: codex   # shell-expanded codex path; do not leak to other tools
 | `Stop` | When the model stops generating. |
 | `Notification` | When Claude Code surfaces a system notification. |
 
-Native emission: Claude Code (`.claude/settings.json`), Codex (`.codex/hooks.json`, per-event arrays), Gemini (`.gemini/settings.json` `hooks`). Other targets log a warning and skip. See each tool's docs for its full event list and matcher semantics.
+Native emission: Claude Code (`.claude/settings.json`), Codex (`.codex/hooks.json`, per-event arrays), Gemini (`.gemini/settings.json` `hooks`), Cursor (`.cursor/hooks.json`, `version` + per-event arrays). Other targets log a warning and skip. Event names pass through verbatim, so a Cursor hook sets `event:` to a Cursor name (`beforeShellExecution`, `afterFileEdit`, `beforeSubmitPrompt`, `sessionStart`, `stop`, ...). See each tool's docs for its full event list and matcher semantics.
 
 agnostic-ai emits the `event:` value **verbatim** into each target's schema; it does not translate event names between tools. Claude and Codex share the `PreToolUse` / `PostToolUse` / `UserPromptSubmit` vocabulary, so one hook spec feeds both. Gemini uses its own names (`BeforeTool`, `AfterTool`, `SessionStart`, `SessionEnd`), so a Gemini hook must set `event:` to one of those. `agnostic-ai validate` flags any event a target does not recognize.
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -33,7 +33,7 @@ Set `sync.target-overview: true` to append a generated section to each entry-poi
 | **claude**      | `.claude/agents/`   | `.claude/skills/` | `.claude/rules/*.md`   | `.claude/settings.json` | `.mcp.json` | `.claude/commands/<name>.md` | `.claude/settings.json` (`permissions`, `model`) | - | - | - |
 | **codex**       | `.codex/agents/*.toml` | `.codex/skills/<name>/SKILL.md` | inlined into `AGENTS.md` (legacy concat via `outputs.codex.rules-file`) | `.codex/hooks.json` (per-event arrays) | `.codex/config.toml` (`[mcp_servers.<name>]`) | `.codex/prompts/<name>.md` | - | - | - | - |
 | **gemini**      | `.gemini/commands/<name>.toml` | `.gemini/commands/skill-<name>.toml` w/ opt-in | inlined into `GEMINI.md` (legacy concat via `outputs.gemini.rules-file`) | `.gemini/settings.json` (`hooks`) | `.gemini/settings.json` (`mcpServers`) | `.gemini/commands/<name>.toml` | - | - | - | `.aiexclude` |
-| **cursor**      | as `.mdc` (alwaysApply: false) | as `.mdc` (`skill-<name>.mdc`) | `.cursor/rules/*.mdc` | - | `.cursor/mcp.json` | `.cursor/commands/<name>.md` w/ opt-in | - | `BUGBOT.md` (per scope) | `.cursor/environment.json` | `.cursorignore` |
+| **cursor**      | as `.mdc` (alwaysApply: false) | as `.mdc` (`skill-<name>.mdc`) | `.cursor/rules/*.mdc` | `.cursor/hooks.json` | `.cursor/mcp.json` | `.cursor/commands/<name>.md` w/ opt-in | - | `BUGBOT.md` (per scope) | `.cursor/environment.json` | `.cursorignore` |
 | **copilot**     | `.github/instructions/agent-<name>.instructions.md` | `.github/instructions/skill-<name>.instructions.md` | `.github/instructions/<name>.instructions.md` (scoped `applyTo:<glob>`; always-on rules use `applyTo:"**"`, or set `outputs.copilot.rules-file` for the legacy concatenated layout) | - | `.vscode/mcp.json` | - | - | - | - | - |
 | **aider**       | source-dir only (legacy merge via `outputs.aider.rules-file`) | source-dir only | inlined into `CONVENTIONS.md` (legacy merge via `outputs.aider.rules-file`) | - | - | - | - | - | - | `.aiderignore` |
 | **cline**       | as `.md` rule (+ `.clinerules/workflows/<name>.md` w/ opt-in) | as `.md` (`skill-<name>.md`) | `.clinerules/*.md`       | -     | - | - | - | - | - | - |
@@ -50,7 +50,7 @@ Cells marked "w/ opt-in" or "source-dir only" do not emit by default. When specs
 Cross-cutting kind notes:
 
 - **Skills**: only Claude Code executes them natively. On every other target they are reference material the agent or human reads and follows.
-- **Hooks**: shell commands on lifecycle events (`PreToolUse`, `PostToolUse`, `SessionStart`, etc.). Native on Claude Code, Codex, and Gemini in each tool's schema. Zed runs them via opt-in `outputs.zed.tasks-file` as on-demand tasks, not event-triggered hooks. Other targets skip with a warning.
+- **Hooks**: shell commands on lifecycle events (`PreToolUse`, `PostToolUse`, `SessionStart`, etc.). Native on Claude Code, Codex, and Gemini in each tool's schema, and on Cursor (`.cursor/hooks.json`, `version: 1` + per-event arrays; Cursor uses its own camelCase event names like `beforeShellExecution` / `afterFileEdit`). Zed runs them via opt-in `outputs.zed.tasks-file` as on-demand tasks, not event-triggered hooks. Other targets skip with a warning.
 - **MCP servers**: propagate to every target with a project-scoped MCP file (10 of 14, see matrix). Aider, Cline, Windsurf, and Antigravity have no MCP surface and skip with a warning. On targets whose native schema uses a `type` field (claude, cursor, copilot, warp, continue, opencode), remote (HTTP / SSE) entries carry an explicit `type` and stdio entries omit it (the inferred default). amp, gemini, and zed have no `type` field and infer the transport from the emitted keys (gemini via `httpUrl` vs `url`; amp and zed via `url` vs `command`).
 - **Commands**: slash-prompt files authored under `commands/`. Native on Claude Code (`.claude/commands/<name>.md`), Codex (`.codex/prompts/<name>.md`), Gemini (`.gemini/commands/<name>.toml`), OpenCode (`.opencode/commands/<name>.md`), and Amp (`.agents/commands/<name>.md`). Cursor emits them as Custom Commands when `outputs.cursor.commands-dir` is set. Other targets skip with a warning.
 
@@ -149,6 +149,7 @@ Verify with the real CLI:
 ```
 .cursor/rules/<name>.mdc
 .cursor/commands/<name>.md           # one per agent and per command spec, only when commands-dir is set
+.cursor/hooks.json                   # when hook specs exist (managed, overwritten each sync)
 ```
 
 - Rules emit with `alwaysApply: true`; agents as rules with `alwaysApply: false`. Override in spec frontmatter.
@@ -157,8 +158,9 @@ Verify with the real CLI:
 - Review specs emit as [Bugbot](https://docs.cursor.com/bugbot) `BUGBOT.md` files: the repo root for unscoped specs, `<scope>/BUGBOT.md` for scoped ones, with same-scope specs concatenated. Override the basename via `outputs.cursor.review-file`. (#433)
 - Environment specs emit as `.cursor/environment.json` (background-agent bootstrap). The spec keys pass through verbatim minus agnostic routing fields; multiple specs merge by top-level key. Override the path via `outputs.cursor.environment-file`. (#434)
 - Ignore specs emit as `.cursorignore` (gitignore syntax). Multiple specs concatenate. Override via `outputs.cursor.ignore-file`. (#435)
+- Hook specs emit as [Cursor Hooks](https://cursor.com/docs/hooks) in a managed `.cursor/hooks.json` (`{version: 1, hooks: {<event>: [{command, matcher?}]}}`). Cursor uses its own camelCase event vocabulary (`beforeShellExecution`, `afterFileEdit`, `beforeSubmitPrompt`, `sessionStart`, `stop`, ...), so a cursor hook sets `event:` to one of those; the name passes through verbatim and `validate` flags unrecognized events. Override the path via `outputs.cursor.hooks-file`. (#438)
 
-Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.cursor.commands-dir` (default empty, opt-in), `outputs.cursor.mcp-file` (default `.cursor/mcp.json`), `outputs.cursor.review-file` (default `BUGBOT.md`), `outputs.cursor.environment-file` (default `.cursor/environment.json`), `outputs.cursor.ignore-file` (default `.cursorignore`).
+Config keys: `outputs.cursor.rules-dir` (default `.cursor/rules`), `outputs.cursor.commands-dir` (default empty, opt-in), `outputs.cursor.mcp-file` (default `.cursor/mcp.json`), `outputs.cursor.review-file` (default `BUGBOT.md`), `outputs.cursor.environment-file` (default `.cursor/environment.json`), `outputs.cursor.ignore-file` (default `.cursorignore`), `outputs.cursor.hooks-file` (default `.cursor/hooks.json`).
 
 Verify with the real IDE:
 
@@ -166,6 +168,7 @@ Verify with the real IDE:
 2. Check the tree: `ls .cursor/rules/ .cursor/mcp.json`, `grep "Generated by agnostic-ai" .cursor/rules/*.mdc` for the provenance header (it sits after the frontmatter block), `python -m json.tool .cursor/mcp.json > /dev/null`.
 3. Open the project. The Rules panel loads every `.cursor/rules/*.mdc`; confirm `alwaysApply` matches each rule's frontmatter, no "failed to parse" warnings.
 4. If MCPs are configured, Settings → MCP shows every `mcpServers.<name>` green.
+5. If hooks are configured, `python -m json.tool .cursor/hooks.json > /dev/null` parses; trigger the matched event (e.g. a shell command for `beforeShellExecution`) and confirm the `command` runs.
 
 ### GitHub Copilot (`copilot`)
 

--- a/internal/adapters/cursor/capability_parity_test.go
+++ b/internal/adapters/cursor/capability_parity_test.go
@@ -33,6 +33,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		{spec.KindAgent, []string{".cursor/rules/alpha.mdc", ".cursor/rules/beta.mdc", ".cursor/rules/gamma.mdc"}},
 		{spec.KindCommand, []string{".cursor/commands/deploy.md"}},
 		{spec.KindSkill, []string{".cursor/rules/skill-uno.mdc", ".cursor/rules/skill-dos.mdc", ".cursor/rules/skill-tres.mdc"}},
+		{spec.KindHook, []string{".cursor/hooks.json"}},
 		{spec.KindMCP, []string{".cursor/mcp.json"}},
 		{spec.KindReview, []string{"BUGBOT.md", "backend/BUGBOT.md"}},
 		{spec.KindEnvironment, []string{".cursor/environment.json"}},
@@ -76,14 +77,13 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	t.Cleanup(emit.ResetCapabilityWarnings)
 
 	entries := []spec.Entry{
-		{Kind: spec.KindHook, Name: "fmt-go", Meta: map[string]any{"event": "PostToolUse", "command": "gofmt -w"}},
 		{Kind: spec.KindSettings, Name: "perms", Path: "settings/perms.yaml", Meta: map[string]any{"model": "opus"}},
 	}
 	if err := New().Emit(spec.NewBundle(entries), &config.Config{OnUnsupported: "warn"}, false); err != nil {
 		t.Fatalf("emit: %v", err)
 	}
-	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
-		t.Errorf("expected 2 capability warnings (hook/settings), got %d", got)
+	if got := emit.PendingCapabilityWarningsCount(); got != 1 {
+		t.Errorf("expected 1 capability warning (settings), got %d", got)
 	}
 }
 

--- a/internal/adapters/cursor/cursor.go
+++ b/internal/adapters/cursor/cursor.go
@@ -22,11 +22,12 @@ const (
 	defaultReviewFile  = "BUGBOT.md"
 	defaultEnvironFile = ".cursor/environment.json"
 	defaultIgnoreFile  = ".cursorignore"
+	defaultHooksFile   = ".cursor/hooks.json"
 )
 
 var caps = emit.Capabilities{
 	Target:   target,
-	Supports: []spec.Kind{spec.KindAgent, spec.KindSkill, spec.KindRule, spec.KindMCP, spec.KindCommand, spec.KindReview, spec.KindEnvironment, spec.KindIgnore},
+	Supports: []spec.Kind{spec.KindAgent, spec.KindSkill, spec.KindRule, spec.KindHook, spec.KindMCP, spec.KindCommand, spec.KindReview, spec.KindEnvironment, spec.KindIgnore},
 }
 
 // environRoutingKeys are the agnostic-ai spec fields stripped after
@@ -91,7 +92,120 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	} else {
 		emit.NoteCoverageGap(target, spec.KindCommand, len(b.Commands), "outputs.cursor.commands-dir")
 	}
+	if err := emitHooks(b.HooksFor(target), cfg, dryRun); err != nil {
+		return err
+	}
 	return emit.WriteMCPFile(b.MCPs, emit.MCPSchemaServersMap, emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)
+}
+
+// hooksDoc is the `.cursor/hooks.json` shape per the Cursor hooks docs:
+// a numeric `version` plus a `hooks` map keyed by lifecycle event name,
+// each event holding an array of `{command, matcher?}` entries.
+type hooksDoc struct {
+	Version int            `json:"version"`
+	Hooks   map[string]any `json:"hooks"`
+}
+
+// emitHooks writes the managed `.cursor/hooks.json` from the hook specs
+// scoped to cursor. The file is overwritten each sync; a no-op when no
+// hooks resolve to output. The path is overridable via
+// `outputs.cursor.hooks-file`. Hook scripts stashed under
+// `.agnostic-ai/scripts/` materialize into `.cursor/hooks/` so the
+// emitted `command:` paths resolve.
+func emitHooks(hooks []spec.Entry, cfg *config.Config, dryRun bool) error {
+	byEvent := buildHooks(hooks)
+	if len(byEvent) == 0 {
+		return nil
+	}
+	raw, err := emit.MarshalJSONIndent(hooksDoc{Version: 1, Hooks: byEvent})
+	if err != nil {
+		return fmt.Errorf("cursor hooks: %w", err)
+	}
+	path := emit.OutputHooksFile(cfg, target, defaultHooksFile)
+	if err := emit.WriteFile(path, string(raw)+"\n", dryRun); err != nil {
+		return err
+	}
+	return materializeHookScripts(hooks, dryRun)
+}
+
+// buildHooks groups hook specs by their `event` frontmatter into Cursor's
+// `hooks.<event> = [{command, matcher?}, ...]` shape. Cursor passes the
+// event name through verbatim (no cross-tool translation), so a cursor
+// hook spec sets `event:` to a Cursor lifecycle name (e.g.
+// `beforeShellExecution`, `afterFileEdit`). `matcher` is omitted when
+// absent. A `command:` list yields one entry per element.
+func buildHooks(hooks []spec.Entry) map[string]any {
+	byEvent := map[string][]map[string]any{}
+	for _, h := range hooks {
+		event, _ := h.Meta["event"].(string)
+		if event == "" {
+			continue
+		}
+		matcher, _ := h.Meta["matcher"].(string)
+		cmds := hookCommands(h.Meta["command"])
+		if len(cmds) == 0 {
+			continue
+		}
+		for _, cmd := range cmds {
+			entry := map[string]any{"command": emit.RewriteHookPath(cmd, target)}
+			if matcher != "" {
+				entry["matcher"] = matcher
+			}
+			byEvent[event] = append(byEvent[event], entry)
+		}
+	}
+	out := map[string]any{}
+	for k, v := range byEvent {
+		out[k] = v
+	}
+	return out
+}
+
+// materializeHookScripts copies each hook's stashed script body from
+// `.agnostic-ai/scripts/` into `.cursor/hooks/` so the emitted
+// hooks.json references a script that exists. Hooks whose command is a
+// free-form shell expression carry no stashed body and skip silently.
+func materializeHookScripts(hooks []spec.Entry, dryRun bool) error {
+	for _, h := range hooks {
+		for _, raw := range hookCommands(h.Meta["command"]) {
+			sourceTool, _ := emit.SourceToolFromHookCommand(raw)
+			rewritten := emit.RewriteHookPath(raw, target)
+			if err := emit.MaterializeHookScript(rewritten, target, sourceTool, dryRun); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// hookCommands normalizes a `command:` field that may be a string or a
+// list of strings into a single []string. Empty strings drop out.
+func hookCommands(raw any) []string {
+	switch v := raw.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, s := range v {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 // command renders a Cursor Custom Command file. The Cursor docs

--- a/internal/adapters/cursor/cursor_test.go
+++ b/internal/adapters/cursor/cursor_test.go
@@ -55,6 +55,56 @@ func TestEmit_CommandSkippedWithoutCommandsDir(t *testing.T) {
 	}
 }
 
+// Hook specs emit Cursor's native .cursor/hooks.json: a numeric version
+// and a hooks map keyed by the verbatim event name, each entry carrying
+// the command and optional matcher (#438).
+func TestEmit_WritesCursorHooksJSON(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindHook, Name: "audit-shell", Meta: map[string]any{"event": "beforeShellExecution", "matcher": "rm|dd", "command": "echo audit"}},
+		{Kind: spec.KindHook, Name: "fmt-edit", Meta: map[string]any{"event": "afterFileEdit", "command": "echo fmt"}},
+	})
+	if err := New().Emit(b, &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".cursor", "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	var doc struct {
+		Version int                         `json:"version"`
+		Hooks   map[string][]map[string]any `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse hooks.json: %v\n%s", err, data)
+	}
+	if doc.Version != 1 {
+		t.Errorf("version = %d, want 1", doc.Version)
+	}
+	shell := doc.Hooks["beforeShellExecution"]
+	if len(shell) != 1 || shell[0]["command"] != "echo audit" || shell[0]["matcher"] != "rm|dd" {
+		t.Errorf("beforeShellExecution = %#v, want one {command: echo audit, matcher: rm|dd}", shell)
+	}
+	edit := doc.Hooks["afterFileEdit"]
+	if len(edit) != 1 || edit[0]["command"] != "echo fmt" {
+		t.Errorf("afterFileEdit = %#v, want one {command: echo fmt}", edit)
+	}
+	if _, ok := edit[0]["matcher"]; ok {
+		t.Errorf("afterFileEdit entry should omit matcher, got %#v", edit[0])
+	}
+}
+
+// No hook specs means no .cursor/hooks.json is written (no surprise file).
+func TestEmit_NoHooksFileWithoutHookSpecs(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	if err := New().Emit(spec.NewBundle(nil), &config.Config{}, false); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".cursor", "hooks.json")); !os.IsNotExist(err) {
+		t.Errorf("expected no hooks.json, stat err = %v", err)
+	}
+}
+
 // Review specs emit one scope-located BUGBOT.md: unscoped at the repo root,
 // scoped under its directory, with same-scope specs concatenated (#433).
 func TestEmit_ReviewWritesBugbotPerScope(t *testing.T) {

--- a/internal/adapters/cursor/header_coverage_test.go
+++ b/internal/adapters/cursor/header_coverage_test.go
@@ -87,6 +87,14 @@ func kitSinkBundle() spec.Bundle {
 		{Kind: spec.KindSkill, Name: "dos", Path: "skills/dos/SKILL.md", Body: "dos skill body"},
 		{Kind: spec.KindSkill, Name: "tres", Path: "skills/tres/SKILL.md", Body: "tres skill body"},
 		{
+			Kind: spec.KindHook, Name: "audit-shell",
+			Meta: map[string]any{"event": "beforeShellExecution", "matcher": "rm|dd", "command": "echo audit"},
+		},
+		{
+			Kind: spec.KindHook, Name: "fmt-edit",
+			Meta: map[string]any{"event": "afterFileEdit", "command": "echo fmt"},
+		},
+		{
 			Kind: spec.KindMCP, Name: "stdio-server",
 			Meta: map[string]any{"command": "npx", "args": []any{"-y", "@modelcontextprotocol/server-filesystem"}},
 		},

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/hooks.json
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/hooks.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": "echo fmt"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "echo audit",
+        "matcher": "rm|dd"
+      }
+    ]
+  }
+}

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -93,8 +93,8 @@ func TestLintDeadSpecs_FlagsKindUnsupportedByAllTargets(t *testing.T) {
 	entries := []spec.Entry{
 		{Kind: spec.KindHook, Name: "h", Path: "hooks/h.yaml"},
 	}
-	// cursor does not support hooks
-	findings := lintDeadSpecs(entries, []string{"cursor"})
+	// copilot does not support hooks
+	findings := lintDeadSpecs(entries, []string{"copilot"})
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 dead-spec finding, got %d", len(findings))
 	}

--- a/internal/cli/native_capabilities.go
+++ b/internal/cli/native_capabilities.go
@@ -27,6 +27,19 @@ var hookEventsByTarget = map[string]map[string]struct{}{
 		"BeforeTool", "AfterTool",
 		"SessionStart", "SessionEnd",
 	),
+	"cursor": setOf(
+		"beforeShellExecution", "afterShellExecution",
+		"beforeMCPExecution", "afterMCPExecution",
+		"beforeReadFile", "afterFileEdit",
+		"beforeSubmitPrompt",
+		"preToolUse", "postToolUse", "postToolUseFailure",
+		"sessionStart", "sessionEnd",
+		"subagentStart", "subagentStop",
+		"preCompact", "stop",
+		"afterAgentResponse", "afterAgentThought",
+		"beforeTabFileRead", "afterTabFileEdit",
+		"workspaceOpen",
+	),
 }
 
 // matcherAcceptingEvents lists the hook events whose native CLI consumes a
@@ -35,6 +48,11 @@ var hookEventsByTarget = map[string]map[string]struct{}{
 var matcherAcceptingEvents = setOf(
 	"PreToolUse", "PostToolUse", // claude, codex
 	"BeforeTool", "AfterTool", // gemini
+	// cursor: tool/shell/MCP/file events filter on a regex matcher.
+	"beforeShellExecution", "afterShellExecution",
+	"beforeMCPExecution", "afterMCPExecution",
+	"beforeReadFile", "afterFileEdit",
+	"preToolUse", "postToolUse", "postToolUseFailure",
 )
 
 // targetsSupportingKind lists the targets whose adapter actually
@@ -45,7 +63,7 @@ var targetsSupportingKind = map[spec.Kind]map[string]struct{}{
 	spec.KindAgent:       setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity"),
 	spec.KindSkill:       setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode"),
 	spec.KindRule:        setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity"),
-	spec.KindHook:        setOf("claude", "codex", "gemini", "zed"),
+	spec.KindHook:        setOf("claude", "codex", "gemini", "cursor", "zed"),
 	spec.KindMCP:         setOf("claude", "codex", "gemini", "cursor", "copilot", "continue", "amp", "zed", "warp", "opencode"),
 	spec.KindCommand:     setOf("claude", "codex", "gemini", "opencode", "amp", "cursor"),
 	spec.KindSettings:    setOf("claude"),

--- a/internal/cli/validate_native_test.go
+++ b/internal/cli/validate_native_test.go
@@ -85,11 +85,11 @@ func TestValidate_HookEventGeminiSubsetUnknownToClaude(t *testing.T) {
 }
 
 func TestValidate_OrphanHookKindWarning(t *testing.T) {
-	// Cursor + cline configured; neither emits hooks. The hook spec
+	// copilot + cline configured; neither emits hooks. The hook spec
 	// is dead weight and validate should say so.
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "agnostic-ai.yaml"),
-		"version: 1\ntargets:\n  - cursor\n  - cline\n")
+		"version: 1\ntargets:\n  - copilot\n  - cline\n")
 	mustWriteFile(t, filepath.Join(dir, ".agnostic-ai", "hooks", "fmt.yaml"),
 		"name: fmt\nevent: PostToolUse\nmatcher: \"\"\ncommand: \"true\"\n")
 	testutil.Chdir(t, dir)

--- a/tests/integration/fixtures/golden/cursor/.cursor/hooks.json
+++ b/tests/integration/fixtures/golden/cursor/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "command": "echo edited",
+        "matcher": "Edit"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Cursor now emits the `hook` spec kind as its native `.cursor/hooks.json` ([Cursor Hooks](https://cursor.com/docs/hooks)): `{version: 1, hooks: {<event>: [{command, matcher?}]}}`. Managed file, overwritten each sync; path overridable via `outputs.cursor.hooks-file`.
- Closes the parity gap: hooks were native only on Claude/Codex/Gemini and skipped cursor with a warning.
- Event names pass through verbatim (project convention). Cursor's camelCase vocabulary (`beforeShellExecution`, `afterFileEdit`, `beforeSubmitPrompt`, ...) is registered in `native_capabilities.go` so `validate`/`lint` recognize it and the matcher-accepting events are correct.
- Stashed hook scripts materialize into `.cursor/hooks/`, same as the Claude/Gemini adapters.
- Docs (`targets.md` matrix + section + verify checklist, `spec-format.md`, `configuration.md`) and `CHANGELOG.md` updated. Capability + golden snapshots regenerated.

## Scope note

Emits `{command, matcher}` matching Gemini's proven shape. Richer Cursor fields (`timeout`, `failClosed`, prompt-type hooks) are a natural follow-up, not needed to close the parity gap.

## Refactor pass

Reviewed every touched file. The `buildHooks`/`hookCommands`/`materializeHookScripts` helpers mirror the Gemini adapter; lifting them into shared `emit` would touch other adapters and cross the adapter-independence boundary, so the duplication stays consistent with the codebase. No refactor changes warranted.

## Test plan

- [x] go test ./... (incl. golden snapshots)
- [x] agnostic-ai sync --check (no tracked drift; `.cursor/` is gitignored)
- [x] gofmt / go vet clean

Closes #438