### PR TITLE
refactor(cli): dedup sync emission loops and defer recording cleanup

### DIFF
--- a/internal/cli/json_output_test.go
+++ b/internal/cli/json_output_test.go
@@ -149,6 +149,56 @@ func TestSyncJSON_Actions(t *testing.T) {
 	}
 }
 
+// TestSyncJSON_UnknownTargetRecordsError verifies the JSON sync path reports a
+// per-target resolve failure as an error record and keeps emitting the
+// remaining targets instead of aborting the whole run. This pins the shared
+// emitTarget helper's continue-on-failure contract for the JSON path.
+func TestSyncJSON_UnknownTargetRecordsError(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	const bogus = "definitely-not-a-real-target"
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude," + bogus, "--json"})
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("a per-target resolve error must not fail the JSON sync: %v", err)
+	}
+
+	result := assertJSONShape(t, out)
+
+	errRecs, _ := result["errors"].([]any)
+	foundBogus := false
+	for _, e := range errRecs {
+		rec, _ := e.(map[string]any)
+		if target, _ := rec["target"].(string); target == bogus {
+			foundBogus = true
+			if msg, _ := rec["message"].(string); msg == "" {
+				t.Error("error record for the unknown target has an empty message")
+			}
+		}
+	}
+	if !foundBogus {
+		t.Errorf("expected an error record for %q; got: %s", bogus, out.String())
+	}
+
+	// The valid target must still emit: the loop continues past the failure.
+	writes, _ := result["writes"].([]any)
+	foundClaude := false
+	for _, w := range writes {
+		rec, _ := w.(map[string]any)
+		if target, _ := rec["target"].(string); target == "claude" {
+			foundClaude = true
+			break
+		}
+	}
+	if !foundClaude {
+		t.Errorf("expected claude writes despite the unknown target; got: %s", out.String())
+	}
+}
+
 func TestSyncCheckJSON_Shape(t *testing.T) {
 	dir := setupFixture(t)
 	testutil.Chdir(t, dir)

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
 
 // syncStateVersion identifies the on-disk schema of `.agnostic-ai/.sync-state`.
@@ -77,6 +78,26 @@ func writeStateFile(projectRoot string, filesChanged int, warningsDigest, notesD
 	return os.WriteFile(p, data, 0o644)
 }
 
+// emitTarget resolves target t and emits it under detailed recording, shared by
+// the text, dry-run, and JSON sync paths so the resolve+record+emit boilerplate
+// lives in one place. resolved reports whether the adapter resolved, letting
+// callers tell a resolve failure (skippable) from an emit failure (fatal for
+// text sync); writes holds the recorded write events and is empty in dry-run.
+// The recording buffer is always stopped before returning, so no global
+// recording state leaks.
+func emitTarget(t string, b spec.Bundle, cfg *config.Config, dryRun bool) (writes []adapters.WrittenFile, resolved bool, err error) {
+	adapter, err := adapters.Resolve(t)
+	if err != nil {
+		return nil, false, err
+	}
+	adapters.StartDetailedRecording()
+	if err := adapters.EmitWithProvenance(adapter, b, cfg, dryRun); err != nil {
+		adapters.StopDetailedRecording()
+		return nil, true, err
+	}
+	return adapters.StopDetailedRecording(), true, nil
+}
+
 func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFlag string) (retErr error) {
 	start := time.Now()
 	adapters.ResetCapabilityWarnings()
@@ -104,6 +125,10 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
 	if gitignoreOn {
 		adapters.StartRecording()
+		// Safety net for the early returns below: the success path
+		// consumes the recorded paths for the .gitignore block, after
+		// which this deferred call no-ops (StopRecording is idempotent).
+		defer adapters.StopRecording()
 	}
 	if !dryRun {
 		adapters.StartTransaction()
@@ -122,40 +147,34 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	verbose := verbosity >= levelVerbose
 	filesChanged := 0
 	var ledgerSession []string
-	if !dryRun {
-		for _, t := range effectiveTargets {
-			adapter, err := adapters.Resolve(t)
-			if err != nil {
+	for _, t := range effectiveTargets {
+		writes, resolved, err := emitTarget(t, b, cfg, dryRun)
+		if err != nil {
+			if !resolved {
 				fmt.Fprintf(os.Stderr, "! %v\n", err)
 				continue
 			}
-			adapters.StartDetailedRecording()
-			if err := adapters.EmitWithProvenance(adapter, b, cfg, dryRun); err != nil {
-				adapters.StopDetailedRecording()
-				if gitignoreOn {
-					adapters.StopRecording()
-				}
-				return fmt.Errorf("%s: %w", t, err)
-			}
-			writes := adapters.StopDetailedRecording()
-			recordLedgerWrites(writes, &ledgerSession)
-			created, updated, skipped := classifyDetailedWrites(writes)
-			filesChanged += created + updated
-			if verbose {
-				verbosef("→ %s: %d created, %d updated, %d unchanged\n", t, created, updated, skipped)
-			}
+			return fmt.Errorf("%s: %w", t, err)
 		}
-		adapters.StartDetailedRecording()
-		if err := writeAgnosticEntryPoints(cfg, b, effectiveTargets, dryRun); err != nil {
-			adapters.StopDetailedRecording()
-			if gitignoreOn {
-				adapters.StopRecording()
-			}
-			return err
+		if dryRun {
+			continue
 		}
-		writes := adapters.StopDetailedRecording()
 		recordLedgerWrites(writes, &ledgerSession)
-		created, updated, _ := classifyDetailedWrites(writes)
+		created, updated, skipped := classifyDetailedWrites(writes)
+		filesChanged += created + updated
+		if verbose {
+			verbosef("→ %s: %d created, %d updated, %d unchanged\n", t, created, updated, skipped)
+		}
+	}
+	adapters.StartDetailedRecording()
+	if err := writeAgnosticEntryPoints(cfg, b, effectiveTargets, dryRun); err != nil {
+		adapters.StopDetailedRecording()
+		return err
+	}
+	entryWrites := adapters.StopDetailedRecording()
+	if !dryRun {
+		recordLedgerWrites(entryWrites, &ledgerSession)
+		created, updated, _ := classifyDetailedWrites(entryWrites)
 		filesChanged += created + updated
 		// resolveAgnosticBody reads AGNOSTIC_AI.md from disk on
 		// subsequent syncs and skips the re-write, so detailed
@@ -163,26 +182,6 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		// the ledger does not treat the source body as an orphan.
 		if _, err := os.Stat(adapters.AgnosticEntryPointPath); err == nil {
 			ledgerSession = append(ledgerSession, adapters.AgnosticEntryPointPath)
-		}
-	} else {
-		for _, t := range effectiveTargets {
-			adapter, err := adapters.Resolve(t)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "! %v\n", err)
-				continue
-			}
-			if err := adapters.EmitWithProvenance(adapter, b, cfg, dryRun); err != nil {
-				if gitignoreOn {
-					adapters.StopRecording()
-				}
-				return fmt.Errorf("%s: %w", t, err)
-			}
-		}
-		if err := writeAgnosticEntryPoints(cfg, b, effectiveTargets, dryRun); err != nil {
-			if gitignoreOn {
-				adapters.StopRecording()
-			}
-			return err
 		}
 	}
 	applied := shared.apply(dryRun)
@@ -325,24 +324,18 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 	gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
 	if gitignoreOn {
 		adapters.StartRecording()
+		defer adapters.StopRecording()
 	}
 	shared.reconcile(prev.Outputs, dryRun)
 
 	out := jsonOutput{Version: "1", Command: "sync"}
 	var ledgerSession []string
 	for _, t := range effectiveTargets {
-		adapter, err := adapters.Resolve(t)
+		writes, _, err := emitTarget(t, b, cfg, dryRun)
 		if err != nil {
 			out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
 			continue
 		}
-		adapters.StartDetailedRecording()
-		if err := adapters.EmitWithProvenance(adapter, b, cfg, dryRun); err != nil {
-			adapters.StopDetailedRecording()
-			out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
-			continue
-		}
-		writes := adapters.StopDetailedRecording()
 		recordLedgerWrites(writes, &ledgerSession)
 		for _, f := range writes {
 			rec := fileRecord{Target: t, Path: f.Path, Action: f.Action, Bytes: f.Bytes}
@@ -359,9 +352,9 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 		adapters.StopDetailedRecording()
 		out.Errors = append(out.Errors, errorRecord{Target: "agnostic-ai", Message: err.Error()})
 	} else {
-		writes := adapters.StopDetailedRecording()
-		recordLedgerWrites(writes, &ledgerSession)
-		for _, f := range writes {
+		entryWrites := adapters.StopDetailedRecording()
+		recordLedgerWrites(entryWrites, &ledgerSession)
+		for _, f := range entryWrites {
 			rec := fileRecord{Target: "agnostic-ai", Path: f.Path, Action: f.Action, Bytes: f.Bytes}
 			if f.Action == "skip" {
 				out.Skipped = append(out.Skipped, rec)

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -294,6 +294,18 @@ func shortDuration(d time.Duration) string {
 	}
 }
 
+// appendFileRecords sorts each write event into out.Writes or out.Skipped, tagged by target.
+func appendFileRecords(out *jsonOutput, target string, writes []adapters.WrittenFile) {
+	for _, f := range writes {
+		rec := fileRecord{Target: target, Path: f.Path, Action: f.Action, Bytes: f.Bytes}
+		if f.Action == "skip" {
+			out.Skipped = append(out.Skipped, rec)
+		} else {
+			out.Writes = append(out.Writes, rec)
+		}
+	}
+}
+
 // runSyncJSON runs a real sync pass and emits a JSON result describing each
 // file written, updated, or skipped per target.
 func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
@@ -337,14 +349,7 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 			continue
 		}
 		recordLedgerWrites(writes, &ledgerSession)
-		for _, f := range writes {
-			rec := fileRecord{Target: t, Path: f.Path, Action: f.Action, Bytes: f.Bytes}
-			if f.Action == "skip" {
-				out.Skipped = append(out.Skipped, rec)
-			} else {
-				out.Writes = append(out.Writes, rec)
-			}
-		}
+		appendFileRecords(&out, t, writes)
 	}
 
 	adapters.StartDetailedRecording()
@@ -354,14 +359,7 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 	} else {
 		entryWrites := adapters.StopDetailedRecording()
 		recordLedgerWrites(entryWrites, &ledgerSession)
-		for _, f := range entryWrites {
-			rec := fileRecord{Target: "agnostic-ai", Path: f.Path, Action: f.Action, Bytes: f.Bytes}
-			if f.Action == "skip" {
-				out.Skipped = append(out.Skipped, rec)
-			} else {
-				out.Writes = append(out.Writes, rec)
-			}
-		}
+		appendFileRecords(&out, "agnostic-ai", entryWrites)
 		// See runSyncOnce: AGNOSTIC_AI.md is read on subsequent
 		// syncs without going through emit, so register it for the
 		// ledger by hand.


### PR DESCRIPTION
## What

Pure internal refactor of `internal/cli/sync_run.go`. The non-dry, dry-run, and JSON sync paths each re-implemented the same per-target `resolve → StartDetailedRecording → EmitWithProvenance → StopDetailedRecording → record` dance, and the recording teardown was hand-repeated at every early return.

- Extract a single `emitTarget` helper shared by all three paths. It returns `(writes, resolved, err)` so callers can tell a resolve failure (skippable) from an emit failure (fatal for text sync) while keeping the boilerplate in one place.
- Fold the near-identical non-dry and dry-run per-target loops in `runSyncOnce` into one; they differed only in post-emit bookkeeping (guarded by `if dryRun`).
- Replace the four manual `StopRecording()` cleanups with one `defer` per path. `StopRecording` is idempotent, so the deferred call safely no-ops after the success path consumes the buffer for the `.gitignore` block. This also drops the pre-existing dead `if gitignoreOn { StopRecording() }` branches on the dry-run path (unreachable — `gitignoreOn` is always false when `dryRun`).
- Follow-up commit extracts `appendFileRecords` to dedup the JSON skip/write record split.

No new exported surface; `internal/cli/sync_run.go` shrinks by 9 lines net.

## Boundary

Scoped strictly to `internal/cli/sync_run.go` (plus one focused test). No adapter / emit-engine / flag / doc changes. Behavior-neutral, so no CHANGELOG per `docs-sync.md`. No parallelism added (kept serial per the issue's scope guard).

## Test plan

- `gofmt -s -l .`, `go vet ./...`, `golangci-lint run` — all clean.
- `go test ./...` — green across 33 packages, including the golden/integration byte-oracle under `tests/integration`.
- Added `TestSyncJSON_UnknownTargetRecordsError` pinning the JSON path's per-target error records (coverage there was thin): a resolve failure is reported as an `errors[]` record while the remaining targets still emit.
- Output-neutrality proven: built the binary from this branch and from `origin/main`; both report zero drift (`sync --check` exit 0) against the same materialized tree — byte-identical emission across `sync`, `sync --check`, `sync --json`, and `sync --dry-run`.

## Review pass

Final review over the touched file surfaced the copy-pasted JSON write-record formatting (extracted in the follow-up commit). The remaining inline entry-point recording dance is left as-is: it appears in two places but extracting it would net-increase lines against the "net line reduction" criterion, and it sits outside the three per-target emission loops the issue targeted.

Closes #489
