### PR TITLE
perf: add benchmark suite for sync hot paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-race test-shell coverage coverage-html cover lint fmt fmt-check vet preflight tools hooks install clean release playground-build playground-serve playground-clean
+.PHONY: build test test-race test-shell bench coverage coverage-html cover lint fmt fmt-check vet preflight tools hooks install clean release playground-build playground-serve playground-clean
 
 BIN := agnostic-ai
 PKG := ./cmd/agnostic-ai
@@ -18,6 +18,13 @@ test-race:
 
 test-shell:
 	bashunit scripts/release_test.sh
+
+# bench runs the permanent sync-hot-path benchmark suite. It is not part
+# of preflight or CI: benchmarks are for local comparison, not pass/fail.
+# `-run '^$$'` skips the unit tests so only Benchmark* functions run. See
+# docs/internal/benchmarks.md for how to read and extend the suite.
+bench:
+	go test -run '^$$' -bench . -benchmem ./...
 
 lint:
 	golangci-lint run

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -8,6 +8,7 @@
 6. [Contributing a preset](contributing-presets.md): adding an `init --preset <name>` pack.
 7. [Decision log](decisions.md): historical design choices.
 8. [Roadmap](roadmap.md): planned directions.
+9. [Benchmarks](benchmarks.md): permanent sync-hot-path bench suite and how to extend it.
 
 ## House rules
 

