### PR TITLE
feat(sync): add opt-in per-target dropped summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ## [Unreleased]
 
+### Added
+
+- `sync.dropped-summary` config: opt-in per-target summary of what each target could not fully emit (unsupported kinds dropped, downgraded kinds and the opt-in key that would carry them), regrouping the existing kind-grouped warnings by target. (#441)
+
 ## v0.40.0 - 2026-06-17
 
 ### Added

--- a/docs/schemas/config.schema.json
+++ b/docs/schemas/config.schema.json
@@ -416,6 +416,9 @@
         },
         "resolve-imports": {
           "type": "string"
+        },
+        "dropped-summary": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -315,6 +315,25 @@ sync:
 
 Only a line that is a lone `@path` token is treated as an import; an `@mention` inside a sentence is left untouched. Paths resolve relative to the project root.
 
+### `sync.dropped-summary`
+
+Prints a per-target summary after sync of what each target could not fully emit: kinds it has no surface for (dropped) and kinds it emits only behind an opt-in key or keeps source-dir only (downgraded). The same information already prints grouped by kind (capability warnings and coverage notes); this regroups it by target so you can scan one tool at a time. Off by default.
+
+```yaml
+# In agnostic-ai.yaml
+sync:
+  dropped-summary: true
+```
+
+Example output:
+
+```
+  dropped summary (per target):
+    cursor: 2 hooks dropped (unsupported)
+    gemini: 3 skills via outputs.gemini.emit-skills-as-commands
+```
+
+
 Targets whose artifacts all flow through the entry-point pointer (aider) get no appendix. External adapters (`agnostic-ai-adapter-<name>` binaries) have no native-artifacts protocol yet, so their section is absent from the appendix.
 
 ## `import`

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -85,6 +85,11 @@ func ResetCapabilityWarnings() { emit.ResetCapabilityWarnings() }
 // sync pass.
 func FlushCapabilityWarnings() { emit.FlushCapabilityWarnings() }
 
+// RenderDroppedSummary writes a per-target summary of buffered capability
+// warnings and coverage notes (what each target could not fully emit)
+// without clearing either buffer. Call before the flushes.
+func RenderDroppedSummary(w io.Writer) { emit.RenderDroppedSummary(w) }
+
 // CapabilityWarningsDigest returns a stable hex digest of the currently
 // buffered capability warnings, "" when none. Used by sync to suppress
 // unchanged warning sets across runs.

--- a/internal/adapters/internal/emit/dropped_summary.go
+++ b/internal/adapters/internal/emit/dropped_summary.go
@@ -1,0 +1,125 @@
+package emit
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// KindDrop is one kind a target could not fully emit: Count specs of Kind,
+// with Via naming the opt-in key (or reason) that would carry them when the
+// drop is a downgrade rather than an outright capability gap.
+type KindDrop struct {
+	Kind  spec.Kind
+	Count int
+	Via   string
+}
+
+// TargetDrop summarizes, for one target, what the last run could not fully
+// emit: Unsupported kinds (no native surface, dropped entirely) and
+// Downgraded kinds (reach the target only behind an opt-in key or stay
+// source-dir only). Built from the same buffers FlushCapabilityWarnings and
+// FlushCoverageNotes consume.
+type TargetDrop struct {
+	Target      string
+	Unsupported []KindDrop
+	Downgraded  []KindDrop
+}
+
+// DroppedByTarget regroups the buffered capability warnings (unsupported)
+// and coverage notes (downgraded) by target, sorted by target name and by
+// kind within each. Read-only: it does not clear either buffer, so the
+// existing kind-grouped flushes still render afterward. Returns nil when
+// nothing is buffered.
+func DroppedByTarget() []TargetDrop {
+	capabilityWarnState.mu.Lock()
+	warns := append([]pendingWarn(nil), capabilityWarnState.pending...)
+	capabilityWarnState.mu.Unlock()
+
+	coverageNoteState.mu.Lock()
+	notes := append([]pendingNote(nil), coverageNoteState.pending...)
+	coverageNoteState.mu.Unlock()
+
+	byTarget := map[string]*TargetDrop{}
+	get := func(target string) *TargetDrop {
+		if d, ok := byTarget[target]; ok {
+			return d
+		}
+		d := &TargetDrop{Target: target}
+		byTarget[target] = d
+		return d
+	}
+
+	seenWarn := map[string]bool{}
+	for _, w := range warns {
+		key := w.target + "\x00" + string(w.kind)
+		if seenWarn[key] {
+			continue
+		}
+		seenWarn[key] = true
+		d := get(w.target)
+		d.Unsupported = append(d.Unsupported, KindDrop{Kind: w.kind, Count: w.count})
+	}
+	seenNote := map[string]bool{}
+	for _, n := range notes {
+		key := n.target + "\x00" + string(n.kind) + "\x00" + n.via
+		if seenNote[key] {
+			continue
+		}
+		seenNote[key] = true
+		d := get(n.target)
+		d.Downgraded = append(d.Downgraded, KindDrop{Kind: n.kind, Count: n.count, Via: n.via})
+	}
+
+	if len(byTarget) == 0 {
+		return nil
+	}
+	out := make([]TargetDrop, 0, len(byTarget))
+	for _, d := range byTarget {
+		sortKindDrops(d.Unsupported)
+		sortKindDrops(d.Downgraded)
+		out = append(out, *d)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Target < out[j].Target })
+	return out
+}
+
+func sortKindDrops(ds []KindDrop) {
+	sort.Slice(ds, func(i, j int) bool {
+		if ds[i].Kind != ds[j].Kind {
+			return ds[i].Kind < ds[j].Kind
+		}
+		return ds[i].Via < ds[j].Via
+	})
+}
+
+// RenderDroppedSummary writes a concise per-target block of what each
+// target could not fully emit. No-op (writes nothing) when no drops are
+// buffered. The phrasing mirrors the kind-grouped warnings: unsupported
+// kinds are "dropped", downgraded kinds name the key that would carry them.
+func RenderDroppedSummary(w io.Writer) {
+	drops := DroppedByTarget()
+	if len(drops) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w, "  dropped summary (per target):")
+	for _, d := range drops {
+		var parts []string
+		for _, k := range d.Unsupported {
+			parts = append(parts, fmt.Sprintf("%d %s dropped (unsupported)", k.Count, pluralizeKind(k.Kind, k.Count)))
+		}
+		for _, k := range d.Downgraded {
+			// Mirror FlushCoverageNotes: a config-key hint reads "via
+			// outputs.x.y"; a free-text reason reads "in the source dir (…)".
+			tail := "via " + k.Via
+			if !strings.HasPrefix(k.Via, "outputs.") {
+				tail = "in the source dir (" + k.Via + ")"
+			}
+			parts = append(parts, fmt.Sprintf("%d %s %s", k.Count, pluralizeKind(k.Kind, k.Count), tail))
+		}
+		_, _ = fmt.Fprintf(w, "    %s: %s\n", d.Target, strings.Join(parts, "; "))
+	}
+}

