### PR TITLE
ref: code-quality cleanup pass (dedup, dead code, shared schema)

### DIFF
--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -43,13 +43,11 @@ type OrderedJSON = emit.OrderedJSON
 // NewOrderedJSON returns an empty OrderedJSON ready for Set / Get.
 func NewOrderedJSON() *OrderedJSON { return emit.NewOrderedJSON() }
 
-// MarshalJSONIndent renders v as indented JSON without HTML escaping,
-// preserving OrderedJSON insertion order when v is an OrderedJSON.
-func MarshalJSONIndent(v any) ([]byte, error) { return emit.MarshalJSONIndent(v) }
-
-// MarshalJSONIndentWith is MarshalJSONIndent with a caller-supplied
-// indent string ("  ", "    ", "\t"). Used by import-side overlay
-// writers that preserve the indent of the captured file.
+// MarshalJSONIndentWith renders v as indented JSON without HTML
+// escaping, with a caller-supplied indent string ("  ", "    ", "\t").
+// Preserves OrderedJSON insertion order when v is an OrderedJSON. Used
+// by import-side overlay writers that preserve the indent of the
+// captured file.
 func MarshalJSONIndentWith(v any, indent string) ([]byte, error) {
 	return emit.MarshalJSONIndentWith(v, indent)
 }
@@ -128,13 +126,6 @@ func StartRecording() { emit.StartRecording() }
 
 // StopRecording returns the recorded paths and disables recording.
 func StopRecording() []string { return emit.StopRecording() }
-
-// StartCounting begins tracking the number of files written to disk.
-// Does not affect IO. Used by sync to record files_changed in the state file.
-func StartCounting() { emit.StartCounting() }
-
-// StopCounting returns the count of files written since StartCounting.
-func StopCounting() int { return emit.StopCounting() }
 
 // StartDetailedRecording begins collecting per-file write results alongside
 // real writes. Determines each file's action (create/update/skip) by
