### PR TITLE
docs: warn gitignored outputs miss fresh worktrees

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -199,3 +199,5 @@ gitignore:
 ```
 
 `sync` rewrites a managed block in `.gitignore` listing every emitted path. Lines outside the block are preserved.
+
+Gitignored outputs are not in git, so a fresh clone or a new `git worktree` starts without them until `agnostic-ai sync` runs. A contributor cloning the repo runs `sync` by hand; automated worktree creation does not. Wire `sync` into your worktree bootstrap, or add a `post-checkout` hook (see [Git hooks](git-hooks.md)), so an AI session opened in a new worktree always finds its config.


### PR DESCRIPTION
## Why

An adopter that gitignores agnostic-ai outputs hit this: a new `git worktree` (created by automation that only symlinks `node_modules`) starts with no `CLAUDE.md`, rules, or hooks, because gitignored files don't carry into a fresh checkout and nobody runs `sync` there.

The "gitignore + each contributor runs sync locally" model in our docs never mentioned worktrees or other automated checkouts where no human runs `sync`.

## What

Add a callout to the `Auto-manage .gitignore` section: gitignored outputs don't exist until `sync` runs, so wire `sync` into worktree bootstrap or a `post-checkout` hook.

Docs-only. The `post-checkout` recipe itself lands in a follow-up PR to `git-hooks.md`.
