### PR TITLE
docs: sync target lists and counts with the 18-adapter registry

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -13,9 +13,11 @@ agnostic-ai/
 │       ├── adapter.go              # Adapter interface + registry
 │       ├── internal/emit/          # shared write helpers (capture/recording/backup, MCP, output paths)
 │       ├── header/                 # provenance-header helper shared across adapters
+│       ├── claudehooks/            # Claude settings.json hook schema (shared by emit + import)
 │       ├── external/               # plugin-protocol passthrough adapter
-│       └── claude/ codex/ gemini/ cursor/ copilot/ aider/ cline/
-│           windsurf/ continueai/ amp/ zed/ warp/ opencode/ antigravity/
+│       └── claude/ codex/ gemini/ cursor/ copilot/ aider/ cline/ windsurf/
+│           continueai/ amp/ zed/ warp/ opencode/ antigravity/ junie/ kiro/
+│           crush/ trae/
 ├── .agnostic-ai/                   # dogfood source specs
 ├── docs/                           # user docs, internal docs, examples
 └── Makefile

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -46,7 +46,7 @@ sources:
   environments: .agnostic-ai/environments
   ignore: .agnostic-ai/ignore
 
-# AI CLIs to emit configs for. These 12 are the default set (used when
+# AI CLIs to emit configs for. These 16 are the default set (used when
 # `targets` is omitted). Two more adapters exist, `amp` and `warp`. They
 # share the root `AGENTS.md` pointer body with `codex` (written once via
 # auto-dedup, since the body is byte-identical), so they add no new
@@ -66,6 +66,10 @@ targets:
   - zed
   - opencode
   - antigravity
+  - junie
+  - kiro
+  - crush
+  - trae
 
 # Per-target output overrides. Each target accepts only the fields
 # relevant to it. Defaults shown in comments. The root entry-point file

--- a/docs/user/errors.md
+++ b/docs/user/errors.md
@@ -60,7 +60,7 @@ The config file was found but could not be parsed as YAML, or its keys do not ma
 
 ### AAI-102: Targets emit to the same output path
 
-Two or more enabled targets would write to the same path (commonly `AGENTS.md`, shared by codex, amp, warp, opencode and zed). Last-writer-wins would mask drift.
+Two or more enabled targets would write to the same path (commonly the root `AGENTS.md`, shared by codex, amp, warp, zed, cline, junie, kiro, crush and trae). Last-writer-wins would mask drift.
 
 **Fix:** drop one colliding target from `targets:` in `agnostic-ai.yaml`, or override the path via `outputs.<target>.file`.
 
@@ -74,7 +74,7 @@ The argument to `agnostic-ai import` matches no registered source.
 
 A target requested via `--target`, `--only`, or the config is not a built-in adapter and no `agnostic-ai-adapter-<name>` binary is on PATH.
 