--- a/docs/internal/benchmarks.md
+++ b/docs/internal/benchmarks.md
@@ -1,0 +1,79 @@
+# Benchmarks
+
+A permanent benchmark suite covers the `sync` hot paths. It exists so any
+hot-path perf change lands against a measured baseline, per
+[`bench-before-perf-refactor`](../../.agnostic-ai/rules/bench-before-perf-refactor.md).
+The rule blocks refactoring a hot path without a bench, so this suite is a
+prerequisite for the perf work (capture fast-path, parallel emission,
+render memoization).
+
+The benchmarks live in `internal/cli/bench_test.go`, colocated so they can
+call the unexported sync internals directly. Fixtures use `testing` only,
+no external deps.
+
+## Run
+
+```bash
+make bench
+```
+
+That expands to:
+
+```bash
+go test -run '^$' -bench . -benchmem ./...
+```
+
+Target one area or size while iterating:
+
+```bash
+go test -run '^$' -bench BenchmarkSyncEmit -benchmem ./internal/cli/
+go test -run '^$' -bench 'Fingerprint' -benchmem -benchtime=100x ./internal/cli/
+```
+
+Benchmarks are not a CI gate. They report numbers for local comparison,
+not pass or fail.
+
+## What it covers
+
+| Benchmark | Path |
+| --- | --- |
+| `BenchmarkSyncEmit` | Emission loop: resolve every target and render the bundle for it in capture mode (no disk). The CPU core of `sync`. |
+| `BenchmarkSyncFull` | Full end-to-end `sync`: emit to disk with change detection, distribute entry points, reconcile the ledger, write state. Timed as a steady-state re-sync. |
+| `BenchmarkSyncCheck` | The `--check` capture-compare pass against an in-sync tree. |
+| `BenchmarkEntryPointRender` | Entry-point body render plus byte-dedupe across targets. |
+| `BenchmarkFolderFingerprint` | Shared-skills folder fingerprint (`folderFingerprint`). |
+
+## Read the output
+
+```
+BenchmarkSyncEmit/specs=100-14   26   45589017 ns/op   80354676 B/op   317246 allocs/op
+```
+
+- `ns/op`: nanoseconds per call. Divide by 1000 for the `μs/call` the rule
+  asks for.
+- `B/op`, `allocs/op`: bytes and allocations per call, from
+  `b.ReportAllocs()`.
+- `specs=N`: the spec-count parameter. Each fixture holds N rules, N
+  agents, and N skills plus a fixed handful of hooks, MCPs, and commands.
+  The suite sweeps 10, 100, and 500. The end-to-end `BenchmarkSyncFull`
+  stops at 100 to bound disk churn.
+
+Every benchmark builds its fixture, then calls `b.ResetTimer()` so setup
+stays out of the measured region. Fixture content is fixed per index, so
+numbers are comparable across runs on the same machine.
+
+## Three subjects
+
+`BenchmarkFolderFingerprint` follows the "three subjects" shape from the
+rule so a future proposal has a place to slot in:
+
+- `status-quo`: `folderFingerprint`, the production impl. It streams each
+  entry into the digest.
+- `baseline`: `naiveFolderFingerprint`, the direct uncached version that
+  concatenates every entry into one buffer before hashing. It anchors the
+  lower bound.
+
+When you propose a hot-path change, add a third `proposed` sub-benchmark
+next to these two, run all three side by side, and compute the crossover
+before touching the production code. Keep the bench after the proposal
+closes: future runtime or compiler changes can re-measure it cheaply.

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -1,0 +1,419 @@
+package cli
+
+// Permanent benchmark suite for the sync hot paths. See
+// docs/internal/benchmarks.md for how to run and read these, and
+// .agnostic-ai/rules/bench-before-perf-refactor.md for the policy that
+// makes them a prerequisite for any hot-path perf change.
+//
+// Covered paths:
+//   - BenchmarkSyncEmit:          the emission loop over N specs x every
+//     target (capture mode, no disk), the core of `sync`.
+//   - BenchmarkSyncFull:          the full end-to-end `sync` including
+//     disk compare, ledger, and state write (steady-state re-sync).
+//   - BenchmarkSyncCheck:         the `--check` capture-compare pass.
+//   - BenchmarkEntryPointRender:  the entry-point body render plus
+//     byte-dedupe across targets.
+//   - BenchmarkFolderFingerprint: the shared-skills folder fingerprint,
+//     shaped as the rule's "three subjects" (status-quo + naive
+//     baseline) so a future proposal slots a third subject in.
+//
+// Fixtures are deterministic (content fixed per index) so numbers stay
+// comparable across runs. Every benchmark calls b.ReportAllocs() and
+// resets the timer after fixture setup.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// benchSpecCounts parameterizes the spec-scaling benchmarks. Each count
+// is the number of rules, agents, and skills the fixture holds (plus a
+// small fixed set of hooks, MCPs, and commands).
+var benchSpecCounts = []int{10, 100, 500}
+
+// benchFingerprintFileCounts parameterizes the fingerprint benchmark by
+// the number of files in one skill folder.
+var benchFingerprintFileCounts = []int{8, 64, 512}
+
+// benchFixedSpecs is the fixed count of hooks, MCPs, and commands every
+// fixture carries regardless of the spec-count parameter. They exercise
+// the pure-YAML and command loaders without dominating setup time.
+const benchFixedSpecs = 5
+
+// Sinks defeat dead-code elimination of benchmarked calls whose results
+// are otherwise unused. The int/string sinks avoid the interface boxing
+// an `any` sink would add to the per-op allocation count.
+var (
+	benchIntSink    int
+	benchStringSink string
+)
+
+// BenchmarkSyncEmit measures the emission loop: resolve every target and
+// render the whole bundle for it, in capture mode so no bytes touch disk.
+// This is the CPU core of `sync` (sync_run.go emitTarget loop) and the
+// subject a future parallel-emission change would optimize.
+func BenchmarkSyncEmit(b *testing.B) {
+	for _, n := range benchSpecCounts {
+		b.Run(fmt.Sprintf("specs=%d", n), func(b *testing.B) {
+			root := benchProject(b, n)
+			cfg, bundle := benchLoad(b, root)
+			resetBenchBuffers()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := captureRenders(cfg, bundle, cfg.Targets)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchIntSink = len(out)
+			}
+		})
+	}
+}
+
+// BenchmarkSyncFull measures a full end-to-end `sync` re-run: load, emit
+// every target to disk with change detection, distribute entry points,
+// reconcile the ledger, and write state. The fixture is primed with one
+// sync before timing so the measured iterations are the steady-state
+// re-sync (create-then-skip), the common dev and CI path.
+func BenchmarkSyncFull(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		b.Run(fmt.Sprintf("specs=%d", n), func(b *testing.B) {
+			root := benchProject(b, n)
+			benchQuiet(b)
+			benchChdir(b, root)
+			benchIsolateGlobalLayer(b)
+			// Prime once so timed iterations measure the re-sync path.
+			if err := runSyncOnce(".", nil, false, false, "off"); err != nil {
+				b.Fatal(err)
+			}
+			resetBenchBuffers()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := runSyncOnce(".", nil, false, false, "off"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSyncCheck measures the `--check` capture-compare pass: render
+// every target in capture mode and diff each would-be file against disk.
+// The fixture is synced first so the compare hits the in-sync path (the
+// green-CI case) rather than reporting everything missing.
+func BenchmarkSyncCheck(b *testing.B) {
+	for _, n := range benchSpecCounts {
+		b.Run(fmt.Sprintf("specs=%d", n), func(b *testing.B) {
+			root := benchProject(b, n)
+			benchQuiet(b)
+			benchChdir(b, root)
+			benchIsolateGlobalLayer(b)
+			// Prime disk via the check path's own writers so the timed
+			// compare finds every file in sync.
+			reports, err := collectDrift(nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, err := fixDrift(reports, false); err != nil {
+				b.Fatal(err)
+			}
+			resetBenchBuffers()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := collectDrift(nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchIntSink = len(out)
+			}
+		})
+	}
+}
+
+// BenchmarkEntryPointRender measures the entry-point render: build each
+// target's pointer body, apply rule appendices and import modes, and
+// dedupe byte-identical files across targets by path.
+func BenchmarkEntryPointRender(b *testing.B) {
+	for _, n := range benchSpecCounts {
+		b.Run(fmt.Sprintf("specs=%d", n), func(b *testing.B) {
+			root := benchProject(b, n)
+			cfg, bundle := benchLoad(b, root)
+			body := adapters.EntryPointBody(cfg)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := renderEntryPointFiles(cfg, bundle, cfg.Targets, body)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchIntSink = len(out)
+			}
+		})
+	}
+}
+
+// BenchmarkFolderFingerprint measures the shared-skills folder
+// fingerprint. It follows the "three subjects" shape from
+// bench-before-perf-refactor.md:
+//
+//   - status-quo: folderFingerprint, which streams each entry into the
+//     digest with no intermediate buffer.
+//   - baseline:   naiveFolderFingerprint, the direct/uncached version
+//     that concatenates every entry into one buffer before hashing.
+//
+// A future proposal adds a third "proposed" subject and compares all
+// three side by side before changing the production impl.
+func BenchmarkFolderFingerprint(b *testing.B) {
+	for _, n := range benchFingerprintFileCounts {
+		files := benchSkillFolderFiles(n)
+		b.Run(fmt.Sprintf("status-quo/files=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchStringSink = folderFingerprint(files)
+			}
+		})
+		b.Run(fmt.Sprintf("baseline/files=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchStringSink = naiveFolderFingerprint(files)
+			}
+		})
+	}
+}
+
+// naiveFolderFingerprint is the direct/baseline subject for
+// BenchmarkFolderFingerprint. It builds the full sorted concatenation in
+// one buffer, then hashes it in a single pass. It computes the same digest
+// as the streaming folderFingerprint but by way of a full intermediate
+// buffer, so the two differ only in cost profile. Not used in production.
+func naiveFolderFingerprint(files map[string]string) string {
+	rels := make([]string, 0, len(files))
+	for rel := range files {
+		rels = append(rels, rel)
+	}
+	sort.Strings(rels)
+	var sb strings.Builder
+	for _, rel := range rels {
+		sb.WriteString(rel)
+		sb.WriteByte(0)
+		sb.WriteString(files[rel])
+		sb.WriteByte(0)
+	}
+	sum := sha256.Sum256([]byte(sb.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// --- fixture helpers ---
+
+// benchProject writes a deterministic project fixture under a fresh temp
+// dir and returns its root. It holds n rules, n agents, and n skills plus
+// benchFixedSpecs hooks, MCPs, and commands. Every spec's content is fixed
+// by index so bench numbers stay comparable across runs.
+func benchProject(b *testing.B, n int) string {
+	b.Helper()
+	root := b.TempDir()
+	writeBenchFile(b, filepath.Join(root, "agnostic-ai.yaml"), benchConfigYAML())
+	base := filepath.Join(root, config.SourceBaseDir)
+	for i := 0; i < n; i++ {
+		writeBenchFile(b, filepath.Join(base, "rules", fmt.Sprintf("rule-%04d.md", i)), benchRule(i))
+		writeBenchFile(b, filepath.Join(base, "agents", fmt.Sprintf("agent-%04d.md", i)), benchAgent(i))
+		writeBenchFile(b, filepath.Join(base, "skills", fmt.Sprintf("skill-%04d", i), "SKILL.md"), benchSkill(i))
+	}
+	for i := 0; i < benchFixedSpecs; i++ {
+		writeBenchFile(b, filepath.Join(base, "hooks", fmt.Sprintf("hook-%02d.yaml", i)), benchHook(i))
+		writeBenchFile(b, filepath.Join(base, "mcps", fmt.Sprintf("mcp-%02d.yaml", i)), benchMCP(i))
+		writeBenchFile(b, filepath.Join(base, "commands", fmt.Sprintf("command-%02d.md", i)), benchCommand(i))
+	}
+	return root
+}
+
+// benchLoad loads the fixture config and a project-only bundle. It skips
+// resolveLayers on purpose so the user-global and project-user layers
+// never leak host state into the numbers; benchIsolateGlobalLayer covers
+// the paths that load through the CLI instead.
+func benchLoad(b *testing.B, root string) (*config.Config, spec.Bundle) {
+	b.Helper()
+	cfg, err := config.Load(root)
+	if err != nil {
+		b.Fatalf("load config: %v", err)
+	}
+	bundle, err := spec.LoadLayered([]spec.Layer{{
+		Name:    "project",
+		Root:    root,
+		Sources: cfg.Sources,
+	}})
+	if err != nil {
+		b.Fatalf("load bundle: %v", err)
+	}
+	return cfg, bundle
+}
+
+// benchConfigYAML renders a config that enables every registered target
+// and sets prefer-spec so the collision pre-flight is a no-op. The full
+// target set makes the emission loop fan out the way a maximal project
+// would.
+func benchConfigYAML() string {
+	names := adapters.Names()
+	sort.Strings(names)
+	var sb strings.Builder
+	sb.WriteString("version: 1\n")
+	sb.WriteString("sync:\n  collision-policy: prefer-spec\n")
+	sb.WriteString("targets:\n")
+	for _, n := range names {
+		sb.WriteString("  - " + n + "\n")
+	}
+	return sb.String()
+}
+
+func benchRule(i int) string {
+	return fmt.Sprintf(`---
+name: rule-%04d
+description: Bench rule %d for deterministic fixtures.
+globs: "**/*.go"
+alwaysApply: true
+---
+
+Rule %d body. Wrap errors with context so the failing path is obvious.
+Prefer stdlib. Keep one idea per sentence. Fixtures stay byte-stable.
+`, i, i, i)
+}
+
+func benchAgent(i int) string {
+	return fmt.Sprintf(`---
+name: agent-%04d
+description: Bench agent %d for deterministic fixtures.
+tools: [Read, Grep, Bash]
+model: sonnet
+---
+
+Agent %d instructions. Review the diff. Report path:line problem then fix.
+`, i, i, i)
+}
+
+func benchSkill(i int) string {
+	return fmt.Sprintf(`---
+name: skill-%04d
+description: Bench skill %d for deterministic fixtures.
+---
+
+# skill-%04d
+
+Steps: read the target, parse it, report violations. Deterministic body.
+`, i, i, i)
+}
+
+func benchHook(i int) string {
+	return fmt.Sprintf(`name: hook-%02d
+description: Bench hook %d.
+event: PostToolUse
+matcher: "Edit|Write"
+command: "echo hook-%02d"
+`, i, i, i)
+}
+
+func benchMCP(i int) string {
+	return fmt.Sprintf(`name: mcp-%02d
+description: Bench MCP %d.
+command: npx
+args:
+  - -y
+  - "@modelcontextprotocol/server-filesystem"
+  - "."
+`, i, i)
+}
+
+func benchCommand(i int) string {
+	return fmt.Sprintf(`---
+name: command-%02d
+description: Bench command %d.
+---
+
+Command %d body. Deterministic content for stable numbers.
+`, i, i, i)
+}
+
+// benchSkillFolderFiles builds a deterministic rel-path -> content map
+// standing in for one rendered skill folder: a SKILL.md plus n-1 sibling
+// assets. Content is fixed by index so the fingerprint is stable.
+func benchSkillFolderFiles(n int) map[string]string {
+	files := make(map[string]string, n)
+	files["SKILL.md"] = benchSkill(0)
+	for i := 1; i < n; i++ {
+		files[fmt.Sprintf("assets/file-%04d.md", i)] = fmt.Sprintf(
+			"# asset %d\n\nDeterministic asset body for the fingerprint bench.\n", i)
+	}
+	return files
+}
+
+func writeBenchFile(b *testing.B, path, content string) {
+	b.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		b.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		b.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// benchChdir switches into dir for the benchmark and restores the prior
+// working directory on cleanup. The disk-backed sync paths resolve output
+// paths relative to the working directory.
+func benchChdir(b *testing.B, dir string) {
+	b.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		b.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		b.Fatalf("chdir %s: %v", dir, err)
+	}
+	b.Cleanup(func() { _ = os.Chdir(cwd) })
+}
+
+// benchQuiet silences the CLI log sink and capability warner so benchmark
+// output stays clean, restoring both on cleanup.
+func benchQuiet(b *testing.B) {
+	b.Helper()
+	prevVerbosity, prevOut := verbosity, logOut
+	verbosity = levelQuiet
+	logOut = io.Discard
+	adapters.SetWarner(io.Discard)
+	b.Cleanup(func() {
+		verbosity = prevVerbosity
+		logOut = prevOut
+		adapters.SetWarner(os.Stderr)
+	})
+}
+
+// benchIsolateGlobalLayer points the user-global layer at an empty temp
+// dir so host state under ~/.agnostic-ai cannot leak into a benchmark
+// that loads through the CLI (resolveLayers). The dir exists but has no
+// spec subdirs, so the layer contributes nothing.
+func benchIsolateGlobalLayer(b *testing.B) {
+	b.Helper()
+	b.Setenv(envUserGlobalRoot, b.TempDir())
+}
+
+// resetBenchBuffers clears the process-global capability-warning and
+// coverage-note buffers so repeated emit passes do not accumulate across
+// iterations or benchmarks.
+func resetBenchBuffers() {
+	adapters.ResetCapabilityWarnings()
+	adapters.ResetCoverageNotes()
+}


### PR DESCRIPTION
## Summary

Adds a permanent, deterministic benchmark suite over the `sync` hot paths. The `bench-before-perf-refactor` rule blocks refactoring a hot path without a permanent benchmark, and the repo had no `Benchmark*` functions, which self-blocked the queued perf work (capture fast-path, parallel emission, render memoization). This suite gives that work a status-quo baseline.

Test and infra only. No production code changes, so no `CHANGELOG.md` entry (per `docs-sync`, test-only changes skip it).

### What is covered

- `BenchmarkSyncEmit`: emission loop over N specs x every target (capture mode, no disk).
- `BenchmarkSyncFull`: full end-to-end sync re-run (disk compare, ledger, state write; timed as steady-state re-sync).
- `BenchmarkSyncCheck`: the `--check` capture-compare pass against an in-sync tree.
- `BenchmarkEntryPointRender`: entry-point body render plus byte-dedupe across targets.
- `BenchmarkFolderFingerprint`: shared-skills `folderFingerprint`, in the rule's three-subjects shape (status-quo + naive baseline) so a future proposal slots in a `proposed` variant.

Fixtures are deterministic (content fixed per index), parameterized by spec count (10 / 100 / 500), call `b.ReportAllocs()`, and reset the timer after setup. Stdlib `testing` only, no new deps.

### Wiring

- `make bench` target (`go test -run '^$' -bench . -benchmem ./...`).
- `docs/internal/benchmarks.md` note, linked from `docs/internal/README.md`.

The optional non-blocking CI bench job from the issue is left out of this PR (it was marked optional; this keeps the change test/infra only).

## Sample bench output

Apple M4 Pro, `go test -bench . -benchmem -run '^$' ./...`:

```
BenchmarkSyncEmit/specs=100-14                       26     44974141 ns/op    80352742 B/op    317241 allocs/op
BenchmarkSyncCheck/specs=100-14                      12    101845125 ns/op    87961424 B/op    370894 allocs/op
BenchmarkEntryPointRender/specs=500-14             3597       363992 ns/op     2739346 B/op      1556 allocs/op
BenchmarkFolderFingerprint/status-quo/files=512-14 22140        53421 ns/op       49104 B/op       516 allocs/op
BenchmarkFolderFingerprint/baseline/files=512-14   17580        67809 ns/op      268953 B/op        22 allocs/op
```

## Test plan

Gate, all green:

- `gofmt -s -l .` empty
- `go vet ./...`
- `go build ./...`
- `go test ./...` (1368 passed across 33 packages)
- `golangci-lint run ./...` no issues
- `go test -bench . -benchmem -run '^$' ./...` runs clean, exit 0

## Review

Final review pass done over all touched files. Two accuracy refinements (the fingerprint baseline comment and the docs count-range note) were folded into the single commit. No follow-up commit needed.

Closes #485
