### PR TITLE
docs: correct README target count and surface parallel emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### **One spec. Every AI CLI. Zero drift.**
 
-Write your agents, skills, rules, and hooks **once**. Ship them to Claude Code, Codex, Gemini, Cursor, Copilot, and 9 more in their native format.
+Write your agents, skills, rules, and hooks **once**. Ship them to Claude Code, Codex, Gemini, Cursor, Copilot, and 13 more in their native format.
 
 [![CI](https://github.com/Chemaclass/agnostic-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/Chemaclass/agnostic-ai/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/chemaclass/agnostic-ai)](https://goreportcard.com/report/github.com/chemaclass/agnostic-ai)
@@ -21,7 +21,7 @@ You write `CLAUDE.md`. Then `.cursor/rules`. Then `GEMINI.md`. Then `AGENTS.md`.
 
 agnostic-ai keeps one source of truth in plain Markdown plus YAML frontmatter, aligned with the [AGENTS.md](https://agents.md) open standard. Run `sync` and every tool gets the config it expects, in its native location, byte-stable across runs.
 
-- **Stateless adapters.** Same input, same output. Diffable, reviewable.
+- **Stateless adapters.** Same input, same output. Diffable, reviewable, safe to emit in parallel (`sync --jobs`).
 - **Uniform entry-point.** One pointer body shared across every target's root file.
 - **Round-trip safe.** Provenance marker plus style preservation keeps `import` then `sync` byte-stable.
 - **Scoped rules.** `rules/backend/auth.md` routes to `.cursor/rules/backend/auth.mdc` and `.github/instructions/auth.instructions.md` with `applyTo: backend/**`.


### PR DESCRIPTION
## Summary

Docs freshness pass over README + guides against current `main`.

- **README tagline** said "Claude Code, Codex, Gemini, Cursor, Copilot, and **9** more" (implying 14 targets) — there are **18**. Corrected to "13 more".
- **Surfaced parallel emission** on the stateless-adapters bullet: `sync --jobs` (#487) is the one user-facing capability added since the last README pass that wasn't reflected there.

## Audit result

Everything else verified current, no changes needed:
- Counts consistent across README + all docs: 18 total, 16 default, 9 root-`AGENTS.md` consumers, 13/18 MCP, import sources.
- `--jobs` fully documented already (cli-reference.md, configuration.md §Parallel emission, CHANGELOG Unreleased, `--help`).
- Benchmark suite (#485) documented + linked (`docs/internal/benchmarks.md`).
- The #484 target-list corrections still hold; nothing regressed.

Docs-only, no behavior change (the `--jobs` behavior itself already has its CHANGELOG entry under #487), so no new CHANGELOG entry.

## Test plan
- [x] Every corrected/verified count checked against the adapter registry and `DefaultTargets()`
- [x] Docs-only; no code touched