### PR TITLE
feat(sync): parallel target emission with --jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ## [Unreleased]
 
+### Added
+
+- `sync --jobs <n>` emits targets in parallel (default: one worker per CPU; `1` forces serial). The emitted tree, summary, JSON, gitignore block, and warnings stay byte-identical regardless of the worker count (#487).
+
 ## v0.43.0 - 2026-07-20
 
 ### Changed

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -237,6 +237,7 @@ agnostic-ai sync [flags]
 | `--watch` | Keep the process alive and re-emit on spec, config, or overlay changes. Watched roots: `agnostic-ai.yaml` + `agnostic-ai.local.yaml`, every `sources.*` directory, `.agnostic-ai.local/`, and `.agnostic-ai/overlays/` (so a hand-edit to `claude.settings.json` / `codex.config.toml` re-emits). Uses OS file events (fsnotify) with a 50 ms debounce; falls back to a 200 ms poll where fsnotify fails. Ctrl+C exits cleanly. Incompatible with `--check`. |
 | `--watch-poll` | Force the polling backend (200 ms) even when fsnotify is available. Use on network mounts or container volumes where fsnotify misses events. Requires `--watch`. |
 | `--all` | Emit every configured target without the first-sync picker. Useful for ad-hoc full emission or scripted runs that bypass prompts. |
+| `--jobs <n>` | Number of targets to emit in parallel. `0` (default) uses one worker per CPU; `1` forces serial emission. Output (files, summary, JSON, gitignore, warnings) is byte-identical regardless of the value, so lower it only to debug or pin ordering. |
 | `--json` | Output as JSON instead of plain text. Stable schema; breaking changes bump `version`. |
 
 ### First-sync target picker
@@ -257,6 +258,7 @@ agnostic-ai sync --except codex        # all configured targets except codex
 agnostic-ai sync --dry-run             # preview
 agnostic-ai sync --check               # CI gate: fail if outputs are stale
 agnostic-ai sync --backup              # leave a .bak trail for revert
+agnostic-ai sync --jobs 1              # force serial emission (default: one worker per CPU)
 agnostic-ai sync --watch               # re-emit on spec changes; Ctrl+C exits
 agnostic-ai sync --json                # machine-readable output
 agnostic-ai sync --check --json        # machine-readable drift report

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -391,6 +391,14 @@ sync:
 - Turning the option off (or a skill starting to diverge) converts links back to real trees on the next sync. Removing a skill sweeps its canonical tree and every link.
 - On filesystems without symlink support (Windows without the privilege), sync warns once and keeps real copies.
 
+### Parallel emission (`--jobs`)
+
+`sync` emits each target on its own worker. The `--jobs <n>` flag bounds how many run at once: `0` (the default) uses one worker per CPU, and `1` forces the old serial path. There is no config-file key; it is a per-run flag on `sync`.
+
+The output never depends on the value. The emitted file tree, the summary counts, the JSON result, the `.gitignore` block, and the capability warnings are byte-identical whether one worker or many ran, so parallelism is safe to leave on. Drop to `--jobs 1` only when you want deterministic goroutine-free ordering for debugging. Targets that write a shared path (the `AGENTS.md` pointer family) are coordinated so exactly one target creates the file and the rest skip it, matching serial emission.
+
+Parallelism helps most on large projects with many targets. On a small spec set or a single target it is close to free either way, since the worker count is capped at the number of targets.
+
 ## `import`
 
 Per-source knobs for the `import` command. Empty blocks fall back to per-source defaults.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/invopop/jsonschema v0.14.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sync v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -41,7 +42,6 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -115,6 +115,21 @@ func CoverageNotesDigest() string { return emit.CoverageNotesDigest() }
 // (target, kind, via) coverage notes currently buffered.
 func PendingCoverageNotesCount() int { return emit.PendingCoverageNotesCount() }
 
+// OrderBufferedDropsByTarget reorders the buffered capability warnings and
+// coverage notes to the given target sequence so their flushed output is
+// deterministic regardless of the order concurrent emission appended them
+// in (sync --jobs > 1). A no-op for serial emission.
+func OrderBufferedDropsByTarget(order []string) { emit.OrderBufferedDropsByTarget(order) }
+
+// SetProvenanceEnabled overrides the process-wide provenance-header toggle
+// and returns the previous value. The parallel sync path pins it per
+// provenance-homogeneous batch so concurrently emitting adapters never
+// observe a half-applied toggle; see internal/adapters/internal/emit/header.go.
+func SetProvenanceEnabled(b bool) bool { return emit.SetProvenanceEnabled(b) }
+
+// ProvenanceEnabled reports the current provenance-header toggle state.
+func ProvenanceEnabled() bool { return emit.ProvenanceEnabled() }
+
 // AgnosticEntryPointPath is the canonical CLI-agnostic entry-point
 // path under .agnostic-ai/ (re-exported from the emit layer for
 // callers in the cli package).

--- a/internal/adapters/internal/emit/drops_order.go
+++ b/internal/adapters/internal/emit/drops_order.go
@@ -1,0 +1,51 @@
+package emit
+
+import "sort"
+
+// OrderBufferedDropsByTarget stable-sorts the buffered capability warnings
+// and coverage notes so their flush output follows the given target order,
+// regardless of the order adapters appended them in.
+//
+// Serial emission already appends in target order, so this is a no-op
+// there. Parallel emission (sync --jobs > 1) interleaves appends across
+// goroutines; re-sorting by target restores the deterministic sequence.
+// The sort is stable, so each target keeps its own append order (kinds in
+// spec.AllKinds order for warnings, skip-site order for notes) — which
+// makes the result byte-identical to the serial buffer. Targets absent
+// from order sort to the end, keeping their relative order.
+//
+// It reorders only: it does not dedupe or clear. The digests already sort
+// internally, so this changes only the human-facing flush and per-target
+// summary output, never the sticky-suppression fingerprints.
+func OrderBufferedDropsByTarget(order []string) {
+	rank := targetRanker(order)
+
+	capabilityWarnState.mu.Lock()
+	sort.SliceStable(capabilityWarnState.pending, func(i, j int) bool {
+		return rank(capabilityWarnState.pending[i].target) < rank(capabilityWarnState.pending[j].target)
+	})
+	capabilityWarnState.mu.Unlock()
+
+	coverageNoteState.mu.Lock()
+	sort.SliceStable(coverageNoteState.pending, func(i, j int) bool {
+		return rank(coverageNoteState.pending[i].target) < rank(coverageNoteState.pending[j].target)
+	})
+	coverageNoteState.mu.Unlock()
+}
+
+// targetRanker returns a function mapping a target name to its index in
+// order, or len(order) when the target is not listed (sorts last).
+func targetRanker(order []string) func(string) int {
+	idx := make(map[string]int, len(order))
+	for i, t := range order {
+		if _, ok := idx[t]; !ok {
+			idx[t] = i
+		}
+	}
+	return func(target string) int {
+		if i, ok := idx[target]; ok {
+			return i
+		}
+		return len(order)
+	}
+}

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -261,6 +261,31 @@ func escapesProjectRoot(path string) bool {
 	return clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator))
 }
 
