### PR TITLE
fix(emit): deterministic key order for x-<target> and unhinted meta keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 - `sync.dropped-summary` config: opt-in per-target summary of what each target could not fully emit (unsupported kinds dropped, downgraded kinds and the opt-in key that would carry them), regrouping the existing kind-grouped warnings by target. (#441)
 
+### Fixed
+
+- A spec whose `x-<target>` block introduces two or more new frontmatter keys now emits them in a stable alphabetical order. Map-iteration order previously leaked into the emitted bytes, so a clean tree could flip-flop and `sync --check` flagged false drift in CI.
+
 ## v0.40.0 - 2026-06-17
 
 ### Added

--- a/internal/adapters/internal/emit/meta.go
+++ b/internal/adapters/internal/emit/meta.go
@@ -162,14 +162,30 @@ func ResolveMetaOrdered(meta map[string]any, keys []string, target string) (map[
 			appendKV(k, v)
 		}
 	}
-	for k, v := range meta {
+	// Unhinted top-level keys append in alphabetical order. Go map
+	// iteration is randomized, so sort explicitly or the emitted key order
+	// (and thus the file bytes) would vary per run, breaking sync --check.
+	unhinted := make([]string, 0, len(meta))
+	for k := range meta {
 		if walked[k] || strings.HasPrefix(k, XPrefix) || routingKeys[k] || seen[k] {
 			continue
 		}
-		appendKV(k, v)
+		unhinted = append(unhinted, k)
+	}
+	sort.Strings(unhinted)
+	for _, k := range unhinted {
+		appendKV(k, meta[k])
 	}
 	if nested, ok := meta[XPrefix+target].(map[string]any); ok {
-		for nk, nv := range nested {
+		// Same reason: iterate the x-<target> keys in sorted order so the
+		// keys it introduces emit deterministically.
+		nestedKeys := make([]string, 0, len(nested))
+		for nk := range nested {
+			nestedKeys = append(nestedKeys, nk)
+		}
+		sort.Strings(nestedKeys)
+		for _, nk := range nestedKeys {
+			nv := nested[nk]
 			if nv == nil {
 				// nil under x-<target> is a delete marker: drop the key
 				// entirely so the per-target emit reproduces the source

--- a/internal/adapters/internal/emit/meta_test.go
+++ b/internal/adapters/internal/emit/meta_test.go
@@ -5,6 +5,44 @@ import (
 	"testing"
 )
 
+// ResolveMetaOrdered must emit a deterministic key order: unhinted
+// top-level keys and keys introduced by an x-<target> block both append
+// alphabetically, not in Go map-iteration order. A non-deterministic
+// order would vary the emitted frontmatter bytes per run and break
+// sync --check.
+func TestResolveMetaOrdered_DeterministicKeyOrder(t *testing.T) {
+	meta := map[string]any{
+		"name":        "a",
+		"zeta":        "z", // unhinted top-level
+		"alpha":       "a", // unhinted top-level
+		"mike":        "m", // unhinted top-level
+		"x-claude":    map[string]any{"tango": 1, "bravo": 2, "yankee": 3},
+		"description": "d",
+	}
+	// Only `name` is hinted; everything else must order deterministically.
+	hint := []string{"name"}
+
+	_, first := ResolveMetaOrdered(cloneMeta(meta), hint, "claude")
+	for i := 0; i < 50; i++ {
+		_, got := ResolveMetaOrdered(cloneMeta(meta), hint, "claude")
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("non-deterministic key order:\n run0 = %v\n run%d = %v", first, i+1, got)
+		}
+	}
+	want := []string{"name", "alpha", "description", "mike", "zeta", "bravo", "tango", "yankee"}
+	if !reflect.DeepEqual(first, want) {
+		t.Errorf("key order = %v, want %v", first, want)
+	}
+}
+
+func cloneMeta(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func TestResolveMeta_DropsOtherTargets(t *testing.T) {
 	in := map[string]any{
 		"name":     "r1",


### PR DESCRIPTION
## Summary
- `ResolveMetaOrdered` appended unhinted top-level keys and keys introduced by an `x-<target>` block in Go map-iteration (randomized) order, despite its doc promising alphabetical order.
- That random order reached the emitted frontmatter bytes, so a spec with a multi-key `x-<target>` block (e.g. `x-claude: {allowed-tools: [...], disable-model-invocation: true}`) could emit a different byte order each run — making a clean tree flip-flop and `sync --check` report false drift in CI.
- Fix: sort both key sets before appending. Adds a 50-iteration determinism regression test.

Found via an adversarial bug-hunt over the emit layer; verified empirically (output order varied across runs before the fix).

## Test plan
- [x] go test ./... (1256 pass)
- [x] agnostic-ai sync --check (clean), golangci-lint clean, gofmt clean