### PR TITLE
feat(doctor): report agentic config on disk not single-sourced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - New `environment` spec kind (`.agnostic-ai/environments/*.yaml`) single-sources dev-env bootstrap. Cursor emits it as `.cursor/environment.json`; other targets report the kind as unsupported. (#434)
 - New `ignore` spec kind (`.agnostic-ai/ignore/*.md`) single-sources agent ignore patterns. Emits each tool's native ignore file from one list: Cursor `.cursorignore`, Gemini `.aiexclude`, Aider `.aiderignore`. (#435)
 - The `command` spec kind now emits each target's native command/prompt format without opt-in flags: Gemini `.gemini/commands/<name>.toml`, OpenCode `.opencode/commands/<name>.md`, and Amp `.agents/commands/<name>.md` join Claude and Codex. Cursor emits Custom Commands when `outputs.cursor.commands-dir` is set. (#436)
+- `doctor` reports an "Unmanaged config" block: known agentic config files on disk (CLAUDE.md, AGENTS.md, GEMINI.md, `.cursor/rules/*.mdc`, BUGBOT.md, per-tool agent/command/skill files, ...) that carry no agnostic-ai provenance marker, grouped with the `import` command that would single-source each. Advisory; does not affect exit code. (#440)
 - Cursor hooks: the `hook` spec kind now emits `.cursor/hooks.json` ([Cursor Hooks](https://cursor.com/docs/hooks), `version` + per-event arrays), closing the parity gap with Claude/Codex/Gemini. Cursor uses its own camelCase event names (`beforeShellExecution`, `afterFileEdit`, ...), passed through verbatim; override the path via `outputs.cursor.hooks-file`. (#438)
 
 ### Fixed

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -340,6 +340,8 @@ Use the no-flag form as a CI gate alongside `sync --check`, or after rebases to 
 
 After the drift report, doctor prints an **MCP block**: each MCP spec's stdio `command:` and whether it resolves on PATH. Missing common commands (`npx`, `uvx`, `python`, `docker`) include an inline install hint. HTTP/SSE servers (no command, only `url:`) skip the check. Advisory only: a missing binary does not change doctor's exit code.
 
+doctor also prints an **Unmanaged config block**: known agentic config files present on disk but not generated from `.agnostic-ai/` (no provenance marker), grouped by the `import` source that would adopt each. This surfaces files still single-sourced by hand (a pre-agnostic-ai `CLAUDE.md`, hand-written `.cursor/rules/*.mdc`, etc.) so you can `agnostic-ai import <target>` them. Only header-bearing formats (markdown, TOML) are scanned; JSON config (settings.json, mcp.json, hooks.json) is merge-managed and covered by the drift block instead. Advisory only: it does not change doctor's exit code.
+
 Subcommands run a single check in isolation: `doctor config` (validate `agnostic-ai.yaml`), `doctor install` (which AI CLIs are on PATH), `doctor mcp` (resolve each MCP server's command binary).
 
 After the MCP block, doctor walks `.agnostic-ai/scripts/<tool>/` per tool and groups files by basename. When the same basename exists under two or more tools with different SHA-256 bodies, it prints one finding per divergent script (sizes + truncated hashes per variant) and the suggested consolidation path `.agnostic-ai/scripts/<basename>`. Divergence counts as drift and contributes to a non-zero exit, since it usually means an unnoticed import diff between tools. Not auto-fixable: choosing the winning body needs human judgement.

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -164,9 +164,10 @@ func newDoctorCmd() *cobra.Command {
 			"  1. Detect installed AI CLIs on PATH.\n" +
 			"  2. Validate agnostic-ai.yaml config.\n" +
 			"  3. Report unsupported spec kinds per target.\n" +
-			"  4. Compare what sync would emit against files on disk (drift).\n" +
-			"  5. Check MCP server command binaries.\n" +
-			"  6. Suggest a concrete next step.\n\n" +
+			"  4. Report agentic config on disk not single-sourced from .agnostic-ai/.\n" +
+			"  5. Compare what sync would emit against files on disk (drift).\n" +
+			"  6. Check MCP server command binaries.\n" +
+			"  7. Suggest a concrete next step.\n\n" +
 			"Exits non-zero on any drift. Subcommands run individual checks.",
 		Example: `  # Full diagnostic (CI gate)
   agnostic-ai doctor
@@ -215,6 +216,9 @@ func newDoctorCmd() *cobra.Command {
 
 			// 3. Unsupported kinds
 			reportUnsupportedKinds(cmd, cfg)
+
+			// 3b. Config present on disk but not single-sourced.
+			reportUnmanagedConfig(cmd, ".")
 
 			// 4. Drift
 			cmd.Println()

--- a/internal/cli/doctor_unmanaged.go
+++ b/internal/cli/doctor_unmanaged.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
+)
+
+// unmanagedConfigGlobs enumerates known agentic config files that
+// agnostic-ai can generate, paired with the `import` source that would
+// bring each under `.agnostic-ai/`. A matched file that lacks the
+// provenance marker is hand-authored and not single-sourced, so doctor
+// surfaces it with a concrete next step.
+//
+// Only header-bearing formats (markdown, TOML) are listed: every
+// agnostic-ai-generated file of these kinds carries the marker (enforced
+// by the per-adapter header-coverage tests), so a missing marker is a
+// reliable "unmanaged" signal. JSON config (settings.json, mcp.json,
+// hooks.json) carries no marker and is partially merge-managed, so it is
+// covered by the drift section instead, not flagged here.
+var unmanagedConfigGlobs = []struct{ glob, target string }{
+	{"CLAUDE.md", "claude"},
+	{"AGENTS.md", "codex"},
+	{"GEMINI.md", "gemini"},
+	{"CONVENTIONS.md", "aider"},
+	{"BUGBOT.md", "cursor"},
+	{".cursor/rules/*.mdc", "cursor"},
+	{".claude/agents/*.md", "claude"},
+	{".claude/commands/*.md", "claude"},
+	{".claude/skills/*/SKILL.md", "claude"},
+	{".codex/prompts/*.md", "codex"},
+	{".codex/agents/*.toml", "codex"},
+	{".gemini/commands/*.toml", "gemini"},
+	{".opencode/commands/*.md", "opencode"},
+	{".agents/commands/*.md", "amp"},
+}
+
+// unmanagedFinding is one config file present on disk but not generated
+// from `.agnostic-ai/`.
+type unmanagedFinding struct {
+	Path   string
+	Target string
+}
+
+// findUnmanagedConfig scans root for known agentic config files that
+// exist but carry no agnostic-ai provenance marker. Returns findings
+// sorted by path. Read errors on individual files are skipped: doctor is
+// advisory and a single unreadable file should not abort the scan.
+func findUnmanagedConfig(root string) ([]unmanagedFinding, error) {
+	var out []unmanagedFinding
+	for _, c := range unmanagedConfigGlobs {
+		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(c.glob)))
+		if err != nil {
+			// Only ErrBadPattern, which our static globs never trigger.
+			return nil, err
+		}
+		for _, m := range matches {
+			info, err := os.Stat(m)
+			if err != nil || info.IsDir() {
+				continue
+			}
+			data, err := os.ReadFile(m)
+			if err != nil {
+				continue
+			}
+			if header.Has(string(data)) {
+				continue
+			}
+			rel, err := filepath.Rel(root, m)
+			if err != nil {
+				rel = m
+			}
+			out = append(out, unmanagedFinding{Path: filepath.ToSlash(rel), Target: c.target})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}
+
+// reportUnmanagedConfig prints the doctor section listing agentic config
+// files present on disk but not single-sourced from `.agnostic-ai/`,
+// each with the `import` command that would adopt it. Returns the number
+// of findings so callers can fold the count into a summary.
+func reportUnmanagedConfig(cmd *cobra.Command, root string) int {
+	findings, err := findUnmanagedConfig(root)
+	if err != nil {
+		return 0
+	}
+	cmd.Println()
+	cmd.Println("Unmanaged config (on disk, not generated from .agnostic-ai/):")
+	if len(findings) == 0 {
+		cmd.Println("  ✓ none found")
+		return 0
+	}
+	byTarget := map[string][]string{}
+	var targetOrder []string
+	for _, f := range findings {
+		if _, seen := byTarget[f.Target]; !seen {
+			targetOrder = append(targetOrder, f.Target)
+		}
+		byTarget[f.Target] = append(byTarget[f.Target], f.Path)
+	}
+	sort.Strings(targetOrder)
+	for _, target := range targetOrder {
+		for _, p := range byTarget[target] {
+			cmd.Printf("  ✗ %s\n", p)
+		}
+		cmd.Printf("    → adopt with: agnostic-ai import %s\n", target)
+	}
+	return len(findings)
+}

--- a/internal/cli/doctor_unmanaged_test.go
+++ b/internal/cli/doctor_unmanaged_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
+)
+
+// A hand-authored config file (no provenance marker) is reported as
+// unmanaged; a generated sibling carrying the marker is not.
+func TestFindUnmanagedConfig_FlagsOnlyUnmarkedFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Hand-authored: no marker -> unmanaged.
+	mustWriteFile(t, filepath.Join(dir, "CLAUDE.md"), "# My project\n\nHand-written instructions.\n")
+	mustWriteFile(t, filepath.Join(dir, ".cursor", "rules", "legacy.mdc"), "---\ndescription: x\n---\n\nold rule\n")
+	// Generated: carries the marker -> managed, must not be flagged.
+	mustWriteFile(t, filepath.Join(dir, "GEMINI.md"), "<!-- "+header.Marker+" -->\npointer body\n")
+
+	got, err := findUnmanagedConfig(dir)
+	if err != nil {
+		t.Fatalf("findUnmanagedConfig: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unmanaged findings, got %d: %+v", len(got), got)
+	}
+	byPath := map[string]string{}
+	for _, f := range got {
+		byPath[f.Path] = f.Target
+	}
+	if byPath["CLAUDE.md"] != "claude" {
+		t.Errorf("CLAUDE.md target = %q, want claude", byPath["CLAUDE.md"])
+	}
+	if byPath[".cursor/rules/legacy.mdc"] != "cursor" {
+		t.Errorf("legacy.mdc target = %q, want cursor", byPath[".cursor/rules/legacy.mdc"])
+	}
+	if _, flagged := byPath["GEMINI.md"]; flagged {
+		t.Errorf("generated GEMINI.md should not be flagged: %+v", got)
+	}
+}
+
+// A clean tree with no known config files yields no findings.
+func TestFindUnmanagedConfig_EmptyTree(t *testing.T) {
+	got, err := findUnmanagedConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("findUnmanagedConfig: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no findings in empty tree, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `doctor` gains an "Unmanaged config" block: it scans known agentic config files (CLAUDE.md / AGENTS.md / GEMINI.md / CONVENTIONS.md, BUGBOT.md, `.cursor/rules/*.mdc`, `.claude/agents|commands|skills`, `.codex/prompts|agents`, `.gemini/commands`, `.opencode/commands`, `.agents/commands`) and reports any present on disk without the agnostic-ai provenance marker — i.e. hand-authored and not single-sourced — grouped with the `agnostic-ai import <target>` command that would adopt each.
- Only header-bearing formats (markdown, TOML) are scanned: every agnostic-ai-generated file of those kinds carries the marker, so a missing marker is a reliable "unmanaged" signal. JSON config (settings.json, mcp.json, hooks.json) is merge-managed and left to the existing drift block, avoiding false positives.
- Advisory: does not change doctor's exit code.

## Test plan

- [x] go test ./...
- [x] `agnostic-ai doctor` on this repo → "✓ none found" (all generated files carry the marker)
- [x] gofmt / go vet clean

## Refactor pass

Reviewed the new file. `findUnmanagedConfig` / `reportUnmanagedConfig` are single-concern; `filepath.FromSlash`/`ToSlash` keep the globs and output portable on Windows; per-file read errors are skipped by design since the scan is advisory. No refactor changes warranted.

Closes #440