@@ -288,13 +279,6 @@ func RenderTargetOverview(sections []TargetArtifacts) string {
 // any pre-existing block first (re-exported from the emit layer).
 func AppendTargetOverview(body, overview string) string {
 	return emit.AppendTargetOverview(body, overview)
-}
-
-// StripTargetOverview removes the sentinel-marked overview block from
-// body (re-exported from the emit layer). Import uses it so the
-// AGNOSTIC_AI.md round-trip stays lossless.
-func StripTargetOverview(body string) string {
-	return emit.StripTargetOverview(body)
 }
 
 // RulesStartMarker and RulesEndMarker mirror the emit-layer sentinels so

--- a/internal/adapters/aider/capability_parity_test.go
+++ b/internal/adapters/aider/capability_parity_test.go
@@ -1,7 +1,6 @@
 package aider
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +32,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	if !pathSetContains(paths, "CONVENTIONS.md") {
 		t.Fatalf("CONVENTIONS.md not emitted (paths: %v)", paths)
 	}
@@ -123,29 +122,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 3 {
 		t.Errorf("expected 3 capability warnings (hook/command/mcp), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/aider/kitsink_golden_test.go
+++ b/internal/adapters/aider/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package aider
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -51,15 +49,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -89,56 +87,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		// Skip files that belong to the agnostic-ai source tree.
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/amp/amp.go
+++ b/internal/adapters/amp/amp.go
@@ -70,10 +70,8 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
-	for _, s := range b.Skills {
-		if err := emit.WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
-			return err
-		}
+	if err := emit.WriteSkillFolders(b.Skills, target, skillsDir, dryRun); err != nil {
+		return err
 	}
 	if err := emit.EmitLegacyRulesFile(b, cfg, target, emit.MergedOpts{Title: "AGENTS.md"}, dryRun); err != nil {
 		return err

--- a/internal/adapters/amp/capability_parity_test.go
+++ b/internal/adapters/amp/capability_parity_test.go
@@ -1,7 +1,6 @@
 package amp
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -107,29 +106,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
 		t.Errorf("expected 2 capability warnings (hook/settings), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/amp/kitsink_golden_test.go
+++ b/internal/adapters/amp/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package amp
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -45,15 +43,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -83,55 +81,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/antigravity/antigravity.go
+++ b/internal/adapters/antigravity/antigravity.go
@@ -60,10 +60,8 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
-	for _, s := range b.Skills {
-		if err := emit.WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
-			return err
-		}
+	if err := emit.WriteSkillFolders(b.Skills, target, skillsDir, dryRun); err != nil {
+		return err
 	}
 	return emit.EmitLegacyRulesFile(b, cfg, target, emit.MergedOpts{Title: "AGENTS.md"}, dryRun)
 }

--- a/internal/adapters/antigravity/capability_parity_test.go
+++ b/internal/adapters/antigravity/capability_parity_test.go
@@ -1,7 +1,6 @@
 package antigravity
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,7 +28,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -99,29 +98,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 3 {
 		t.Errorf("expected 3 capability warnings (hook/command/mcp), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/antigravity/kitsink_golden_test.go
+++ b/internal/adapters/antigravity/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package antigravity
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -41,15 +39,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -79,55 +77,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/claude/capability_parity_test.go
+++ b/internal/adapters/claude/capability_parity_test.go
@@ -1,7 +1,6 @@
 package claude
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,7 +23,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -72,29 +71,6 @@ func TestEmit_NoCapabilityWarningsForKitSinkBundle(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 0 {
 		t.Errorf("expected no capability warnings for a kit-sink bundle, got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/claude/claude.go
+++ b/internal/adapters/claude/claude.go
@@ -30,6 +30,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/chemaclass/agnostic-ai/internal/adapters/claudehooks"
 	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
@@ -521,7 +522,7 @@ func globsToPaths(globs any) []string {
 func hookSettingsJSONWithOrder(hooks []spec.Entry, preferred []string) *emit.OrderedJSON {
 	doc := emit.NewOrderedJSON()
 	type matcherKey struct{ event, matcher string }
-	byKey := map[matcherKey][]hookCommandEntry{}
+	byKey := map[matcherKey][]claudehooks.CommandEntry{}
 	keyOrder := []matcherKey{}
 	for _, h := range hooks {
 		event, _ := h.Meta["event"].(string)
@@ -545,7 +546,7 @@ func hookSettingsJSONWithOrder(hooks []spec.Entry, preferred []string) *emit.Ord
 			keyOrder = append(keyOrder, k)
 		}
 		for _, cmd := range cmds {
-			byKey[k] = append(byKey[k], hookCommandEntry{
+			byKey[k] = append(byKey[k], claudehooks.CommandEntry{
 				Type:          "command",
 				Command:       emit.RewriteHookPath(cmd, target),
 				Timeout:       timeout,
@@ -558,13 +559,13 @@ func hookSettingsJSONWithOrder(hooks []spec.Entry, preferred []string) *emit.Ord
 			})
 		}
 	}
-	byEvent := map[string][]matcherGroup{}
+	byEvent := map[string][]claudehooks.Group{}
 	eventOrder := []string{}
 	for _, k := range keyOrder {
 		if _, seen := byEvent[k.event]; !seen {
 			eventOrder = append(eventOrder, k.event)
 		}
-		byEvent[k.event] = append(byEvent[k.event], matcherGroup{Matcher: k.matcher, Hooks: byKey[k]})
+		byEvent[k.event] = append(byEvent[k.event], claudehooks.Group{Matcher: k.matcher, Hooks: byKey[k]})
 	}
 	for event, groups := range byEvent {
 		sort.SliceStable(groups, func(i, j int) bool { return groups[i].Matcher < groups[j].Matcher })
@@ -609,36 +610,9 @@ func mergePreferredAndLifecycle(preferred, seen []string) []string {
 	return out
 }
 
-// hookCommandEntry mirrors the `{type, command}` JSON object Claude Code
-// expects inside a matcher group's `hooks` array. Using a struct lets
-// `encoding/json` emit the fields in declaration order rather than the
-// alpha-sorted order map iteration would produce.
-//
-// The optional fields propagate from the same-named spec Meta keys and
-// `omitempty` so specs that don't set them produce the historic minimal
-// `{type, command}` payload. `async`, `asyncRewake`, `shell`, and `if`
-// are current command-hook schema fields; dropping them on emit would
-// silently strip behavior a user authored in settings.json (import
-// captures them for the round-trip).
-type hookCommandEntry struct {
-	Type          string `json:"type"`
-	Command       string `json:"command"`
-	Timeout       int    `json:"timeout,omitempty"`
-	StatusMessage string `json:"statusMessage,omitempty"`
-	Async         bool   `json:"async,omitempty"`
-	AsyncRewake   bool   `json:"asyncRewake,omitempty"`
-	Shell         string `json:"shell,omitempty"`
-	If            string `json:"if,omitempty"`
-	Once          bool   `json:"once,omitempty"`
-}
-
-// matcherGroup mirrors the `{matcher, hooks}` JSON object in
-// settings.json's hook event arrays. Same rationale as
-// hookCommandEntry: ordered struct fields beat sorted map keys.
-type matcherGroup struct {
-	Matcher string             `json:"matcher"`
-	Hooks   []hookCommandEntry `json:"hooks"`
-}
+// The `.claude/settings.json` hook wire structs (matcher groups and
+// command entries) live in internal/adapters/claudehooks so the importer
+// decodes the exact shape this emitter writes.
 
 // hookEventLifecycleOrder names the canonical sequence the Claude Code
 // hooks reference uses when listing hook events. Events that appear in

--- a/internal/adapters/claude/kitsink_golden_test.go
+++ b/internal/adapters/claude/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package claude
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -38,15 +36,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir, "CLAUDE.md"); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -80,55 +78,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if relSlash == "CLAUDE.md" || strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/claudehooks/claudehooks.go
+++ b/internal/adapters/claudehooks/claudehooks.go
@@ -1,0 +1,45 @@
+// Package claudehooks defines the `.claude/settings.json` hooks wire
+// schema shared by the Claude emitter and the `import claude` reader.
+//
+// The emitter (internal/adapters/claude) marshals these structs into the
+// `hooks` block; the importer (internal/cli) unmarshals the same block
+// back into specs. Keeping one definition means a new hook field is added
+// once and survives the round-trip instead of being silently dropped by
+// whichever side was not updated.
+package claudehooks
+
+// CommandEntry mirrors one `{type, command, ...}` object inside a matcher
+// group's `hooks` array. A struct (not a map) makes `encoding/json` emit
+// the fields in declaration order rather than the alpha-sorted order map
+// iteration would produce.
+//
+// The optional fields carry `omitempty` so specs that don't set them
+// produce the historic minimal `{type, command}` payload. `async`,
+// `asyncRewake`, `shell`, and `if` are command-hook schema fields;
+// dropping them on emit would strip behavior a user authored in
+// settings.json (import captures them for the round-trip).
+type CommandEntry struct {
+	Type          string `json:"type"`
+	Command       string `json:"command"`
+	Timeout       int    `json:"timeout,omitempty"`
+	StatusMessage string `json:"statusMessage,omitempty"`
+	Async         bool   `json:"async,omitempty"`
+	AsyncRewake   bool   `json:"asyncRewake,omitempty"`
+	Shell         string `json:"shell,omitempty"`
+	If            string `json:"if,omitempty"`
+	Once          bool   `json:"once,omitempty"`
+}
+
+// Group mirrors one `{matcher, hooks}` object in a settings.json hook
+// event array. Same rationale as CommandEntry: ordered struct fields beat
+// sorted map keys.
+type Group struct {
+	Matcher string         `json:"matcher"`
+	Hooks   []CommandEntry `json:"hooks"`
+}
+
+// Settings is the `.claude/settings.json` subset the importer decodes: the
+// top-level `hooks` map keyed by event name.
+type Settings struct {
+	Hooks map[string][]Group `json:"hooks"`
+}

--- a/internal/adapters/cline/capability_parity_test.go
+++ b/internal/adapters/cline/capability_parity_test.go
@@ -1,7 +1,6 @@
 package cline
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,7 +23,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -88,29 +87,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 3 {
 		t.Errorf("expected 3 capability warnings (hook/command/mcp), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/cline/kitsink_golden_test.go
+++ b/internal/adapters/cline/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package cline
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -38,15 +36,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -76,55 +74,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/codex/capability_parity_test.go
+++ b/internal/adapters/codex/capability_parity_test.go
@@ -1,7 +1,6 @@
 package codex
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -38,7 +37,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 
 	type expect struct {
 		kind     spec.Kind
@@ -89,29 +88,6 @@ func TestEmit_NoCapabilityWarningsForKitSinkBundle(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 0 {
 		t.Errorf("expected no capability warnings for a kit-sink bundle, got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/codex/kitsink_golden_test.go
+++ b/internal/adapters/codex/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package codex
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -50,15 +48,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir, "AGENTS.md"); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -88,57 +86,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		// Skip files that belong to the agnostic-ai source tree or the
-		// project-root AGENTS.md (owned by sync, not the adapter).
-		relSlash := filepath.ToSlash(rel)
-		if relSlash == "AGENTS.md" || strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/continueai/capability_parity_test.go
+++ b/internal/adapters/continueai/capability_parity_test.go
@@ -1,7 +1,6 @@
 package continueai
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,7 +20,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -85,29 +84,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
 		t.Errorf("expected 2 capability warnings (hook/command), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/continueai/kitsink_golden_test.go
+++ b/internal/adapters/continueai/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package continueai
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -37,15 +35,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -75,55 +73,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/copilot/capability_parity_test.go
+++ b/internal/adapters/copilot/capability_parity_test.go
@@ -1,7 +1,6 @@
 package copilot
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,7 +20,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -85,29 +84,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
 		t.Errorf("expected 2 capability warnings (hook/command), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/copilot/copilot.go
+++ b/internal/adapters/copilot/copilot.go
@@ -73,10 +73,8 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
-	for _, s := range b.Skills {
-		if err := emit.WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
-			return err
-		}
+	if err := emit.WriteSkillFolders(b.Skills, target, skillsDir, dryRun); err != nil {
+		return err
 	}
 	if err := emitChatmodes(b, cfg, dryRun); err != nil {
 		return err

--- a/internal/adapters/copilot/kitsink_golden_test.go
+++ b/internal/adapters/copilot/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package copilot
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -37,15 +35,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -75,55 +73,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/crush/capability_parity_test.go
+++ b/internal/adapters/crush/capability_parity_test.go
@@ -1,7 +1,6 @@
 package crush
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,7 +26,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -99,29 +98,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 4 {
 		t.Errorf("expected 4 capability warnings (agent/hook/command/settings), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/crush/crush.go
+++ b/internal/adapters/crush/crush.go
@@ -58,10 +58,8 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
-	for _, s := range b.Skills {
-		if err := emit.WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
-			return err
-		}
+	if err := emit.WriteSkillFolders(b.Skills, target, skillsDir, dryRun); err != nil {
+		return err
 	}
 	return emitMCPConfig(b.MCPs, emit.OutputMCPFile(cfg, target, defaultMCPFile), dryRun)
 }

--- a/internal/adapters/crush/kitsink_golden_test.go
+++ b/internal/adapters/crush/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package crush
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -36,15 +34,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -74,55 +72,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/cursor/capability_parity_test.go
+++ b/internal/adapters/cursor/capability_parity_test.go
@@ -1,7 +1,6 @@
 package cursor
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,7 +22,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -85,29 +84,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 1 {
 		t.Errorf("expected 1 capability warning (settings), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/cursor/kitsink_golden_test.go
+++ b/internal/adapters/cursor/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package cursor
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -37,15 +35,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -75,55 +73,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/gemini/capability_parity_test.go
+++ b/internal/adapters/gemini/capability_parity_test.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -94,29 +93,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 1 {
 		t.Errorf("expected 1 capability warning (review), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/gemini/gemini.go
+++ b/internal/adapters/gemini/gemini.go
@@ -64,10 +64,8 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
-	for _, s := range b.Skills {
-		if err := emit.WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
-			return err
-		}
+	if err := emit.WriteSkillFolders(b.Skills, target, skillsDir, dryRun); err != nil {
+		return err
 	}
 	if emit.EmitSkillsAsCommands(cfg, target) {
 		if err := emitSkillCommands(b.Skills, commandsDir, dryRun); err != nil {

--- a/internal/adapters/gemini/kitsink_golden_test.go
+++ b/internal/adapters/gemini/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package gemini
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -35,15 +33,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -73,55 +71,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/internal/emit/skill_folder.go
+++ b/internal/adapters/internal/emit/skill_folder.go
@@ -51,3 +51,16 @@ func WriteSkillFolder(s spec.Entry, target, skillsDir string, dryRun bool) error
 	}
 	return PropagateSkillAssets(s, folder, SkipSKILLMd, dryRun)
 }
+
+// WriteSkillFolders writes the standard Agent Skills folder layout for
+// every skill into skillsDir. It is the multi-skill form of
+// WriteSkillFolder, shared by the adapters that emit skills through the
+// native folder layout with no per-target customization.
+func WriteSkillFolders(skills []spec.Entry, target, skillsDir string, dryRun bool) error {
+	for _, s := range skills {
+		if err := WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/adapters/junie/capability_parity_test.go
+++ b/internal/adapters/junie/capability_parity_test.go
@@ -1,7 +1,6 @@
 package junie
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,7 +23,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -87,29 +86,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
 		t.Errorf("expected 2 capability warnings (hook/command), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/junie/kitsink_golden_test.go
+++ b/internal/adapters/junie/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package junie
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -32,15 +30,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -70,55 +68,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/kiro/capability_parity_test.go
+++ b/internal/adapters/kiro/capability_parity_test.go
@@ -1,7 +1,6 @@
 package kiro
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,7 +20,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -83,29 +82,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
 		t.Errorf("expected 2 capability warnings (hook/command), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/kiro/kitsink_golden_test.go
+++ b/internal/adapters/kiro/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package kiro
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -32,15 +30,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -70,55 +68,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/opencode/capability_parity_test.go
+++ b/internal/adapters/opencode/capability_parity_test.go
@@ -1,7 +1,6 @@
 package opencode
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -93,29 +92,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
 		t.Errorf("expected 2 capability warnings (hook/settings), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/opencode/kitsink_golden_test.go
+++ b/internal/adapters/opencode/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package opencode
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -35,15 +33,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -73,55 +71,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/opencode/opencode.go
+++ b/internal/adapters/opencode/opencode.go
@@ -72,10 +72,8 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
-	for _, s := range b.Skills {
-		if err := emit.WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
-			return err
-		}
+	if err := emit.WriteSkillFolders(b.Skills, target, skillsDir, dryRun); err != nil {
+		return err
 	}
 	if emit.EmitSkillsAsCommands(cfg, target) {
 		if err := emitSkillCommands(b.Skills, commandsDir, dryRun); err != nil {

--- a/internal/adapters/trae/capability_parity_test.go
+++ b/internal/adapters/trae/capability_parity_test.go
@@ -1,7 +1,6 @@
 package trae
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,7 +22,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -86,29 +85,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 3 {
 		t.Errorf("expected 3 capability warnings (hook/command/mcp), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/trae/kitsink_golden_test.go
+++ b/internal/adapters/trae/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package trae
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -32,15 +30,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -70,55 +68,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/warp/capability_parity_test.go
+++ b/internal/adapters/warp/capability_parity_test.go
@@ -1,7 +1,6 @@
 package warp
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	body := readFile(t, filepath.Join(dir, "AGENTS-rules.md"))
 	type expect struct {
 		kind     spec.Kind
@@ -100,29 +99,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 2 {
 		t.Errorf("expected 2 capability warnings (hook/command), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/warp/kitsink_golden_test.go
+++ b/internal/adapters/warp/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package warp
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -35,15 +33,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -73,55 +71,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/windsurf/capability_parity_test.go
+++ b/internal/adapters/windsurf/capability_parity_test.go
@@ -1,7 +1,6 @@
 package windsurf
 
 import (
-	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,7 +17,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	type expect struct {
 		kind     spec.Kind
 		matchers []string
@@ -76,29 +75,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 3 {
 		t.Errorf("expected 3 capability warnings (hook/command/mcp), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/windsurf/kitsink_golden_test.go
+++ b/internal/adapters/windsurf/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package windsurf
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -32,15 +30,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -70,55 +68,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/zed/capability_parity_test.go
+++ b/internal/adapters/zed/capability_parity_test.go
@@ -1,7 +1,6 @@
 package zed
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ func TestEmit_CapabilityMatrixCoversEveryDeclaredKind(t *testing.T) {
 		t.Fatalf("emit: %v", err)
 	}
 
-	paths := walkRel(t, dir)
+	paths := testutil.WalkRel(t, dir)
 	rulesBody, _ := os.ReadFile(filepath.Join(dir, ".rules"))
 	body := string(rulesBody)
 
@@ -100,29 +99,6 @@ func TestEmit_UnsupportedKindsWarn(t *testing.T) {
 	if got := emit.PendingCapabilityWarningsCount(); got != 1 {
 		t.Errorf("expected 1 capability warning (command), got %d", got)
 	}
-}
-
-func walkRel(t *testing.T, root string) []string {
-	t.Helper()
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		out = append(out, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
-	return out
 }
 
 func pathSetContains(paths []string, needle string) bool {

--- a/internal/adapters/zed/kitsink_golden_test.go
+++ b/internal/adapters/zed/kitsink_golden_test.go
@@ -1,10 +1,8 @@
 package zed
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -32,15 +30,15 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 		if err := os.RemoveAll(expectedDir); err != nil {
 			t.Fatalf("clean expected dir: %v", err)
 		}
-		if err := copyEmittedTree(dir, expectedDir); err != nil {
+		if err := testutil.CopyEmittedTree(dir, expectedDir); err != nil {
 			t.Fatalf("copy: %v", err)
 		}
 		t.Logf("kit-sink golden updated: %s", expectedDir)
 		return
 	}
 
-	got := walkRel(t, dir)
-	want, err := loadKitSinkExpected(expectedDir)
+	got := testutil.WalkRel(t, dir)
+	want, err := testutil.LoadExpectedTree(expectedDir)
 	if err != nil {
 		t.Fatalf("load expected: %v", err)
 	}
@@ -70,55 +68,4 @@ func TestKitSink_GoldenSnapshot(t *testing.T) {
 			t.Errorf("unexpected output file: %s (run UPDATE_GOLDEN=1 to accept)", rel)
 		}
 	}
-}
-
-func loadKitSinkExpected(root string) (map[string]string, error) {
-	out := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		out[filepath.ToSlash(rel)] = string(data)
-		return nil
-	})
-	return out, err
-}
-
-func copyEmittedTree(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		relSlash := filepath.ToSlash(rel)
-		if strings.HasPrefix(relSlash, ".agnostic-ai/") {
-			return nil
-		}
-		dst := filepath.Join(dstDir, rel)
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, data, 0o644)
-	})
 }

--- a/internal/adapters/zed/zed.go
+++ b/internal/adapters/zed/zed.go
@@ -60,10 +60,8 @@ func (Adapter) Emit(b spec.Bundle, cfg *config.Config, dryRun bool) error {
 		return err
 	}
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
-	for _, s := range b.Skills {
-		if err := emit.WriteSkillFolder(s, target, skillsDir, dryRun); err != nil {
-			return err
-		}
+	if err := emit.WriteSkillFolders(b.Skills, target, skillsDir, dryRun); err != nil {
+		return err
 	}
 	// Agents have no per-agent surface in current Zed; only the legacy
 	// merged document carries their bodies.

--- a/internal/cli/import_claude_hooks.go
+++ b/internal/cli/import_claude_hooks.go
@@ -10,28 +10,9 @@ import (
 	"sort"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/claudehooks"
 )
-
-type claudeHookCommand struct {
-	Type          string `json:"type"`
-	Command       string `json:"command"`
-	Timeout       int    `json:"timeout,omitempty"`
-	StatusMessage string `json:"statusMessage,omitempty"`
-	Async         bool   `json:"async,omitempty"`
-	AsyncRewake   bool   `json:"asyncRewake,omitempty"`
-	Shell         string `json:"shell,omitempty"`
-	If            string `json:"if,omitempty"`
-	Once          bool   `json:"once,omitempty"`
-}
-
-type claudeHookGroup struct {
-	Matcher string              `json:"matcher"`
-	Hooks   []claudeHookCommand `json:"hooks"`
-}
-
-type claudeSettings struct {
-	Hooks map[string][]claudeHookGroup `json:"hooks"`
-}
 
 // importClaudeHooks reads .claude/settings.json and writes one yaml per
 // matcher group into dstDir. Filenames come from hookSpecName so the
@@ -50,7 +31,7 @@ func importClaudeHooks(root, dstDir string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("read %s: %w", src, err)
 	}
-	var s claudeSettings
+	var s claudehooks.Settings
 	if err := json.Unmarshal(data, &s); err != nil {
 		return 0, fmt.Errorf("parse %s: %w", src, err)
 	}

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"gopkg.in/yaml.v3"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/claudehooks"
 )
 
 // Codex stores subagents and skills under `.agents/`. Older layouts used
@@ -733,7 +735,9 @@ func mergeCodexHooksJSON(root string, hooks map[codexHookKey]*codexHookSlot) err
 	if err != nil {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
-	var s claudeSettings // identical shape: hooks[<event>][n].{matcher, hooks[m].{...}}
+	// .codex/hooks.json uses the same shape as .claude/settings.json:
+	// hooks[<event>][n].{matcher, hooks[m].{...}}.
+	var s claudehooks.Settings
 	if err := json.Unmarshal(data, &s); err != nil {
 		return fmt.Errorf("parse %s: %w", path, err)
 	}

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -43,6 +43,11 @@ func stateFilePath(projectRoot string) string {
 	return filepath.Join(projectRoot, ".agnostic-ai", ".sync-state")
 }
 
+// readStateFile loads the sync-state cache. A missing or corrupt file
+// yields the zero value on purpose: the state is a self-healing cache the
+// next sync rewrites, so an unreadable one means "no prior state" rather
+// than a fatal error. Mirrors lastSyncTimestamp, which swallows the same
+// read for the same reason.
 func readStateFile(projectRoot string) syncStateFile {
 	var s syncStateFile
 	data, err := os.ReadFile(stateFilePath(projectRoot))

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -1,0 +1,99 @@
+package testutil
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// WalkRel returns every file under root as a slash-form path relative to
+// root, in walk order. Directories are skipped. It fails the test on a
+// walk error.
+func WalkRel(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// LoadExpectedTree reads every file under root into a map keyed by the
+// slash-form path relative to root. It is the loader half of a golden
+// snapshot comparison.
+func LoadExpectedTree(root string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	return out, err
+}
+
+// CopyEmittedTree copies every file under srcDir to dstDir, keeping the
+// relative layout. Files under `.agnostic-ai/` are always skipped: they
+// belong to the source tree, not the emitted output. Any slash-form
+// relative path in skipRel is skipped too, for entry-point files that
+// sync owns rather than the adapter (e.g. CLAUDE.md, AGENTS.md). It
+// backs the UPDATE_GOLDEN=1 refresh path of adapter golden tests.
+func CopyEmittedTree(srcDir, dstDir string, skipRel ...string) error {
+	skip := make(map[string]bool, len(skipRel))
+	for _, s := range skipRel {
+		skip[s] = true
+	}
+	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		relSlash := filepath.ToSlash(rel)
+		if skip[relSlash] || strings.HasPrefix(relSlash, ".agnostic-ai/") {
+			return nil
+		}
+		dst := filepath.Join(dstDir, rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dst, data, 0o644)
+	})
+}


### PR DESCRIPTION
## Summary

Coordinated code-quality sweep across eight dimensions. Four produced high-confidence changes (below); four confirmed the codebase already clean and made no changes (import cycles, weak types, legacy/fallback, comment slop).

Each commit is an independent, output-neutral refactor. Combined: **+269 / −1624**, zero behavior change.

- **`ref(cli): document intentional swallow in readStateFile`** — doc-only. Explains why a corrupt internal-cache `json.Unmarshal` is deliberately swallowed (self-healing; next sync rewrites), matching its sibling `lastSyncTimestamp`.
- **`ref(adapters): remove unused facade wrappers`** — drop 4 dead wrappers in `adapter.go` (`MarshalJSONIndent`, `StartCounting`, `StopCounting`, `StripTargetOverview`), each verified zero consumers across cli + cmd + wasm + tests. Underlying `emit` impls kept (still reachable).
- **`ref(adapters): share Claude settings.json hook schema`** — the Claude hook wire schema was reinvented byte-for-byte across `claude.go`, `import_claude_hooks.go`, and `import_codex_native.go`. Consolidated into a new shared leaf package `internal/adapters/claudehooks/` (mirrors the `header` precedent; respects no-cross-adapter-imports). Emitted `settings.json` byte-identical.
- **`ref(adapters): share skill-folder loop and golden-test scaffolding`** — added `emit.WriteSkillFolders` to collapse an identical skill-emit loop in 7 adapters; lifted byte-identical golden-test helpers (`walkRel`, `loadKitSinkExpected`, `copyEmittedTree`) from 18 adapter test packages into `internal/testutil`. ~1300 lines of duplicated scaffolding removed. Output-neutral.

No CHANGELOG entry: all four are pure refactors with no user-visible change (docs-sync rule skips refactors).

## Test plan
- [x] gofmt / go vet / go build clean
- [x] go test ./... — 1367 passed, 33 packages
- [x] GOOS=js GOARCH=wasm build ok
- [x] agnostic-ai sync --check clean (output-neutral)