### PR TITLE
fix(gemini): honor x-gemini.description override in command TOML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 - A spec whose `x-<target>` block introduces two or more new frontmatter keys now emits them in a stable alphabetical order. Map-iteration order previously leaked into the emitted bytes, so a clean tree could flip-flop and `sync --check` flagged false drift in CI.
 - A spec `name:` containing path separators or `..` is rejected at load instead of being used as an output filename, closing a path traversal that could write files outside the project tree. `sync` also refuses any emitted path that escapes the project root as defense-in-depth.
+- Gemini command/skill/agent TOML now honors an `x-gemini.description` override instead of always emitting the top-level (Claude-side) description, matching how Codex resolves per-target descriptions.
 
 ## v0.40.0 - 2026-06-17
 

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -279,9 +279,15 @@ func emitSkillCommands(skills []spec.Entry, dir string, dryRun bool) error {
 // keys declared under `x-gemini` are emitted verbatim between description
 // and prompt (sorted, target-scoped). See #367.
 func commandTOML(e spec.Entry) string {
+	// Resolve through the per-target meta so an x-gemini.description wins
+	// over the (claude-side) top-level value, matching codex skillMarkdown.
+	// Without this the override is silently dropped (CustomTargetMeta below
+	// excludes description from the pass-through keys).
+	resolved := emit.ResolveMeta(e.Meta, target)
+	desc, _ := resolved["description"].(string)
 	var sb strings.Builder
-	if d := e.Description(); d != "" {
-		emit.WriteTOMLString(&sb, "description", d)
+	if desc != "" {
+		emit.WriteTOMLString(&sb, "description", desc)
 	}
 	if cm, keys := emit.CustomTargetMeta(e.Meta, target, "description", "prompt"); cm != nil {
 		for _, k := range keys {
@@ -290,7 +296,7 @@ func commandTOML(e spec.Entry) string {
 	}
 	body := strings.TrimSpace(e.Body)
 	if body == "" {
-		body = e.Description()
+		body = desc
 	}
 	emit.WriteTOMLMultiline(&sb, "prompt", body)
 	return sb.String()

--- a/internal/adapters/gemini/gemini_test.go
+++ b/internal/adapters/gemini/gemini_test.go
@@ -11,6 +11,26 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
+// An x-gemini.description override must win over the top-level (claude-side)
+// description in the emitted command TOML, mirroring codex skillMarkdown.
+func TestCommandTOML_XGeminiDescriptionWins(t *testing.T) {
+	e := spec.Entry{
+		Kind: spec.KindCommand, Name: "deploy",
+		Meta: map[string]any{
+			"description": "top-level desc",
+			"x-gemini":    map[string]any{"description": "gemini-specific desc"},
+		},
+		Body: "do it",
+	}
+	got := commandTOML(e)
+	if !strings.Contains(got, `description = "gemini-specific desc"`) {
+		t.Errorf("x-gemini.description should win, got:\n%s", got)
+	}
+	if strings.Contains(got, "top-level desc") {
+		t.Errorf("top-level description should be overridden, got:\n%s", got)
+	}
+}
+
 func TestName(t *testing.T) {
 	if got := New().Name(); got != "gemini" {
 		t.Errorf("Name() = %q, want %q", got, "gemini")


### PR DESCRIPTION
## Summary
- `commandTOML` read only the top-level `description` and excluded it from the `x-gemini` pass-through keys, so an `x-gemini.description` override was silently dropped and the Claude-side description emitted instead.
- Fix: resolve the description through `emit.ResolveMeta(e.Meta, target)` first, mirroring `codex` `skillMarkdown` (the #312 pattern). Affects Gemini agents, commands, and skills (all render via `commandTOML`).

Found via the emit-layer bug-hunt.

## Test plan
- [x] go test ./... (1260 pass) — added override unit test
- [x] agnostic-ai sync --check (clean), golangci-lint clean, gofmt clean