--- a/internal/adapters/internal/emit/dropped_summary_test.go
+++ b/internal/adapters/internal/emit/dropped_summary_test.go
@@ -1,0 +1,124 @@
+package emit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+func TestDroppedByTarget_GroupsAndDoesNotClear(t *testing.T) {
+	ResetCapabilityWarnings()
+	ResetCoverageNotes()
+	t.Cleanup(ResetCapabilityWarnings)
+	t.Cleanup(ResetCoverageNotes)
+
+	// cursor: hooks unsupported (dropped). gemini: skills downgraded.
+	caps := Capabilities{Target: "cursor", Supports: []spec.Kind{spec.KindRule}}
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindHook, Name: "h", Meta: map[string]any{"event": "PostToolUse"}},
+	})
+	if err := ReportUnsupported(caps, b, OnUnsupportedWarn); err != nil {
+		t.Fatal(err)
+	}
+	NoteCoverageGap("gemini", spec.KindSkill, 3, "outputs.gemini.emit-skills-as-commands")
+
+	drops := DroppedByTarget()
+	if len(drops) != 2 {
+		t.Fatalf("expected 2 targets, got %d: %+v", len(drops), drops)
+	}
+	// sorted by target name: cursor, gemini
+	if drops[0].Target != "cursor" || len(drops[0].Unsupported) != 1 || drops[0].Unsupported[0].Kind != spec.KindHook {
+		t.Errorf("cursor unsupported wrong: %+v", drops[0])
+	}
+	if drops[1].Target != "gemini" || len(drops[1].Downgraded) != 1 || drops[1].Downgraded[0].Count != 3 {
+		t.Errorf("gemini downgraded wrong: %+v", drops[1])
+	}
+
+	// Read-only: buffers still populated for the regular flushes.
+	if PendingCapabilityWarningsCount() == 0 {
+		t.Errorf("DroppedByTarget must not clear the capability buffer")
+	}
+	if PendingCoverageNotesCount() == 0 {
+		t.Errorf("DroppedByTarget must not clear the coverage buffer")
+	}
+}
+
+func TestRenderDroppedSummary_Output(t *testing.T) {
+	ResetCapabilityWarnings()
+	ResetCoverageNotes()
+	t.Cleanup(ResetCapabilityWarnings)
+	t.Cleanup(ResetCoverageNotes)
+
+	caps := Capabilities{Target: "cursor", Supports: []spec.Kind{spec.KindRule}}
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindSettings, Name: "s", Meta: map[string]any{"model": "x"}},
+	})
+	if err := ReportUnsupported(caps, b, OnUnsupportedWarn); err != nil {
+		t.Fatal(err)
+	}
+	NoteCoverageGap("aider", spec.KindAgent, 2, "outputs.aider.rules-file")
+	NoteCoverageGap("aider", spec.KindSkill, 1, "source-dir only") // free-text via
+
+	var sb strings.Builder
+	RenderDroppedSummary(&sb)
+	out := sb.String()
+	if !strings.Contains(out, "cursor: 1 settings dropped (unsupported)") {
+		t.Errorf("missing cursor unsupported line: %q", out)
+	}
+	// Config-key via renders "via …"; free-text via renders "in the source dir (…)".
+	if !strings.Contains(out, "2 agents via outputs.aider.rules-file") {
+		t.Errorf("missing config-key downgrade: %q", out)
+	}
+	if !strings.Contains(out, "1 skill in the source dir (source-dir only)") {
+		t.Errorf("missing free-text downgrade wording: %q", out)
+	}
+	// Both aider downgrades collapse onto one line joined by "; ".
+	if !strings.Contains(out, "aider: ") || !strings.Contains(out, "; ") {
+		t.Errorf("expected single joined aider line: %q", out)
+	}
+}
+
+// DroppedByTarget collapses duplicate (target,kind) warnings and
+// (target,kind,via) notes the same way the flushes do, and sorts kinds
+// within a target.
+func TestDroppedByTarget_DedupAndIntraTargetSort(t *testing.T) {
+	ResetCapabilityWarnings()
+	ResetCoverageNotes()
+	t.Cleanup(ResetCapabilityWarnings)
+	t.Cleanup(ResetCoverageNotes)
+
+	caps := Capabilities{Target: "cursor", Supports: []spec.Kind{spec.KindRule}}
+	// Two unsupported kinds out of alphabetical order (settings, hook), each
+	// reported twice to exercise the dedup.
+	b := spec.NewBundle([]spec.Entry{
+		{Kind: spec.KindSettings, Name: "s", Meta: map[string]any{"model": "x"}},
+		{Kind: spec.KindHook, Name: "h", Meta: map[string]any{"event": "PostToolUse"}},
+	})
+	for i := 0; i < 2; i++ {
+		if err := ReportUnsupported(caps, b, OnUnsupportedWarn); err != nil {
+			t.Fatal(err)
+		}
+	}
+	drops := DroppedByTarget()
+	if len(drops) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(drops))
+	}
+	got := drops[0].Unsupported
+	if len(got) != 2 {
+		t.Fatalf("dedup failed: expected 2 distinct kinds, got %d: %+v", len(got), got)
+	}
+	if got[0].Kind != spec.KindHook || got[1].Kind != spec.KindSettings {
+		t.Errorf("intra-target sort wrong: %+v", got)
+	}
+}
+
+func TestRenderDroppedSummary_EmptyWhenNothingBuffered(t *testing.T) {
+	ResetCapabilityWarnings()
+	ResetCoverageNotes()
+	var sb strings.Builder
+	RenderDroppedSummary(&sb)
+	if sb.Len() != 0 {
+		t.Errorf("expected no output, got %q", sb.String())
+	}
+}