-**Fix:** check the spelling. Built-ins: `claude`, `codex`, `gemini`, `cursor`, `copilot`, `aider`, `cline`, `windsurf`, `continue`, `amp`, `zed`, `warp`, `opencode`, `antigravity`. External adapters live on PATH as `agnostic-ai-adapter-<name>`.
+**Fix:** check the spelling. Built-ins: `claude`, `codex`, `gemini`, `cursor`, `copilot`, `aider`, `cline`, `windsurf`, `continue`, `amp`, `zed`, `warp`, `opencode`, `antigravity`, `junie`, `kiro`, `crush`, `trae`. External adapters live on PATH as `agnostic-ai-adapter-<name>`.
 
 ### AAI-302: Mutually exclusive flags
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -141,7 +141,7 @@ Full tree after `sync` with the default targets (only files with content are wri
 ├── rules/
 │   └── conventional-commits.md
 ├── .claude/rules/<name>.md                      # for Claude Code (project rules)
-├── AGENTS.md                                    # for Codex / Amp / Warp (shared open standard)
+├── AGENTS.md                                    # shared open standard (Codex / Amp / Warp / Zed / Cline / Junie / Kiro / Crush / Trae)
 ├── .codex/agents/<name>.toml                    # for Codex subagents
 ├── .agents/commands/<name>.md                   # for Amp slash commands
 ├── GEMINI.md                                    # for Gemini CLI

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -233,7 +233,7 @@ Verify with the real CLI:
 ### Cline (`cline`)
 
 ```
-AGENTS.md                            # canonical entry-point pointer body (written by sync, shared with codex/amp/warp/zed)
+AGENTS.md                            # canonical entry-point pointer body (written by sync, shared across the AGENTS.md consumers)
 .clinerules/<name>.md
 .clinerules/workflows/<name>.md      # one per agent, only when workflows-dir is set
 ```
@@ -295,13 +295,13 @@ Verify with the real extension:
 ### Amp (`amp`)
 
 ```
-AGENTS.md                              # canonical entry-point pointer body (written by sync, shared with codex/warp)
+AGENTS.md                              # canonical entry-point pointer body (written by sync, shared across the AGENTS.md consumers)
 .agents/commands/<name>.md             # one per agent
 .agents/skills/<name>/SKILL.md         # one folder per skill (Amp's native skills path)
 .amp/settings.json                     # when MCP entries exist (merged with existing user config)
 ```
 
-- **Rules**: `sync` writes `AGENTS.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline, shared byte-for-byte with codex and warp so the three coexist at the same path.
+- **Rules**: `sync` writes `AGENTS.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline, shared byte-for-byte with codex, warp, zed, and crush so they coexist at the same path.
 - **Skills**: one folder per skill under `.agents/skills/<name>/SKILL.md` (Amp's [native skills layout](https://ampcode.com/manual)). Amp [removed custom slash commands in favor of skills](https://ampcode.com/news/slashing-custom-commands), so skills no longer emit as `.agents/commands/skill-<name>.md`. The SKILL.md frontmatter carries `name` + `description`; sibling assets next to the source SKILL.md are copied byte-for-byte. Arbitrary `x-amp` keys pass through.
 - **Agents**: still emit as custom slash commands under `.agents/commands/<name>.md`. Amp has no documented per-agent file surface after the command removal; this path may be read for back-compat.
 - **Commands**: one markdown file per command spec under `.agents/commands/<name>.md`, the same surface as agents. `description` frontmatter passes through; the body is the prompt template.
@@ -322,14 +322,14 @@ Verify with the real CLI:
 ### Zed (`zed`)
 
 ```
-AGENTS.md                              # canonical entry-point pointer body + inlined rules (written by sync, shared with codex/amp/warp/cline)
-.agents/skills/<name>/SKILL.md         # one folder per skill (shared tree with codex/amp)
+AGENTS.md                              # canonical entry-point pointer body + inlined rules (written by sync, shared across the AGENTS.md consumers)
+.agents/skills/<name>/SKILL.md         # one folder per skill (shared tree with codex/amp/crush)
 .zed/settings.json                     # when MCP entries exist (merged with existing user config)
 .zed/tasks.json                        # one task per hook, only when tasks-file is set
 ```
 
-- **Rules**: Zed 1.4.2 retired its rules library; always-on project instructions are the root `AGENTS.md`. `sync` writes the pointer body plus the sentinel-marked `## Rules` block there, shared byte-for-byte with codex, amp, and warp. Set `outputs.zed.rules-file: .rules` to keep the legacy merged document (which also carries agent bodies) for older Zed versions.
-- **Skills**: native [Zed skills](https://zed.dev/docs/ai/skills) folders at `.agents/skills/<name>/SKILL.md`, the cross-tool path codex and amp emit too. Identical rendered bytes dedupe into one write; divergent `x-zed` overrides surface through the collision check.
+- **Rules**: Zed 1.4.2 retired its rules library; always-on project instructions are the root `AGENTS.md`. `sync` writes the pointer body plus the sentinel-marked `## Rules` block there, shared byte-for-byte with codex, amp, warp, and crush. Set `outputs.zed.rules-file: .rules` to keep the legacy merged document (which also carries agent bodies) for older Zed versions.
+- **Skills**: native [Zed skills](https://zed.dev/docs/ai/skills) folders at `.agents/skills/<name>/SKILL.md`, the cross-tool path codex, amp, and crush emit too. Identical rendered bytes dedupe into one write; divergent `x-zed` overrides surface through the collision check.
 - **Agents**: no per-agent surface in current Zed; sync prints a coverage note unless `outputs.zed.rules-file` is set (the merged document carries agent sections).
 - **MCP**: written into `.zed/settings.json` under `context_servers` (Zed's key, not `mcpServers`). Stdio servers use a flat `command`/`args`/`env` shape; remote (HTTP / SSE) servers use a native `url`/`headers` shape. User-managed keys (theme, buffer_font_size) are preserved.
 - **Hooks**: when `outputs.zed.tasks-file` is set, every hook spec emits as a [Zed Task](https://zed.dev/docs/tasks) using `sh -c "<hook command>"`. The hook name is the label (description appended after an em-dash when present). Zed has no lifecycle-hook surface, so tasks run on demand from the command palette.
@@ -347,12 +347,12 @@ Verify with the real editor:
 ### Warp (`warp`)
 
 ```
-AGENTS.md                              # canonical entry-point pointer body (written by sync, shared with codex/amp)
+AGENTS.md                              # canonical entry-point pointer body (written by sync, shared across the AGENTS.md consumers)
 .warp/workflows/<name>.yaml            # one per agent, only when workflows-dir is set
 .warp/.mcp.json                        # when MCP entries exist
 ```
 
-- **Rules**: `sync` writes `AGENTS.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline, shared byte-for-byte with codex and amp so the three coexist at the same path.
+- **Rules**: `sync` writes `AGENTS.md` with the pointer body plus a sentinel-marked `## Rules` block holding every rule body inline, shared byte-for-byte with codex, amp, zed, and crush so they coexist at the same path.
 - **Workflows**: when `outputs.warp.workflows-dir` is set, each agent emits as a [Warp Workflow](https://docs.warp.dev/features/warp-drive/workflows) YAML at `<dir>/<name>.yaml` (`name`/`command`/`description`/`tags`). The `command:` is the agent body verbatim; tailor it to a Warp-friendly shell snippet.
 - **Legacy rename**: Warp's current Rules docs specify `AGENTS.md` per the AGENTS.md standard. On first sync after upgrading, any agnostic-generated `WARP.md` at the configured root is renamed to `WARP.md.bak`. A user-authored `WARP.md` (no `Generated by agnostic-ai` marker) is left untouched.
 


### PR DESCRIPTION
## Summary

Docs-accuracy audit after the #474 target batch (junie/kiro/crush/trae) and the #483 cleanup. Code, `sync --check`, and 1367 tests are green; these are doc-only corrections where inline examples and per-target claims drifted from the registry.

Fixes:
- **configuration.md** — default-set example said "12" and listed only 12 targets. Now 16, with junie/kiro/crush/trae added (matches `DefaultTargets()`).
- **errors.md** — AAI-301 built-ins list was missing the four new targets (now all 18). AAI-102 collision example named `opencode` as an `AGENTS.md` sharer, but opencode writes its own `.opencode/AGENTS.md`; corrected to the nine root-`AGENTS.md` consumers.
- **targets.md** — amp/zed/warp said "the three coexist" at the root `AGENTS.md`; five inline-rules tools now share it (codex, amp, warp, zed, crush). Generalized the pointer-body tree comments so they stop rotting, and added crush to the `.agents/skills` shared-tree notes.
- **getting-started.md** — `AGENTS.md` tree comment listed 3 of 9 consumers; now all nine.
- **architecture.md** — internal adapter-package tree stopped at antigravity; added junie/kiro/crush/trae and the new `claudehooks/` shared helper (#483).

Verified correct and left unchanged: cli-reference import sources (16, kiro/crush have no importer by design), README counts (18 total / 16 default / 9 AGENTS.md consumers), MCP "13 of 18".

## Test plan
- [x] All 18 targets emit cleanly (268 files); `sync --check` idempotent/clean
- [x] Every corrected count/list checked against the registry, `DefaultTargets()`, `entryPointPaths`, and `inlineRulesTargets`
- [x] No em dashes introduced (plain-english); doc-only, no code touched