### PR TITLE
fix(cursor): preserve .mdc frontmatter on round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- Cursor `.mdc` rule emit no longer rewrites frontmatter cosmetically: an `alwaysApply: true` rule with empty globs keeps them empty instead of gaining `globs: "**/*"`, scalar globs like `apps/foo/**` stay unquoted instead of being double-quoted, and an empty `description:` drops its trailing space. Adopting agnostic-ai on a repo with existing Cursor rules now produces a clean diff instead of touching every rule. (#443)
 - `validate` / `lint` no longer flag `command` specs as orphaned when only Gemini, OpenCode, Amp, or Cursor are enabled. The orphan-kind map now lists every target that emits commands, matching the adapters. (#436)
 - `import` strips the agnostic-ai provenance header when seeding `.agnostic-ai/AGNOSTIC_AI.md` from a generated entry-point (CLAUDE.md, AGENTS.md, ...), so the source you edit no longer gains a "Do not edit" banner and the import->sync round-trip stays byte-stable. (#429)
 - `import cursor` drops the catch-all `globs: "**/*"` and empty `description` the cursor adapter emits by default, so an always-apply rule round-trips to a stable source instead of flipping its `globs` representation each cycle. (#429)

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -152,7 +152,7 @@ Verify with the real CLI:
 .cursor/hooks.json                   # when hook specs exist (managed, overwritten each sync)
 ```
 
-- Rules emit with `alwaysApply: true`; agents as rules with `alwaysApply: false`. Override in spec frontmatter.
+- Rules emit with `alwaysApply: true`; agents as rules with `alwaysApply: false`. Override in spec frontmatter. An `alwaysApply: true` rule omits `globs` (the field is ignored when always-applied); an `alwaysApply: false` rule with no globs defaults to `**/*`. Scalar globs keep minimal YAML quoting so a hand-authored `.mdc` round-trips without cosmetic rewrites. (#443)
 - When `outputs.cursor.commands-dir` is set, each agent and each command spec emits as a [Cursor Custom Command](https://docs.cursor.com/agent/custom-commands): Markdown with optional `description` and `model` frontmatter. The agent rule-form emission still happens. Commands have no other Cursor surface, so without `commands-dir` they stay source-only and `sync` prints a coverage note.
 - Skills flatten to a single `.mdc` rule, so a skill that bundles sibling files (scripts, assets) cannot carry them to Cursor. `sync` prints a note for each such skill instead of dropping the payloads silently. (#430)
 - Review specs emit as [Bugbot](https://docs.cursor.com/bugbot) `BUGBOT.md` files: the repo root for unscoped specs, `<scope>/BUGBOT.md` for scoped ones, with same-scope specs concatenated. Override the basename via `outputs.cursor.review-file`. (#433)

--- a/internal/adapters/cursor/cursor.go
+++ b/internal/adapters/cursor/cursor.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
@@ -332,19 +334,46 @@ func mdc(e spec.Entry, alwaysApplyDefault bool) string {
 	m := emit.ResolveMeta(e.Meta, target)
 	desc, _ := m["description"].(string)
 	globs, _ := m["globs"].(string)
-	if globs == "" {
-		globs = "**/*"
-	}
 	always := alwaysApplyDefault
 	if v, ok := m["alwaysApply"].(bool); ok {
 		always = v
 	}
+	// An alwaysApply:false rule (agents, skills) defaults to a broad
+	// `**/*` auto-attach when it declares no globs. An alwaysApply:true
+	// rule ignores globs entirely, so synthesizing one there is pure
+	// round-trip noise against a hand-authored source; omit it (#443).
+	if globs == "" && !always {
+		globs = "**/*"
+	}
 	var b strings.Builder
 	b.WriteString("---\n")
-	b.WriteString("description: " + desc + "\n")
-	fmt.Fprintf(&b, "globs: %q\n", globs)
+	// Emit an empty description as a bare `description:` key (no trailing
+	// space) so it byte-matches a hand-authored rule on round-trip (#443).
+	if desc != "" {
+		b.WriteString("description: " + desc + "\n")
+	} else {
+		b.WriteString("description:\n")
+	}
+	// Quote the globs value only when YAML needs it (a leading `*`, etc.)
+	// rather than always double-quoting, which rewrote `apps/foo/**` to
+	// `"apps/foo/**"` and broke byte round-trips (#443).
+	if globs != "" {
+		b.WriteString("globs: " + mdcScalar(globs) + "\n")
+	}
 	fmt.Fprintf(&b, "alwaysApply: %t\n", always)
 	b.WriteString("---\n\n")
 	b.WriteString(e.Body)
 	return b.String()
+}
+
+// mdcScalar renders s as a YAML scalar with minimal quoting: a plain
+// value like `apps/foo/**` stays unquoted, while a value YAML cannot
+// represent plainly (a leading `*`, a colon, ...) is quoted just enough
+// to stay valid.
+func mdcScalar(s string) string {
+	out, err := yaml.Marshal(s)
+	if err != nil {
+		return fmt.Sprintf("%q", s)
+	}
+	return strings.TrimRight(string(out), "\n")
 }

--- a/internal/adapters/cursor/cursor_test.go
+++ b/internal/adapters/cursor/cursor_test.go
@@ -352,11 +352,53 @@ func TestEmit_WritesMdcRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(got), `globs: "**/*.go"`) {
+	// `**/*.go` needs quoting (leading `*`), so YAML uses a single-quoted
+	// scalar — not the gratuitous double-quoting the emitter used before.
+	if !strings.Contains(string(got), `globs: '**/*.go'`) {
 		t.Errorf("missing globs: %s", got)
 	}
 	if !strings.Contains(string(got), "alwaysApply: true") {
 		t.Errorf("rule should default alwaysApply=true: %s", got)
+	}
+}
+
+// A hand-authored rule with empty globs and alwaysApply:true must
+// round-trip without the emitter synthesizing `globs: "**/*"`, re-quoting
+// scalar globs, or leaving a trailing space on an empty description (#443).
+func TestEmit_MdcRuleFrontmatterByteStable(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+
+	entries := []spec.Entry{
+		// Empty description + empty globs + alwaysApply:true.
+		{Kind: spec.KindRule, Name: "always", Meta: map[string]any{"alwaysApply": true}, Body: "body"},
+		// Scalar globs that does not need quoting must stay unquoted.
+		{Kind: spec.KindRule, Name: "scoped", Meta: map[string]any{"globs": "apps/foo/**", "alwaysApply": false}, Body: "body"},
+	}
+	if err := New().Emit(spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	always, err := os.ReadFile(filepath.Join(dir, ".cursor/rules/always.mdc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(always), "globs:") {
+		t.Errorf("alwaysApply:true rule should omit synthesized globs:\n%s", always)
+	}
+	if strings.Contains(string(always), "description: \n") {
+		t.Errorf("empty description should not carry a trailing space:\n%s", always)
+	}
+	if !strings.Contains(string(always), "description:\n") {
+		t.Errorf("expected bare `description:` key:\n%s", always)
+	}
+
+	scoped, err := os.ReadFile(filepath.Join(dir, ".cursor/rules/scoped.mdc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(scoped), "globs: apps/foo/**\n") {
+		t.Errorf("scalar globs should stay unquoted:\n%s", scoped)
 	}
 }
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/alpha.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/alpha.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: "**/*"
+description:
+globs: '**/*'
 alwaysApply: false
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/beta.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/beta.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: "**/*"
+description:
+globs: '**/*'
 alwaysApply: false
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/gamma.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/gamma.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: "**/*"
+description:
+globs: '**/*'
 alwaysApply: false
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/r1.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/r1.mdc
@@ -1,6 +1,5 @@
 ---
-description: 
-globs: "**/*"
+description:
 alwaysApply: true
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/r2.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/r2.mdc
@@ -1,6 +1,5 @@
 ---
-description: 
-globs: "**/*"
+description:
 alwaysApply: true
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/r3.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/r3.mdc
@@ -1,6 +1,5 @@
 ---
-description: 
-globs: "**/*"
+description:
 alwaysApply: true
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/skill-dos.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/skill-dos.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: "**/*"
+description:
+globs: '**/*'
 alwaysApply: false
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/skill-tres.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/skill-tres.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: "**/*"
+description:
+globs: '**/*'
 alwaysApply: false
 ---
 

--- a/internal/adapters/cursor/testdata/kitsink/.cursor/rules/skill-uno.mdc
+++ b/internal/adapters/cursor/testdata/kitsink/.cursor/rules/skill-uno.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: "**/*"
+description:
+globs: '**/*'
 alwaysApply: false
 ---
 

--- a/tests/integration/fixtures/golden/cursor/.cursor/rules/sample-agent.mdc
+++ b/tests/integration/fixtures/golden/cursor/.cursor/rules/sample-agent.mdc
@@ -1,6 +1,6 @@
 ---
 description: A sample agent for golden snapshot tests.
-globs: "**/*"
+globs: '**/*'
 alwaysApply: false
 ---
 

--- a/tests/integration/fixtures/golden/cursor/.cursor/rules/sample-rule.mdc
+++ b/tests/integration/fixtures/golden/cursor/.cursor/rules/sample-rule.mdc
@@ -1,6 +1,5 @@
 ---
 description: A sample rule for golden snapshot tests.
-globs: "**/*"
 alwaysApply: true
 ---
 

--- a/tests/integration/fixtures/golden/cursor/.cursor/rules/skill-sample-skill.mdc
+++ b/tests/integration/fixtures/golden/cursor/.cursor/rules/skill-sample-skill.mdc
@@ -1,6 +1,6 @@
 ---
 description: A sample skill for golden snapshot tests.
-globs: "**/*"
+globs: '**/*'
 alwaysApply: false
 ---
 


### PR DESCRIPTION
## Summary

Emitting a rule to `.cursor/rules/*.mdc` rewrote YAML frontmatter cosmetically, so adopting agnostic-ai on a repo with existing Cursor rules touched every rule with noise:

- An `alwaysApply: true` rule with empty globs gained `globs: "**/*"` (no behavioral effect; alwaysApply wins). Now omitted.
- Scalar globs were double-quoted: `apps/foo/**` → `"apps/foo/**"`. Now minimally quoted (unquoted when YAML allows).
- An empty `description:` carried a trailing space. Now a bare `description:` key.

The `alwaysApply: false` broad auto-attach default (`**/*` for agents/skills) is kept — that one is behavioral, not cosmetic. The provenance header stays (every generated file carries it); `import cursor` already strips it (#429), so re-import is idempotent.

## Test plan

- [x] go test ./... (incl. regenerated cursor kit-sink + integration goldens)
- [x] New `TestEmit_MdcRuleFrontmatterByteStable` locks: no synthesized globs on alwaysApply:true, unquoted scalar globs, no trailing-space description
- [x] agnostic-ai sync --check clean; gofmt / go vet clean

## Refactor pass

`mdc()` and the new `mdcScalar` helper are minimal and single-purpose; no duplication introduced. No further changes warranted.

Closes #443