--- a/internal/cli/sync_dropped_summary_test.go
+++ b/internal/cli/sync_dropped_summary_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// setupDroppedFixture writes a project with a rule (cursor-supported) and a
+// settings spec (cursor-unsupported, so it buffers a capability warning the
+// per-target summary can report). droppedSummary toggles the opt-in flag.
+func setupDroppedFixture(t *testing.T, droppedSummary bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	must := func(err error) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := "version: 1\ntargets:\n  - cursor\n"
+	if droppedSummary {
+		cfg += "sync:\n  dropped-summary: true\n"
+	}
+	must(os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"), []byte(cfg), 0o644))
+	must(os.MkdirAll(filepath.Join(dir, ".agnostic-ai", "rules"), 0o755))
+	must(os.WriteFile(filepath.Join(dir, ".agnostic-ai", "rules", "r1.md"),
+		[]byte("---\nname: r1\n---\nrule body"), 0o644))
+	must(os.MkdirAll(filepath.Join(dir, ".agnostic-ai", "settings"), 0o755))
+	must(os.WriteFile(filepath.Join(dir, ".agnostic-ai", "settings", "defaults.yaml"),
+		[]byte("model: claude-opus-4-8\n"), 0o644))
+	return dir
+}
+
+// captureLog redirects the package log sink to a buffer at default
+// verbosity for the duration of the test.
+func captureLog(t *testing.T) *strings.Builder {
+	t.Helper()
+	buf := &strings.Builder{}
+	prevOut, prevV := logOut, verbosity
+	logOut = buf
+	verbosity = levelDefault
+	t.Cleanup(func() { logOut, verbosity = prevOut, prevV })
+	return buf
+}
+
+func TestSync_DroppedSummary_RendersWhenEnabled(t *testing.T) {
+	dir := setupDroppedFixture(t, true)
+	testutil.Chdir(t, dir)
+	silence(t)
+	buf := captureLog(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "dropped summary (per target):") {
+		t.Errorf("expected per-target summary, got:\n%s", out)
+	}
+	if !strings.Contains(out, "cursor: 1 settings dropped (unsupported)") {
+		t.Errorf("expected cursor settings drop, got:\n%s", out)
+	}
+}
+
+func TestSync_DroppedSummary_SilentWhenDisabled(t *testing.T) {
+	dir := setupDroppedFixture(t, false)
+	testutil.Chdir(t, dir)
+	silence(t)
+	buf := captureLog(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if strings.Contains(buf.String(), "dropped summary") {
+		t.Errorf("summary must stay silent when the flag is off, got:\n%s", buf.String())
+	}
+}

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -185,7 +185,16 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	digest := adapters.CapabilityWarningsDigest()
 	notesDigest := adapters.CoverageNotesDigest()
 	prev := readStateFile(root)
-	if digest != "" && digest == prev.WarningsDigest {
+	warningsUnchanged := digest != "" && digest == prev.WarningsDigest
+	notesUnchanged := notesDigest != "" && notesDigest == prev.NotesDigest
+	// Render the per-target summary only when at least one of the buffers
+	// actually changed, so it honors the same unchanged-since-last-sync
+	// suppression as the kind-grouped flushes below instead of re-printing
+	// every run. Must run before the flushes clear the buffers.
+	if cfg.Sync.DroppedSummary && verbosity >= levelDefault && !(warningsUnchanged && notesUnchanged) {
+		adapters.RenderDroppedSummary(logOut)
+	}
+	if warningsUnchanged {
 		n := adapters.PendingCapabilityWarningsCount()
 		summaryf("  (%d capability warning%s unchanged since last sync; delete %s to re-show)\n",
 			n, plural(n), stateFilePath(root))
@@ -193,7 +202,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	} else {
 		adapters.FlushCapabilityWarnings()
 	}
-	if notesDigest != "" && notesDigest == prev.NotesDigest {
+	if notesUnchanged {
 		n := adapters.PendingCoverageNotesCount()
 		summaryf("  (%d coverage note%s unchanged since last sync; delete %s to re-show)\n",
 			n, plural(n), stateFilePath(root))

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -191,7 +191,8 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	// actually changed, so it honors the same unchanged-since-last-sync
 	// suppression as the kind-grouped flushes below instead of re-printing
 	// every run. Must run before the flushes clear the buffers.
-	if cfg.Sync.DroppedSummary && verbosity >= levelDefault && !(warningsUnchanged && notesUnchanged) {
+	dropsChanged := !warningsUnchanged || !notesUnchanged
+	if cfg.Sync.DroppedSummary && verbosity >= levelDefault && dropsChanged {
 		adapters.RenderDroppedSummary(logOut)
 	}
 	if warningsUnchanged {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,12 @@ type SyncConfig struct {
 	//               sentinel block that `import` restores to the original @-line
 	// Targets that resolve imports natively (claude) always pass through.
 	ResolveImports string `yaml:"resolve-imports,omitempty" json:"resolve-imports,omitempty"`
+	// DroppedSummary prints a per-target summary after sync listing which
+	// kinds each target could not represent (unsupported) or only emits
+	// behind an opt-in key (downgraded / source-dir only), so the loss is
+	// visible per target rather than grouped by kind. Off by default; the
+	// kind-grouped warnings and coverage notes still print regardless.
+	DroppedSummary bool `yaml:"dropped-summary,omitempty" json:"dropped-summary,omitempty"`
 }
 
 // ProvenanceHeaderEnabled returns whether the named target should write


### PR DESCRIPTION
## Summary
- New `sync.dropped-summary` config (default off): prints a per-target summary of what each target could not fully emit — kinds with no native surface (dropped/unsupported) and kinds reachable only behind an opt-in key or source-dir only (downgraded).
- Regroups the existing kind-grouped capability warnings and coverage notes by target, reading the same buffers read-only (no double-capture).
- Honors the unchanged-since-last-sync digest suppression, so it stays quiet when nothing changed (consistent with the kind-grouped flushes) instead of re-printing every run.

## Test plan
- [x] go test ./... (1255 pass)
- [x] agnostic-ai sync --check (clean), schemagen fresh, gofmt clean
- [x] Adversarial review workflow; fixed the confirmed major (digest-suppression inconsistency) + added CLI wiring test, dedup/sort/source-dir-branch coverage, and stdlib/wording cleanups.

Closes #441