+// pathLocks serializes concurrent writes to the same output path across
+// sessions. Parallel sync (`--jobs > 1`) emits every target on its own
+// Session, but several targets legitimately write the SAME shared path
+// (e.g. the AGENTS.md family of pointer files). Without coordination two
+// targets race the read-classify-write critical section below: both observe
+// the path missing, both classify a "create", both log a rollback entry,
+// and both call os.WriteFile. A per-path mutex makes exactly one target
+// create the file and the rest observe it present with identical content
+// and skip — matching serial emission, keeping the transaction log free of
+// duplicate entries, and never tearing a half-written file.
+//
+// This is pure write coordination, not shared business state: the map holds
+// one mutex per distinct path for the process lifetime (bounded by the
+// output tree, freed on exit) and carries no data of its own.
+var pathLocks sync.Map // map[string]*sync.Mutex
+
+// lockPath acquires the write mutex for path (keyed by its cleaned form so
+// spellings of the same file coincide) and returns the unlock func.
+func lockPath(path string) func() {
+	m, _ := pathLocks.LoadOrStore(filepath.Clean(path), &sync.Mutex{})
+	mu := m.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
 func (s *Session) writeFileWithMode(path, content string, mode os.FileMode, dryRun bool) error {
 	s.mu.Lock()
 	capturing := s.capturing
@@ -289,6 +314,13 @@ func (s *Session) writeFileWithMode(path, content string, mode os.FileMode, dryR
 	if escapesProjectRoot(path) {
 		return fmt.Errorf("refusing to write outside the project root: %s", path)
 	}
+	// Serialize the read-classify-write below against any other session
+	// targeting the same path so concurrent emitters cannot both see it
+	// missing. Held until the write and its rollback/detail bookkeeping
+	// complete. Ordering is always pathLock (outer) then s.mu (inner); the
+	// early s.mu section above has already been released, so no goroutine
+	// holds s.mu while acquiring a path lock and the two never deadlock.
+	defer lockPath(path)()
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -87,26 +87,41 @@ func BenchmarkSyncEmit(b *testing.B) {
 // reconcile the ledger, and write state. The fixture is primed with one
 // sync before timing so the measured iterations are the steady-state
 // re-sync (create-then-skip), the common dev and CI path.
+//
+// Each spec count runs twice — serial (--jobs 1) and parallel (--jobs 0 =
+// one worker per CPU) — so the two subjects sit side by side per
+// bench-before-perf-refactor.md and the parallel-emission crossover
+// (the spec count where fan-out beats serial) is read straight off the
+// numbers.
 func BenchmarkSyncFull(b *testing.B) {
+	jobsCases := []struct {
+		name string
+		jobs int
+	}{
+		{"serial", 1},   // status-quo: today's sequential emission
+		{"parallel", 0}, // proposed: bounded fan-out, one worker per CPU
+	}
 	for _, n := range []int{10, 100} {
-		b.Run(fmt.Sprintf("specs=%d", n), func(b *testing.B) {
-			root := benchProject(b, n)
-			benchQuiet(b)
-			benchChdir(b, root)
-			benchIsolateGlobalLayer(b)
-			// Prime once so timed iterations measure the re-sync path.
-			if err := runSyncOnce(".", nil, false, false, "off"); err != nil {
-				b.Fatal(err)
-			}
-			resetBenchBuffers()
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if err := runSyncOnce(".", nil, false, false, "off"); err != nil {
+		for _, jc := range jobsCases {
+			b.Run(fmt.Sprintf("specs=%d/%s", n, jc.name), func(b *testing.B) {
+				root := benchProject(b, n)
+				benchQuiet(b)
+				benchChdir(b, root)
+				benchIsolateGlobalLayer(b)
+				// Prime once so timed iterations measure the re-sync path.
+				if err := runSyncOnce(".", nil, false, false, "off", jc.jobs); err != nil {
 					b.Fatal(err)
 				}
-			}
-		})
+				resetBenchBuffers()
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if err := runSyncOnce(".", nil, false, false, "off", jc.jobs); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -17,6 +17,7 @@ func newSyncCmd() *cobra.Command {
 	var targets, only, except []string
 	var dryRun, check, plan, backup, watch, watchPoll, jsonOut, allTargets bool
 	var gitignoreFlag string
+	var jobs int
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -106,12 +107,12 @@ func newSyncCmd() *cobra.Command {
 			if watch {
 				ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 				defer stop()
-				return watchSync(ctx, 200*time.Millisecond, ".", effective, dryRun, backup, gitignoreFlag, watchPoll)
+				return watchSync(ctx, 200*time.Millisecond, ".", effective, dryRun, backup, gitignoreFlag, watchPoll, jobs)
 			}
 			if jsonOut {
-				return runSyncJSON(cmd, ".", effective, dryRun, backup, gitignoreFlag)
+				return runSyncJSON(cmd, ".", effective, dryRun, backup, gitignoreFlag, jobs)
 			}
-			return runSyncOnce(".", effective, dryRun, backup, gitignoreFlag)
+			return runSyncOnce(".", effective, dryRun, backup, gitignoreFlag, jobs)
 		},
 	}
 	cmd.Flags().StringSliceVarP(&targets, "target", "t", nil, "Targets to emit (default: all in config)")
@@ -126,6 +127,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&watchPoll, "watch-poll", false, "Force polling instead of fsnotify (use on filesystems where fsnotify is unreliable, e.g. some network mounts)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for machine consumption")
 	cmd.Flags().BoolVar(&allTargets, "all", false, "Sync every configured target without prompting (skip the first-sync target picker)")
+	cmd.Flags().IntVar(&jobs, "jobs", 0, "Number of targets to emit in parallel (0 = one per CPU; 1 = serial). Output is identical regardless.")
 	registerTargetCompletion(cmd)
 	return cmd
 }

--- a/internal/cli/sync_parallel_test.go
+++ b/internal/cli/sync_parallel_test.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// writeParallelFixture writes a project that fans out to every registered
+// target and carries a spread of spec kinds — including kinds several
+// targets do not emit (settings, environments) so capability warnings and
+// coverage notes buffer during emission. Their flushed ordering is the
+// output most exposed to goroutine scheduling, so it belongs in every
+// determinism assertion. extraConfig is appended verbatim under the config
+// root (e.g. per-target provenance opt-outs).
+func writeParallelFixture(t *testing.T, dir, extraConfig string) {
+	t.Helper()
+	must := func(err error) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeSpec := func(rel, content string) {
+		p := filepath.Join(dir, ".agnostic-ai", rel)
+		must(os.MkdirAll(filepath.Dir(p), 0o755))
+		must(os.WriteFile(p, []byte(content), 0o644))
+	}
+
+	names := adapters.Names()
+	sort.Strings(names)
+	var cfg strings.Builder
+	cfg.WriteString("version: 1\n")
+	cfg.WriteString("sync:\n  dropped-summary: true\n  collision-policy: prefer-spec\n")
+	cfg.WriteString("targets:\n")
+	for _, n := range names {
+		cfg.WriteString("  - " + n + "\n")
+	}
+	cfg.WriteString(extraConfig)
+	must(os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"), []byte(cfg.String()), 0o644))
+
+	for i := 0; i < 6; i++ {
+		writeSpec(fmt.Sprintf("rules/rule-%d.md", i),
+			fmt.Sprintf("---\nname: rule-%d\ndescription: Rule %d.\nglobs: \"**/*.go\"\n---\nRule %d body. Keep it deterministic.\n", i, i, i))
+		writeSpec(fmt.Sprintf("agents/agent-%d.md", i),
+			fmt.Sprintf("---\nname: agent-%d\ndescription: Agent %d.\n---\nAgent %d body. Review then report.\n", i, i, i))
+		writeSpec(fmt.Sprintf("skills/skill-%d/SKILL.md", i),
+			fmt.Sprintf("---\nname: skill-%d\ndescription: Skill %d.\n---\n# skill-%d\n\nDeterministic skill body.\n", i, i, i))
+	}
+	// Kinds that not every target supports, so warnings and notes buffer.
+	writeSpec("settings/defaults.yaml", "model: claude-opus-4-8\ntemperature: 0.2\n")
+	writeSpec("environments/dev.yaml", "name: dev\nvalues:\n  FOO: bar\n")
+	writeSpec("commands/deploy.md", "---\nname: deploy\ndescription: Deploy command.\n---\nRun the deploy.\n")
+}
+
+var durationToken = regexp.MustCompile(`\d+(\.\d+)?(µs|ms|s)\b`)
+
+// syncOutputAt runs a full `sync --jobs jobs` in a fresh copy of the
+// fixture and returns the normalized human output (summary sink + flushed
+// capability warnings) and the emitted file tree. The elapsed-time token
+// in the summary is normalized so only order-sensitive content is
+// compared. extraConfig lets a caller vary per-target settings.
+func syncOutputAt(t *testing.T, jobs int, extraConfig string) (string, map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	writeParallelFixture(t, dir, extraConfig)
+	testutil.Chdir(t, dir)
+
+	logBuf := &strings.Builder{}
+	warnBuf := &strings.Builder{}
+	prevOut, prevV := logOut, verbosity
+	logOut = logBuf
+	verbosity = levelDefault
+	adapters.SetWarner(warnBuf)
+	defer func() {
+		logOut, verbosity = prevOut, prevV
+		adapters.SetWarner(os.Stderr)
+	}()
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--gitignore", "on", "--jobs", strconv.Itoa(jobs)})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync --jobs %d: %v", jobs, err)
+	}
+	out := durationToken.ReplaceAllString(logBuf.String()+"\n"+warnBuf.String(), "DUR")
+	return out, snapshotTree(t, dir)
+}
+
+// snapshotTree returns every emitted file under dir keyed by its path
+// relative to dir, skipping the sync-state cache (it carries a wall-clock
+// timestamp that legitimately differs run to run).
+func snapshotTree(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	tree := map[string]string{}
+	stateRel := filepath.Join(".agnostic-ai", ".sync-state")
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == stateRel {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		tree[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return tree
+}
+
+// assertSameTree fails with the first divergent path when two emitted
+// trees are not byte-identical.
+func assertSameTree(t *testing.T, label string, a, b map[string]string) {
+	t.Helper()
+	for rel, ca := range a {
+		cb, ok := b[rel]
+		if !ok {
+			t.Errorf("%s: path %q present in serial tree, missing in parallel tree", label, rel)
+			continue
+		}
+		if ca != cb {
+			t.Errorf("%s: content differs for %q\n--- serial ---\n%s\n--- parallel ---\n%s", label, rel, ca, cb)
+		}
+	}
+	for rel := range b {
+		if _, ok := a[rel]; !ok {
+			t.Errorf("%s: path %q present in parallel tree, missing in serial tree", label, rel)
+		}
+	}
+}
+
+// TestSync_ParallelEmission_DeterministicTreeAndSummary pins the core
+// guarantee of --jobs: the emitted file tree, the summary, and the flushed
+// capability warnings are identical whether one worker or eight ran the
+// per-target emits. Run under -race it also exercises the concurrent emit
+// path across every target on its own session.
+func TestSync_ParallelEmission_DeterministicTreeAndSummary(t *testing.T) {
+	out1, tree1 := syncOutputAt(t, 1, "")
+	out8, tree8 := syncOutputAt(t, 8, "")
+
+	if out1 != out8 {
+		t.Errorf("human output differs between --jobs 1 and --jobs 8:\n=== jobs=1 ===\n%s\n=== jobs=8 ===\n%s", out1, out8)
+	}
+	assertSameTree(t, "jobs1-vs-jobs8", tree1, tree8)
+}
+
+// TestSync_ParallelEmission_MixedProvenance covers the one emit-time global
+// adapters still share: the provenance-header toggle. Half the targets opt
+// out, so concurrent emission must batch by setting or a target's header
+// bleeds into another's files. The parallel tree must still match serial.
+func TestSync_ParallelEmission_MixedProvenance(t *testing.T) {
+	names := adapters.Names()
+	sort.Strings(names)
+	var extra strings.Builder
+	extra.WriteString("outputs:\n")
+	for i, n := range names {
+		if i%2 == 0 {
+			extra.WriteString("  " + n + ":\n    provenance-header: false\n")
+		}
+	}
+	cfg := extra.String()
+
+	_, tree1 := syncOutputAt(t, 1, cfg)
+	_, tree8 := syncOutputAt(t, 8, cfg)
+	assertSameTree(t, "mixed-provenance", tree1, tree8)
+}
+
+// TestSync_ParallelEmission_DeterministicJSON pins the JSON result: the
+// per-target writes / skipped / errors must appear in the same stable
+// order regardless of --jobs.
+func TestSync_ParallelEmission_DeterministicJSON(t *testing.T) {
+	runJSON := func(jobs int) string {
+		dir := t.TempDir()
+		writeParallelFixture(t, dir, "")
+		testutil.Chdir(t, dir)
+		adapters.SetWarner(io.Discard)
+		defer adapters.SetWarner(os.Stderr)
+
+		buf := &strings.Builder{}
+		root := NewRootCmd("test")
+		root.SetArgs([]string{"sync", "--json", "--gitignore", "on", "--jobs", strconv.Itoa(jobs)})
+		root.SetOut(buf)
+		root.SetErr(io.Discard)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("sync --json --jobs %d: %v", jobs, err)
+		}
+		return buf.String()
+	}
+
+	if got1, got8 := runJSON(1), runJSON(8); got1 != got8 {
+		t.Errorf("JSON output differs between --jobs 1 and --jobs 8:\n=== jobs=1 ===\n%s\n=== jobs=8 ===\n%s", got1, got8)
+	}
+}
+
+// TestSync_ParallelEmission_MoreWorkersThanTargets stresses the worker
+// bound above the target count and confirms the run still succeeds and
+// stays byte-identical to serial. Meaningful under -race.
+func TestSync_ParallelEmission_MoreWorkersThanTargets(t *testing.T) {
+	_, treeSerial := syncOutputAt(t, 1, "")
+	_, treeMany := syncOutputAt(t, 64, "")
+	assertSameTree(t, "jobs1-vs-jobs64", treeSerial, treeMany)
+}
+
+// TestResolveJobs checks the flag-to-worker mapping in isolation.
+func TestResolveJobs(t *testing.T) {
+	if got := resolveJobs(0, 8); got < 1 {
+		t.Errorf("resolveJobs(0, 8) = %d, want >= 1 (NumCPU)", got)
+	}
+	if got := resolveJobs(1, 8); got != 1 {
+		t.Errorf("resolveJobs(1, 8) = %d, want 1 (serial)", got)
+	}
+	if got := resolveJobs(16, 4); got != 4 {
+		t.Errorf("resolveJobs(16, 4) = %d, want 4 (capped at target count)", got)
+	}
+	if got := resolveJobs(-3, 8); got < 1 {
+		t.Errorf("resolveJobs(-3, 8) = %d, want >= 1", got)
+	}
+	if got := resolveJobs(0, 0); got != 1 {
+		t.Errorf("resolveJobs(0, 0) = %d, want 1 (no targets floors at 1)", got)
+	}
+}

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -1,14 +1,18 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
@@ -98,9 +102,216 @@ func emitTarget(sess *adapters.Session, t string, b spec.Bundle, cfg *config.Con
 	return sess.StopDetailedRecording(), true, nil
 }
 
-func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFlag string) (retErr error) {
+// targetEmit is one target's emission result. Collecting these lets the
+// serial post-emission phase process targets in stable order, so output
+// stays deterministic regardless of how many workers ran the emits.
+type targetEmit struct {
+	target   string
+	writes   []adapters.WrittenFile
+	recorded []string // gitignore paths; empty unless gitignore recording is on
+	resolved bool     // false when the adapter could not be resolved (skippable)
+	err      error
+}
+
+// resolveJobs maps the --jobs flag to a worker count: 0 or negative means
+// runtime.NumCPU(). The count is capped at the target count (idle workers
+// buy nothing) and floored at 1.
+func resolveJobs(jobs, targets int) int {
+	if jobs <= 0 {
+		jobs = runtime.NumCPU()
+	}
+	if jobs > targets {
+		jobs = targets
+	}
+	if jobs < 1 {
+		jobs = 1
+	}
+	return jobs
+}
+
+// provenanceBatch is a set of target indices that share one
+// provenance-header setting, run together so the process-global toggle is
+// constant while they emit concurrently.
+type provenanceBatch struct {
+	provenance bool
+	indices    []int
+}
+
+// provenanceBatches partitions target indices by their provenance-header
+// setting, preserving target order within each batch. Concurrent emission
+// runs one batch at a time and pins the toggle to the batch's value, so no
+// target sees another's setting through the shared global (see
+// internal/adapters/internal/emit/header.go). The common case — every
+// target on the default — is a single batch, i.e. full fan-out.
+func provenanceBatches(cfg *config.Config, targets []string) []provenanceBatch {
+	var on, off []int
+	for i, t := range targets {
+		if cfg.ProvenanceHeaderEnabled(t) {
+			on = append(on, i)
+		} else {
+			off = append(off, i)
+		}
+	}
+	var batches []provenanceBatch
+	if len(on) > 0 {
+		batches = append(batches, provenanceBatch{provenance: true, indices: on})
+	}
+	if len(off) > 0 {
+		batches = append(batches, provenanceBatch{provenance: false, indices: off})
+	}
+	return batches
+}
+
+// emitTargetsConcurrent emits every target on its own emit.Session with
+// bounded parallelism (jobs workers), returning the per-target results in
+// the SAME order as targets so downstream processing is deterministic
+// regardless of --jobs. Each target owns its Session, so the per-target
+// detailed-recording, gitignore-recording, and transaction buffers never
+// cross-talk; the returned sessions (target order) carry the transaction
+// logs the caller commits or rolls back.
+//
+// Targets run in provenance-homogeneous batches so the one emit-time
+// process global adapters still share — the provenance-header toggle — is
+// constant for every concurrently-running target.
+//
+// With failFast set, the first emit error cancels the group and is
+// returned wrapped with its target (`<target>: <err>`); resolve failures
+// (unknown target) stay non-fatal and ride along in the result. Without
+// it, every target runs to completion and all errors ride along in the
+// results — the JSON path, which reports per-target errors rather than
+// aborting the whole sync.
+func emitTargetsConcurrent(targets []string, b spec.Bundle, cfg *config.Config, dryRun, backup, gitignoreOn, failFast bool, jobs int) ([]targetEmit, []*adapters.Session, error) {
+	results := make([]targetEmit, len(targets))
+	sessions := make([]*adapters.Session, len(targets))
+	for i, t := range targets {
+		results[i] = targetEmit{target: t}
+	}
+	workers := resolveJobs(jobs, len(targets))
+
+	// Pin/restore the shared provenance toggle around the whole phase so
+	// the serial post-emission writers (entry points) see the prior value.
+	orig := adapters.ProvenanceEnabled()
+	defer adapters.SetProvenanceEnabled(orig)
+
+	var firstErr error
+	for _, batch := range provenanceBatches(cfg, targets) {
+		adapters.SetProvenanceEnabled(batch.provenance)
+		g, ctx := errgroup.WithContext(context.Background())
+		g.SetLimit(workers)
+		for _, idx := range batch.indices {
+			idx := idx
+			g.Go(func() error {
+				if failFast && ctx.Err() != nil {
+					return nil // group already failing; do not start new work
+				}
+				sess := adapters.NewSession()
+				sessions[idx] = sess
+				if backup {
+					sess.SetBackup(true)
+				}
+				if !dryRun {
+					sess.StartTransaction()
+				}
+				if gitignoreOn {
+					sess.StartRecording()
+				}
+				writes, resolved, err := emitTarget(sess, targets[idx], b, cfg, dryRun)
+				var recorded []string
+				if gitignoreOn {
+					recorded = sess.StopRecording()
+				}
+				results[idx] = targetEmit{target: targets[idx], writes: writes, recorded: recorded, resolved: resolved, err: err}
+				if failFast && err != nil && resolved {
+					return fmt.Errorf("%s: %w", targets[idx], err)
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if failFast {
+				break
+			}
+		}
+	}
+	return results, sessions, firstErr
+}
+
+// rollbackSessions undoes the writes recorded across every session, latest
+// phase first: sessions are appended in write order (targets, then the
+// serial entry-point session), so reverse iteration restores a path an
+// entry point overwrote before the target-level create is undone. Errors
+// are joined.
+func rollbackSessions(sessions []*adapters.Session) error {
+	var errs []error
+	for i := len(sessions) - 1; i >= 0; i-- {
+		if sessions[i] == nil {
+			continue
+		}
+		if err := sessions[i].Rollback(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// commitSessions releases the transaction log on every session. Order is
+// irrelevant: Commit only clears state.
+func commitSessions(sessions []*adapters.Session) {
+	for _, s := range sessions {
+		if s != nil {
+			s.Commit()
+		}
+	}
+}
+
+// normalizeSharedWriteAttribution makes the create/update/skip action for a
+// path several targets write deterministic regardless of --jobs. The emit
+// layer's per-path lock already guarantees exactly one target creates or
+// updates a shared path and the rest skip it, but WHICH target won the write
+// depends on goroutine scheduling. Serial emission always credits the
+// create/update to the first target in target order and skips the rest, so
+// reassign the non-skip action to the earliest target (emits is in stable
+// target order) and force every later occurrence of the path to "skip".
+//
+// The sharing targets wrote byte-identical content — a genuine content
+// conflict on one path is caught earlier by collision detection — so this
+// relabels bookkeeping only; it never changes bytes on disk, the total
+// created+updated count, or the ledger's path set.
+func normalizeSharedWriteAttribution(emits []targetEmit) {
+	// winning[path] is the non-skip action some target recorded for path.
+	// A path absent here was skipped by every target, so its attribution is
+	// already order-independent and left untouched.
+	winning := map[string]string{}
+	for i := range emits {
+		for _, w := range emits[i].writes {
+			if w.Action != "skip" {
+				winning[w.Path] = w.Action
+			}
+		}
+	}
+	claimed := map[string]bool{}
+	for i := range emits {
+		for j := range emits[i].writes {
+			w := &emits[i].writes[j]
+			act, ok := winning[w.Path]
+			if !ok {
+				continue
+			}
+			if claimed[w.Path] {
+				w.Action = "skip"
+				continue
+			}
+			w.Action = act
+			claimed[w.Path] = true
+		}
+	}
+}
+
+func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFlag string, jobs int) (retErr error) {
 	start := time.Now()
-	sess := adapters.NewSession()
 	adapters.ResetCapabilityWarnings()
 	adapters.ResetCoverageNotes()
 	cfg, b, err := loadProject(root)
@@ -119,60 +330,87 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		return err
 	}
 	prev := readStateFile(root)
+
+	// mainSess drives the serial post-emission writes (entry points,
+	// shared-skill links, orphan sweep). Each concurrent target owns its
+	// own session; sessions collects every session with a rollback log in
+	// write order, so the deferred rollback undoes the latest phase first.
+	mainSess := adapters.NewSession()
 	if backup {
-		sess.SetBackup(true)
-		defer sess.SetBackup(false)
+		mainSess.SetBackup(true)
 	}
-	gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
-	if gitignoreOn {
-		sess.StartRecording()
-		// Safety net for the early returns below: the success path
-		// consumes the recorded paths for the .gitignore block, after
-		// which this deferred call no-ops (StopRecording is idempotent).
-		defer sess.StopRecording()
-	}
+	var sessions []*adapters.Session
 	if !dryRun {
-		sess.StartTransaction()
+		mainSess.StartTransaction()
 		defer func() {
 			if retErr != nil {
 				fmt.Fprintf(os.Stderr, "! sync failed; rolling back partial writes\n")
-				if rbErr := sess.Rollback(); rbErr != nil {
+				if rbErr := rollbackSessions(sessions); rbErr != nil {
 					fmt.Fprintf(os.Stderr, "! rollback: %v\n", rbErr)
 				}
 			} else {
-				sess.Commit()
+				commitSessions(sessions)
 			}
 		}()
 	}
+	gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
+
 	shared.reconcile(prev.Outputs, dryRun)
+
+	// Emit every target concurrently (bounded by jobs) on its own session,
+	// collecting per-target results in stable order. The first emit error
+	// cancels the group and trips the rollback above.
+	emits, targetSessions, emitErr := emitTargetsConcurrent(effectiveTargets, b, cfg, dryRun, backup, gitignoreOn, true, jobs)
+	for _, s := range targetSessions {
+		if s != nil {
+			sessions = append(sessions, s)
+		}
+	}
+	sessions = append(sessions, mainSess) // written last (entry points), rolled back first
+	if emitErr != nil {
+		return emitErr
+	}
+	normalizeSharedWriteAttribution(emits)
+
 	verbose := verbosity >= levelVerbose
 	filesChanged := 0
 	var ledgerSession []string
-	for _, t := range effectiveTargets {
-		writes, resolved, err := emitTarget(sess, t, b, cfg, dryRun)
-		if err != nil {
-			if !resolved {
-				fmt.Fprintf(os.Stderr, "! %v\n", err)
-				continue
-			}
-			return fmt.Errorf("%s: %w", t, err)
+	var gitignoreEntries []string
+	for _, e := range emits {
+		if e.err != nil && !e.resolved {
+			fmt.Fprintf(os.Stderr, "! %v\n", e.err)
+			continue
 		}
+		gitignoreEntries = append(gitignoreEntries, e.recorded...)
 		if dryRun {
 			continue
 		}
-		recordLedgerWrites(writes, &ledgerSession)
-		created, updated, skipped := classifyDetailedWrites(writes)
+		recordLedgerWrites(e.writes, &ledgerSession)
+		created, updated, skipped := classifyDetailedWrites(e.writes)
 		filesChanged += created + updated
 		if verbose {
-			verbosef("→ %s: %d created, %d updated, %d unchanged\n", t, created, updated, skipped)
+			verbosef("→ %s: %d created, %d updated, %d unchanged\n", e.target, created, updated, skipped)
 		}
 	}
-	sess.StartDetailedRecording()
-	if err := writeAgnosticEntryPoints(sess, cfg, b, effectiveTargets, dryRun); err != nil {
-		sess.StopDetailedRecording()
+
+	// Entry points and shared-skill links write serially through mainSess,
+	// after every target, so their ordering, dedupe, and gitignore capture
+	// stay stable regardless of --jobs.
+	if gitignoreOn {
+		mainSess.StartRecording()
+	}
+	mainSess.StartDetailedRecording()
+	if err := writeAgnosticEntryPoints(mainSess, cfg, b, effectiveTargets, dryRun); err != nil {
+		mainSess.StopDetailedRecording()
+		if gitignoreOn {
+			mainSess.StopRecording()
+		}
 		return err
 	}
-	entryWrites := sess.StopDetailedRecording()
+	entryWrites := mainSess.StopDetailedRecording()
+	if gitignoreOn {
+		gitignoreEntries = append(gitignoreEntries, mainSess.StopRecording()...)
+	}
 	if !dryRun {
 		recordLedgerWrites(entryWrites, &ledgerSession)
 		created, updated, _ := classifyDetailedWrites(entryWrites)
@@ -185,20 +423,25 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 			ledgerSession = append(ledgerSession, adapters.AgnosticEntryPointPath)
 		}
 	}
-	applied := shared.apply(sess, dryRun)
+	applied := shared.apply(mainSess, dryRun)
 	ledgerSession = adjustLedgerForLinks(ledgerSession, applied)
 	if gitignoreOn {
-		entries := sess.StopRecording()
 		for _, l := range applied {
-			entries = append(entries, l.path)
+			gitignoreEntries = append(gitignoreEntries, l.path)
 		}
-		entries = append(entries, gitignoreHintsForTargets(cfg, effectiveTargets)...)
-		block := buildManagedBlock(cfg, entries)
+		gitignoreEntries = append(gitignoreEntries, gitignoreHintsForTargets(cfg, effectiveTargets)...)
+		block := buildManagedBlock(cfg, gitignoreEntries)
 		if err := updateGitignore(root, cfg, block); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
 		summaryf("→ updated .gitignore\n")
 	}
+
+	// Concurrent emission appends capability warnings / coverage notes in
+	// completion order; re-sort them to the target sequence so the flushed
+	// output below is byte-identical regardless of --jobs.
+	adapters.OrderBufferedDropsByTarget(effectiveTargets)
+
 	digest := adapters.CapabilityWarningsDigest()
 	notesDigest := adapters.CoverageNotesDigest()
 	warningsUnchanged := digest != "" && digest == prev.WarningsDigest
@@ -229,7 +472,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 	}
 	ledger := finalizeLedger(ledgerSession)
 	ledger = reconcilePartialLedger(ledger, prev.Outputs, coversAllConfiguredTargets(effectiveTargets, cfg.Targets))
-	removed, sweepErr := sweepLedgerOrphans(sess, prev.Outputs, ledger, dryRun)
+	removed, sweepErr := sweepLedgerOrphans(mainSess, prev.Outputs, ledger, dryRun)
 	if sweepErr != nil {
 		fmt.Fprintf(os.Stderr, "! orphan sweep: %v\n", sweepErr)
 	}
@@ -309,8 +552,7 @@ func appendFileRecords(out *jsonOutput, target string, writes []adapters.Written
 
 // runSyncJSON runs a real sync pass and emits a JSON result describing each
 // file written, updated, or skipped per target.
-func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
-	sess := adapters.NewSession()
+func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, backup bool, gitignoreFlag string, jobs int) error {
 	adapters.ResetCapabilityWarnings()
 	adapters.ResetCoverageNotes()
 	defer adapters.ResetCapabilityWarnings()
@@ -331,35 +573,44 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 		return err
 	}
 	prev := readStateFile(root)
+
+	// mainSess handles the serial entry-point and shared-link writes; each
+	// target emits on its own session. The JSON path is not transactional:
+	// it reports per-target errors in the result rather than rolling back.
+	mainSess := adapters.NewSession()
 	if backup {
-		sess.SetBackup(true)
-		defer sess.SetBackup(false)
+		mainSess.SetBackup(true)
 	}
 	gitignoreOn := !dryRun && resolveGitignore(cfg, gitignoreFlag)
-	if gitignoreOn {
-		sess.StartRecording()
-		defer sess.StopRecording()
-	}
 	shared.reconcile(prev.Outputs, dryRun)
 
 	out := jsonOutput{Version: "1", Command: "sync"}
 	var ledgerSession []string
-	for _, t := range effectiveTargets {
-		writes, _, err := emitTarget(sess, t, b, cfg, dryRun)
-		if err != nil {
-			out.Errors = append(out.Errors, errorRecord{Target: t, Message: err.Error()})
+	var gitignoreEntries []string
+
+	// Emit every target concurrently; failFast is off so all per-target
+	// errors ride along in the results and are reported in target order.
+	emits, _, _ := emitTargetsConcurrent(effectiveTargets, b, cfg, dryRun, backup, gitignoreOn, false, jobs)
+	normalizeSharedWriteAttribution(emits)
+	for _, e := range emits {
+		if e.err != nil {
+			out.Errors = append(out.Errors, errorRecord{Target: e.target, Message: e.err.Error()})
 			continue
 		}
-		recordLedgerWrites(writes, &ledgerSession)
-		appendFileRecords(&out, t, writes)
+		gitignoreEntries = append(gitignoreEntries, e.recorded...)
+		recordLedgerWrites(e.writes, &ledgerSession)
+		appendFileRecords(&out, e.target, e.writes)
 	}
 
-	sess.StartDetailedRecording()
-	if err := writeAgnosticEntryPoints(sess, cfg, b, effectiveTargets, dryRun); err != nil {
-		sess.StopDetailedRecording()
+	if gitignoreOn {
+		mainSess.StartRecording()
+	}
+	mainSess.StartDetailedRecording()
+	if err := writeAgnosticEntryPoints(mainSess, cfg, b, effectiveTargets, dryRun); err != nil {
+		mainSess.StopDetailedRecording()
 		out.Errors = append(out.Errors, errorRecord{Target: "agnostic-ai", Message: err.Error()})
 	} else {
-		entryWrites := sess.StopDetailedRecording()
+		entryWrites := mainSess.StopDetailedRecording()
 		recordLedgerWrites(entryWrites, &ledgerSession)
 		appendFileRecords(&out, "agnostic-ai", entryWrites)
 		// See runSyncOnce: AGNOSTIC_AI.md is read on subsequent
@@ -369,26 +620,28 @@ func runSyncJSON(cmd *cobra.Command, root string, targets []string, dryRun, back
 			ledgerSession = append(ledgerSession, adapters.AgnosticEntryPointPath)
 		}
 	}
+	if gitignoreOn {
+		gitignoreEntries = append(gitignoreEntries, mainSess.StopRecording()...)
+	}
 
-	applied := shared.apply(sess, dryRun)
+	applied := shared.apply(mainSess, dryRun)
 	ledgerSession = adjustLedgerForLinks(ledgerSession, applied)
 	for _, l := range applied {
 		out.Writes = append(out.Writes, fileRecord{Target: "agnostic-ai", Path: l.path, Action: "link"})
 	}
 	if gitignoreOn {
-		entries := sess.StopRecording()
 		for _, l := range applied {
-			entries = append(entries, l.path)
+			gitignoreEntries = append(gitignoreEntries, l.path)
 		}
-		entries = append(entries, gitignoreHintsForTargets(cfg, effectiveTargets)...)
-		block := buildManagedBlock(cfg, entries)
+		gitignoreEntries = append(gitignoreEntries, gitignoreHintsForTargets(cfg, effectiveTargets)...)
+		block := buildManagedBlock(cfg, gitignoreEntries)
 		if err := updateGitignore(root, cfg, block); err != nil {
 			return fmt.Errorf("gitignore: %w", err)
 		}
 	}
 	ledger := finalizeLedger(ledgerSession)
 	ledger = reconcilePartialLedger(ledger, prev.Outputs, coversAllConfiguredTargets(effectiveTargets, cfg.Targets))
-	removed, sweepErr := sweepLedgerOrphans(sess, prev.Outputs, ledger, dryRun)
+	removed, sweepErr := sweepLedgerOrphans(mainSess, prev.Outputs, ledger, dryRun)
 	if sweepErr != nil {
 		out.Errors = append(out.Errors, errorRecord{Target: "agnostic-ai", Message: sweepErr.Error()})
 	}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -28,24 +28,24 @@ const agnosticOverlayDir = ".agnostic-ai/overlays"
 // watchSync runs an initial sync, then re-runs whenever a watched path
 // changes. When forcePoll is false it tries fsnotify and falls back to
 // polling if the watcher cannot be created.
-func watchSync(ctx context.Context, pollInterval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string, forcePoll bool) error {
-	if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
+func watchSync(ctx context.Context, pollInterval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string, forcePoll bool, jobs int) error {
+	if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag, jobs); err != nil {
 		return err
 	}
 	if !forcePoll {
-		err := watchSyncFsnotify(ctx, root, targets, dryRun, backup, gitignoreFlag)
+		err := watchSyncFsnotify(ctx, root, targets, dryRun, backup, gitignoreFlag, jobs)
 		if err == nil || ctx.Err() != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "! fsnotify unavailable (%v); falling back to polling\n", err)
 	}
-	return watchSyncPoll(ctx, pollInterval, root, targets, dryRun, backup, gitignoreFlag)
+	return watchSyncPoll(ctx, pollInterval, root, targets, dryRun, backup, gitignoreFlag, jobs)
 }
 
 // watchSyncFsnotify watches via OS file events. Returns the first
 // unrecoverable setup error so the caller can fall back to polling.
 // Per-event errors during the loop are logged and the loop continues.
-func watchSyncFsnotify(ctx context.Context, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
+func watchSyncFsnotify(ctx context.Context, root string, targets []string, dryRun, backup bool, gitignoreFlag string, jobs int) error {
 	cfg, err := config.Load(root)
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ func watchSyncFsnotify(ctx context.Context, root string, targets []string, dryRu
 			printWatchEvent(lastEvent)
 			adapters.ResetCapabilityWarnings()
 			adapters.ResetCoverageNotes()
-			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
+			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag, jobs); err != nil {
 				fmt.Fprintf(os.Stderr, "! sync: %v\n", err)
 			}
 			// Pick up source roots that may have appeared (e.g. a
@@ -125,7 +125,7 @@ func watchSyncFsnotify(ctx context.Context, root string, targets []string, dryRu
 
 // watchSyncPoll is the original mtime-poll loop. Used as a fallback
 // when fsnotify fails (e.g. some network mounts) or with --watch-poll.
-func watchSyncPoll(ctx context.Context, interval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string) error {
+func watchSyncPoll(ctx context.Context, interval time.Duration, root string, targets []string, dryRun, backup bool, gitignoreFlag string, jobs int) error {
 	cfg, err := config.Load(root)
 	if err != nil {
 		return err
@@ -150,7 +150,7 @@ func watchSyncPoll(ctx context.Context, interval time.Duration, root string, tar
 			changed := firstChangedPath(snapshot, curr)
 			snapshot = curr
 			printWatchEvent(changed)
-			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag); err != nil {
+			if err := runSyncOnce(root, targets, dryRun, backup, gitignoreFlag, jobs); err != nil {
 				fmt.Fprintf(os.Stderr, "! sync: %v\n", err)
 			}
 			if newCfg, err := config.Load(root); err == nil {

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -74,7 +74,7 @@ func TestWatchSync_ReEmitsOnChange(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- watchSync(ctx, 10*time.Millisecond, ".", []string{"claude"}, false, false, "off", false)
+		done <- watchSync(ctx, 10*time.Millisecond, ".", []string{"claude"}, false, false, "off", false, 1)
 	}()
 
 	// Wait for initial sync.
@@ -157,7 +157,7 @@ func TestWatchSync_PollFallback(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		// forcePoll = true exercises the polling backend explicitly.
-		done <- watchSync(ctx, 20*time.Millisecond, ".", []string{"claude"}, false, false, "off", true)
+		done <- watchSync(ctx, 20*time.Millisecond, ".", []string{"claude"}, false, false, "off", true, 1)
 	}()
 
 	time.Sleep(80 * time.Millisecond)
@@ -269,7 +269,7 @@ func TestWatchSync_ReEmitsOnCodexOverlayChange(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		// forcePoll=true: deterministic across platforms.
-		done <- watchSync(ctx, 20*time.Millisecond, ".", []string{"codex"}, false, false, "off", true)
+		done <- watchSync(ctx, 20*time.Millisecond, ".", []string{"codex"}, false, false, "off", true, 1)
 	}()
 
 	codexConfig := filepath.Join(dir, ".codex", "config.toml")


### PR DESCRIPTION
Closes #487

## What

Emit targets concurrently on their own `emit.Session`, behind a `--jobs <n>` flag on `sync`:

- `0` (default): one worker per CPU
- `1`: serial (today's behavior, for reproducible ordering / debug)
- capped at the target count (idle workers buy nothing)

Only the per-target `Emit` calls parallelize. The post-emission phase (entry points, shared-skill links, ledger, gitignore, orphan sweep) stays serial and ordered.

## Determinism (the hard requirement)

Output is byte-identical regardless of `--jobs`. Verified from scratch on this repo: `--jobs 1` and `--jobs 8` both emit 251 files with identical trees. A new test (`sync_parallel_test.go`) asserts equal tree + summary + JSON + flushed warnings across `--jobs 1 / 8 / 64`, and runs under `-race`.

Three things make it deterministic:

1. **Per-path write lock** (emit layer): several targets legitimately write the same shared path (the `AGENTS.md` pointer family). A package-level `sync.Map` of path -> mutex serializes the read-classify-write section so exactly one target creates the file and the rest skip it. This matches serial, fixes the create-count (was 238 vs 237 without it), and keeps the transaction log free of duplicate rollback entries. Pure write coordination, no shared business state.
2. **Shared-write attribution normalization** (cli layer): the per-path lock guarantees one non-skip write, but scheduling decides which target won. Reassign the create/update to the first target in target order, matching serial, so per-target JSON/summary is stable.
3. **Buffered drops re-sort**: capability warnings and coverage notes are appended in completion order during concurrent emit, then re-sorted to target order before flushing.

Targets run in provenance-homogeneous batches so the one remaining emit-time process global (the provenance-header toggle) is constant while a batch runs concurrently. First emit error cancels the group, is wrapped with its target, and trips the existing transaction rollback.

## Benchmark (per bench-before-perf-refactor.md)

Permanent `BenchmarkSyncFull` now runs serial vs parallel side by side. Steady-state re-sync path, 14 CPU, 18 targets:

| specs | serial (median) | parallel (median) | speedup |
|------:|----------------:|------------------:|--------:|
| 10    | 13.85 ms        | 11.31 ms          | 1.22x (18%) |
| 100   | 133.24 ms       | 104.95 ms (80.5 ms best) | 1.27x median, up to 1.60x |

Parallel wins at every full-fanout size; there is no crossover where serial is faster (at 1-2 targets they converge since workers cap at target count). The win is modest and variable because the path is I/O- and GC-bound (92 MB/op at 100 specs) with a serial tail that `--jobs` cannot touch. Honest framing: the flag's first value is correctness + opt-in control; the wall-clock win is a real but modest bonus that grows with project size.

## Gate

- `gofmt -l .` empty, `go vet ./...` clean, `go build ./...` clean
- `go test -race ./...`: 1374 pass across 33 packages
- `sync --check` exits 0 (idempotent)
- `--jobs 1` == `--jobs 8`: byte-identical trees verified

## Docs

- `--jobs` row + example in `docs/user/cli-reference.md`
- Parallel emission subsection in `docs/user/configuration.md`
- `CHANGELOG.md` Unreleased / Added