### PR TITLE
fix(spec): reject path-traversal spec names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Fixed
 
 - A spec whose `x-<target>` block introduces two or more new frontmatter keys now emits them in a stable alphabetical order. Map-iteration order previously leaked into the emitted bytes, so a clean tree could flip-flop and `sync --check` flagged false drift in CI.
+- A spec `name:` containing path separators or `..` is rejected at load instead of being used as an output filename, closing a path traversal that could write files outside the project tree. `sync` also refuses any emitted path that escapes the project root as defense-in-depth.
 
 ## v0.40.0 - 2026-06-17
 

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -240,6 +240,19 @@ func normalizeTrailingNewline(content string) string {
 	return strings.TrimRight(content, "\n") + "\n"
 }
 
+// escapesProjectRoot reports whether a project-relative output path climbs
+// above the project root via `..`. Adapters always emit inside the project,
+// so a relative path that escapes upward signals a traversal (e.g. from a
+// crafted spec `name:` or `scope:`). Defense-in-depth behind the loader's
+// name check; absolute paths are left to the caller.
+func escapesProjectRoot(path string) bool {
+	if filepath.IsAbs(path) {
+		return false
+	}
+	clean := filepath.Clean(path)
+	return clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator))
+}
+
 func writeFileWithMode(path, content string, mode os.FileMode, dryRun bool) error {
 	state.mu.Lock()
 	capturing := state.capturing
@@ -264,6 +277,9 @@ func writeFileWithMode(path, content string, mode os.FileMode, dryRun bool) erro
 	if dryRun {
 		fmt.Printf("--- %s ---\n%s\n", path, content)
 		return nil
+	}
+	if escapesProjectRoot(path) {
+		return fmt.Errorf("refusing to write outside the project root: %s", path)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)

--- a/internal/adapters/internal/emit/emit_test.go
+++ b/internal/adapters/internal/emit/emit_test.go
@@ -9,6 +9,43 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// WriteFile refuses to write a project-relative path that climbs above the
+// project root, the last line of defense against a path traversal from a
+// crafted spec name/scope.
+func TestWriteFile_RefusesProjectRootEscape(t *testing.T) {
+	dir := t.TempDir()
+	testutilChdir(t, dir)
+
+	for _, bad := range []string{"../escape.md", ".opencode/commands/../../../escape.md", ".."} {
+		if err := WriteFile(bad, "x", false); err == nil {
+			t.Errorf("path %q: expected escape rejection, got nil", bad)
+		}
+		// Confirm nothing landed outside the project dir.
+		if _, err := os.Stat(filepath.Join(filepath.Dir(dir), "escape.md")); err == nil {
+			t.Errorf("path %q wrote a file outside the project root", bad)
+		}
+	}
+
+	// A normal in-project path still writes.
+	if err := WriteFile(".cursor/commands/deploy.md", "x", false); err != nil {
+		t.Errorf("safe in-project path rejected: %v", err)
+	}
+}
+
+// testutilChdir changes into dir for the test and restores cwd after, kept
+// local to avoid importing internal/testutil from the emit package.
+func testutilChdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+}
+
 func TestWriteFile_CreatesNestedDirs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "a", "b", "c.txt")

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -602,6 +602,21 @@ func insideFolderSkill(path, root string) bool {
 	}
 }
 
+// checkSpecName rejects a spec name that is not a single safe path
+// segment. Every adapter uses the name as a filename or directory segment
+// in its output, so a value carrying path separators or `..` could make
+// sync write outside the target directory (path traversal). Rejecting it
+// at load fails the run with a clear message instead of emitting an
+// escaping file. A name derived from a filename stem is always safe; the
+// guard matters for an author-supplied `name:` frontmatter value.
+func checkSpecName(name string) error {
+	if name != filepath.Base(name) || name == "." || name == ".." ||
+		strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return fmt.Errorf("invalid spec name %q: must be a single path segment (no %q, %q, or path separators)", name, "/", "..")
+	}
+	return nil
+}
+
 func walkDir(dir, ext string, kind Kind, parse func(string) (Entry, error)) ([]Entry, error) {
 	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
@@ -634,6 +649,9 @@ func walkDir(dir, ext string, kind Kind, parse func(string) (Entry, error)) ([]E
 			} else {
 				entry.Name = strings.TrimSuffix(d.Name(), ext)
 			}
+		}
+		if err := checkSpecName(entry.Name); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
 		}
 		entries = append(entries, entry)
 		return nil

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -223,6 +223,33 @@ func TestLoadAll_ParsesSettingsKind(t *testing.T) {
 	}
 }
 
+// A spec whose frontmatter name carries path separators or `..` is a path
+// traversal: the name becomes a filename/dir segment in every adapter, so
+// the loader rejects it instead of letting sync write outside the tree.
+func TestLoadAll_RejectsPathTraversalName(t *testing.T) {
+	for _, bad := range []string{"../escape", "../../etc/passwd", "a/b", ".."} {
+		dir := t.TempDir()
+		mustWrite(t, filepath.Join(dir, "rules", "r.md"), "---\nname: "+bad+"\n---\nbody")
+		cfg := defaultsForTest()
+		if _, err := LoadAll(dir, cfg); err == nil {
+			t.Errorf("name %q: expected load error, got nil", bad)
+		}
+	}
+}
+
+func TestLoadAll_AcceptsSafeNames(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "rules", "ok.md"), "---\nname: code-style\n---\nbody")
+	cfg := defaultsForTest()
+	entries, err := LoadAll(dir, cfg)
+	if err != nil {
+		t.Fatalf("safe name rejected: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "code-style" {
+		t.Errorf("expected 1 entry named code-style, got %+v", entries)
+	}
+}
+
 func TestLoadAll_MissingDirsAreSkipped(t *testing.T) {
 	dir := t.TempDir()
 	cfg := defaultsForTest()


### PR DESCRIPTION
## Summary
- A spec `name:` is used verbatim as a filename/directory segment by every adapter. A value like `name: ../../../tmp/pwned` made `sync` write a file **outside the project tree** (path traversal) — verified end-to-end (a crafted command spec wrote `/tmp/...` outside the project root).
- Fix: reject any spec name that is not a single safe path segment (no `/`, `\`, or `..`) at load, with a clear error naming the file.
- Defense-in-depth: `emit.WriteFile` now refuses any project-relative output path that climbs above the project root, catching traversals from any source (name, scope, direct Bundle construction).
- The review-`scope` traversal was already guarded; this closes the per-entry `name` vector the bug-hunt surfaced.

## Test plan
- [x] go test ./... (1259 pass) — loader rejection + emit-guard regression tests added
- [x] agnostic-ai sync --check (clean), golangci-lint clean, gofmt clean