### PR TITLE
feat(sync): actionable --check output (--diff, --format=github, fix hint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `sync --check` gains actionable drift output: `--diff` prints a unified diff per drifted file (truncated when large), `--format=github` emits GitHub Actions `::error` annotations that surface inline on the PR, and a failing check now prints the reconcile command (`agnostic-ai sync`) on stderr and points its error and the config-error hints at `agnostic-ai doctor`. Exit codes and the `--json` schema are unchanged (#488).
 - `sync --jobs <n>` emits targets in parallel (default: one worker per CPU; `1` forces serial). The emitted tree, summary, JSON, gitignore block, and warnings stay byte-identical regardless of the worker count (#487).
 
 ## v0.43.0 - 2026-07-20

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -232,6 +232,8 @@ agnostic-ai sync [flags]
 | `--except <list>` | Emit all configured targets except these (comma-separated). Mutually exclusive with `--only`. Errors on unknown names. |
 | `--dry-run` | Print to stdout instead of writing files |
 | `--check` | Compare emitted output to disk; exit non-zero on drift. Writes nothing. |
+| `--diff` | With `--check`, print a unified diff per drifted file (on-disk vs what sync would write). Off by default so CI logs stay lean. Large diffs are truncated with a summary line. |
+| `--format <human\|github>` | With `--check`, the drift report format. `human` (default) is the per-target table; `github` emits GitHub Actions `::error` annotations so drift surfaces inline on the pull request. `--json` still selects JSON and takes precedence. |
 | `--backup` | Copy each existing target file to `<path>.bak` before overwriting. Pair with `revert` to restore. |
 | `--gitignore <on\|off>` | Override `gitignore.enabled` for this run. |
 | `--watch` | Keep the process alive and re-emit on spec, config, or overlay changes. Watched roots: `agnostic-ai.yaml` + `agnostic-ai.local.yaml`, every `sources.*` directory, `.agnostic-ai.local/`, and `.agnostic-ai/overlays/` (so a hand-edit to `claude.settings.json` / `codex.config.toml` re-emits). Uses OS file events (fsnotify) with a 50 ms debounce; falls back to a 200 ms poll where fsnotify fails. Ctrl+C exits cleanly. Incompatible with `--check`. |
@@ -257,6 +259,8 @@ agnostic-ai sync --only claude,cursor  # only claude and cursor
 agnostic-ai sync --except codex        # all configured targets except codex
 agnostic-ai sync --dry-run             # preview
 agnostic-ai sync --check               # CI gate: fail if outputs are stale
+agnostic-ai sync --check --diff        # show a unified diff of every drifted file
+agnostic-ai sync --check --format=github  # GitHub Actions annotations, inline on the PR
 agnostic-ai sync --backup              # leave a .bak trail for revert
 agnostic-ai sync --jobs 1              # force serial emission (default: one worker per CPU)
 agnostic-ai sync --watch               # re-emit on spec changes; Ctrl+C exits
@@ -265,6 +269,15 @@ agnostic-ai sync --check --json        # machine-readable drift report
 ```
 
 `--only` and `--except` validate names against the configured targets and error on unknown names (no silent skip).
+
+### Reading a failing `--check`
+
+A drifting `--check` exits non-zero and, on stderr, prints the one command that reconciles it: `agnostic-ai sync`. The error line itself points at `agnostic-ai doctor` for a full diagnosis. Two flags make the failure self-explanatory without a local re-run:
+
+- `--diff` prints a unified diff per drifted file (on-disk content vs what sync would write), so you see the exact changed lines. Missing files show a one-line create summary; large diffs truncate with a count.
+- `--format=github` swaps the human table for GitHub Actions `::error file=...,line=...::` annotations. Drop it in a CI step and drift surfaces inline on the pull request. `--json` still selects the machine-readable report and wins if both are set.
+
+Exit codes are unchanged: zero when in sync, non-zero on drift, in every format.
 
 **JSON output schema (version 1):**
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -399,6 +399,20 @@ The output never depends on the value. The emitted file tree, the summary counts
 
 Parallelism helps most on large projects with many targets. On a small spec set or a single target it is close to free either way, since the worker count is capped at the number of targets.
 
+### Actionable `--check` output (`--diff`, `--format`)
+
+`sync --check` is the CI drift gate. Two per-run flags make a red build self-explanatory; there is no config-file key for either.
+
+- `--diff` prints a unified diff per drifted file (on-disk vs what sync would write) instead of only counts. Off by default so CI logs stay lean; large diffs truncate with a summary line.
+- `--format=github` emits GitHub Actions `::error file=...,line=...::` annotations so drift surfaces inline on the pull request. The default `human` format keeps the per-target table. `--json` still selects the machine-readable report and takes precedence.
+
+A failing `--check` prints the reconcile command (`agnostic-ai sync`) on stderr and points its error at `agnostic-ai doctor` for a full diagnosis. Exit codes are unchanged: non-zero on drift in every format.
+
+```bash
+agnostic-ai sync --check --diff            # unified diff of every drifted file
+agnostic-ai sync --check --format=github   # inline PR annotations in CI
+```
+
 ## `import`
 
 Per-source knobs for the `import` command. Empty blocks fall back to per-source defaults.

--- a/docs/user/errors.md
+++ b/docs/user/errors.md
@@ -50,13 +50,13 @@ A spec kind (hook, mcp, command, ...) is in the bundle but the target adapter do
 
 Neither `agnostic-ai.yaml` nor the legacy `agnostic.config.yaml` exists in the project root.
 
-**Fix:** run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one.
+**Fix:** run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one. Run `agnostic-ai doctor` for a full diagnosis.
 
 ### AAI-004: Config decode failed
 
 The config file was found but could not be parsed as YAML, or its keys do not match the schema.
 
-**Fix:** validate against `docs/schemas/config.schema.json`. Check indentation and that list keys (e.g. `targets:`) hold a YAML sequence.
+**Fix:** validate against `docs/schemas/config.schema.json`. Check indentation and that list keys (e.g. `targets:`) hold a YAML sequence. Run `agnostic-ai doctor` for a full diagnosis.
 
 ### AAI-102: Targets emit to the same output path
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -15,8 +15,8 @@ import (
 
 func newSyncCmd() *cobra.Command {
 	var targets, only, except []string
-	var dryRun, check, plan, backup, watch, watchPoll, jsonOut, allTargets bool
-	var gitignoreFlag string
+	var dryRun, check, plan, backup, watch, watchPoll, jsonOut, allTargets, diff bool
+	var gitignoreFlag, format string
 	var jobs int
 
 	cmd := &cobra.Command{
@@ -37,6 +37,12 @@ func newSyncCmd() *cobra.Command {
   # CI gate: non-zero exit when output drifts from specs
   agnostic-ai sync --check
 
+  # Show a unified diff of every drifted file
+  agnostic-ai sync --check --diff
+
+  # Emit GitHub Actions annotations so drift surfaces inline on the PR
+  agnostic-ai sync --check --format=github
+
   # Back up each existing file to <path>.bak before overwriting
   agnostic-ai sync --backup
 
@@ -47,6 +53,9 @@ func newSyncCmd() *cobra.Command {
   agnostic-ai sync --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateGitignoreFlag(gitignoreFlag); err != nil {
+				return err
+			}
+			if err := validateCheckFormat(format); err != nil {
 				return err
 			}
 			if len(only) > 0 && len(except) > 0 {
@@ -96,10 +105,7 @@ func newSyncCmd() *cobra.Command {
 				if jsonOut {
 					return printSyncCheckJSON(cmd, reports)
 				}
-				if printDrift(reports) {
-					return fmt.Errorf("drift detected")
-				}
-				return nil
+				return reportCheckDrift(cmd, reports, format, diff)
 			}
 			if watchPoll && !watch {
 				return fmt.Errorf("--watch-poll requires --watch")
@@ -120,6 +126,8 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&except, "except", nil, "Emit all configured targets except these (comma-separated); mutually exclusive with --only")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print outputs instead of writing")
 	cmd.Flags().BoolVar(&check, "check", false, "Compare emitted output to disk; non-zero exit on drift")
+	cmd.Flags().BoolVar(&diff, "diff", false, "With --check, print a unified diff per drifted file (default: counts only, so CI logs stay lean)")
+	cmd.Flags().StringVar(&format, "format", checkFormatHuman, "With --check, drift report format: 'human' or 'github' (GitHub Actions ::error annotations)")
 	cmd.Flags().BoolVar(&plan, "plan", false, "Show per-target added/changed counts without writing")
 	cmd.Flags().BoolVar(&backup, "backup", false, "Copy each existing target file to <path>.bak before overwriting (consumed by `agnostic-ai revert`; clear leftover .bak with `agnostic-ai cleanup --backups`)")
 	cmd.Flags().StringVar(&gitignoreFlag, "gitignore", "", "Override config: 'on' or 'off' to manage the .gitignore block this run.")

--- a/internal/cli/sync_check_output_test.go
+++ b/internal/cli/sync_check_output_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// captureLogOut redirects the summary sink (logOut) to a buffer for the test
+// so printDrift's human table neither leaks to the terminal nor pollutes the
+// stdout captured via SetOut. Restored on cleanup.
+func captureLogOut(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prev := logOut
+	buf := &bytes.Buffer{}
+	logOut = buf
+	t.Cleanup(func() { logOut = prev })
+	return buf
+}
+
+// syncThenEditRule syncs claude, then overwrites the emitted r1 rule with
+// hand-edited content so the next --check sees one stale file.
+func syncThenEditRule(t *testing.T, dir string) string {
+	t.Helper()
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	rule := filepath.Join(dir, ".claude/rules/r1.md")
+	if err := os.WriteFile(rule, []byte("hand-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return rule
+}
+
+func TestSyncCheck_Diff_ShowsChangedLines(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+	captureLogOut(t)
+	syncThenEditRule(t, dir)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"sync", "-t", "claude", "--check", "--diff"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected drift error from --check --diff")
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "-hand-edited") {
+		t.Errorf("diff should show the removed on-disk line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "+rule body") {
+		t.Errorf("diff should show the would-be content, got:\n%s", got)
+	}
+	if !strings.Contains(got, "@@") {
+		t.Errorf("diff should carry a unified hunk header, got:\n%s", got)
+	}
+}
+
+func TestSyncCheck_FormatGitHub_EmitsErrorAnnotations(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+	captureLogOut(t)
+	syncThenEditRule(t, dir)
+
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"sync", "-t", "claude", "--check", "--format=github"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected drift error from --check --format=github")
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "::error file=.claude/rules/r1.md") {
+		t.Errorf("expected a github error annotation for the stale file, got:\n%s", got)
+	}
+	if !strings.Contains(got, "line=") {
+		t.Errorf("stale annotation should carry a line number, got:\n%s", got)
+	}
+}
+
+func TestSyncCheck_FormatGitHub_ReportsMissingFile(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+	captureLogOut(t)
+
+	// No sync first: every emitted file is missing.
+	var out bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetArgs([]string{"sync", "-t", "claude", "--check", "--format=github"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected drift error when files are missing")
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "::error file=") || !strings.Contains(got, "is missing") {
+		t.Errorf("expected a github missing-file annotation, got:\n%s", got)
+	}
+}
+
+func TestSyncCheck_FixHint_PrintsReconcileCommandOnStderr(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+	captureLogOut(t)
+	syncThenEditRule(t, dir)
+
+	var errBuf bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"sync", "-t", "claude", "--check"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected drift error")
+	}
+	if !strings.Contains(errBuf.String(), "agnostic-ai sync") {
+		t.Errorf("stderr should print the reconcile command, got:\n%s", errBuf.String())
+	}
+	// The drift error itself points at doctor for a full diagnosis.
+	if !strings.Contains(err.Error(), "agnostic-ai doctor") {
+		t.Errorf("drift error should point at doctor, got: %v", err)
+	}
+}
+
+func TestSyncCheck_CleanRun_StaysSilent(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+	logBuf := captureLogOut(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	logBuf.Reset() // drop the initial sync's summary; only the --check below matters
+
+	var out, errBuf bytes.Buffer
+	root = NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"sync", "-t", "claude", "--check", "--diff", "--format=github"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("clean --check should not error, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("clean --check should print nothing to stdout, got:\n%s", out.String())
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("clean --check should print no fix hint, got:\n%s", errBuf.String())
+	}
+	if logBuf.Len() != 0 {
+		t.Errorf("clean --check should print no summary, got:\n%s", logBuf.String())
+	}
+}
+
+func TestSyncCheck_InvalidFormat_Errors(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--check", "--format=bogus"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown --format value")
+	}
+	if !strings.Contains(err.Error(), "--format") {
+		t.Errorf("error should name the --format flag, got: %v", err)
+	}
+}

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -701,9 +702,186 @@ func printSyncCheckJSON(cmd *cobra.Command, reports []driftReport) error {
 		return err
 	}
 	if hasDrift {
-		return fmt.Errorf("drift detected")
+		return errDriftDetected()
 	}
 	return nil
+}
+
+// checkFormatHuman is the default `--check` report: a per-target table.
+// checkFormatGitHub emits GitHub Actions annotations. JSON output stays
+// behind the separate `--json` flag, which takes precedence over --format.
+const (
+	checkFormatHuman  = "human"
+	checkFormatGitHub = "github"
+)
+
+// validateCheckFormat rejects an unknown `--format` value so a typo fails
+// fast instead of silently falling back to the human table.
+func validateCheckFormat(format string) error {
+	switch format {
+	case checkFormatHuman, checkFormatGitHub:
+		return nil
+	}
+	return fmt.Errorf("--format: expected %q or %q, got %q", checkFormatHuman, checkFormatGitHub, format)
+}
+
+// errDriftDetected is the failure a drifting `sync --check` returns. It names
+// `agnostic-ai doctor` so a bare CI line still points at the full diagnosis;
+// the reconcile command prints separately as a stderr hint.
+func errDriftDetected() error {
+	return fmt.Errorf("drift detected; run `agnostic-ai doctor` for a full diagnosis")
+}
+
+// reportCheckDrift renders a `sync --check` result in the requested text
+// format and returns a non-zero error when any target drifts. The report
+// goes to stdout; the fix hint goes to stderr, so a machine reading stdout (a
+// captured log, a github matcher) sees only the drift lines. Presentation
+// only: it never writes files or changes what counts as drift.
+func reportCheckDrift(cmd *cobra.Command, reports []driftReport, format string, diff bool) error {
+	var drift bool
+	switch format {
+	case checkFormatGitHub:
+		drift = printDriftGitHub(cmd, reports)
+	default:
+		drift = printDrift(reports)
+	}
+	if diff {
+		printDriftDiffs(cmd, reports)
+	}
+	if !drift {
+		return nil
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), "to reconcile, run: agnostic-ai sync")
+	return errDriftDetected()
+}
+
+// printDriftGitHub emits one GitHub Actions error annotation per drifted file
+// so drift surfaces inline on the pull request. Missing files carry no line;
+// stale files point at the first changed line. Returns true if any target
+// drifted, so an in-sync run emits nothing and stays silent.
+func printDriftGitHub(cmd *cobra.Command, reports []driftReport) bool {
+	out := cmd.OutOrStdout()
+	drift := false
+	for _, r := range reports {
+		for _, f := range r.Missing {
+			drift = true
+			fmt.Fprintf(out, "::error file=%s::%s is missing; run agnostic-ai sync to generate it\n",
+				githubProp(f.Path), githubData(filepath.ToSlash(f.Path)))
+		}
+		for _, f := range r.Stale {
+			drift = true
+			fmt.Fprintf(out, "::error file=%s,line=%d::%s drifted from specs; run agnostic-ai sync to reconcile\n",
+				githubProp(f.Path), firstChangedLine(f.Path, f.Content), githubData(filepath.ToSlash(f.Path)))
+		}
+	}
+	return drift
+}
+
+// diffBodyMax caps the changed lines shown per file so a large rewrite does
+// not flood CI logs. Past it, a summary line reports the remainder.
+const diffBodyMax = 200
+
+// printDriftDiffs prints a unified diff for every drifted file: the on-disk
+// content against what sync would write. Missing files show a concise create
+// line rather than a full body. Only drifted files produce output, so an
+// in-sync run stays silent. Presentation only; nothing is written.
+func printDriftDiffs(cmd *cobra.Command, reports []driftReport) {
+	out := cmd.OutOrStdout()
+	for _, r := range reports {
+		for _, f := range r.Missing {
+			fmt.Fprintf(out, "would create %s (%d bytes)\n", filepath.ToSlash(f.Path), len(f.Content))
+		}
+		for _, f := range r.Stale {
+			disk, err := os.ReadFile(f.Path)
+			if err != nil {
+				fmt.Fprintf(out, "%s: %v\n", f.Path, err)
+				continue
+			}
+			_, _ = fmt.Fprint(out, unifiedDiff(f.Path, string(disk), f.Content, diffBodyMax))
+		}
+	}
+}
+
+// unifiedDiff renders a minimal unified diff between the on-disk content
+// (have) and what sync would write (want), keyed by path. It trims the shared
+// leading and trailing lines and prints the differing middle as one hunk:
+// on-disk lines with `-`, would-write lines with `+`. Output past maxLines is
+// dropped with a summary so CI logs stay lean. A display helper over line
+// slices, not a general diff engine.
+func unifiedDiff(path, have, want string, maxLines int) string {
+	haveLines := splitLines(have)
+	wantLines := splitLines(want)
+
+	p := commonPrefix(haveLines, wantLines)
+	s := 0
+	for s < len(haveLines)-p && s < len(wantLines)-p &&
+		haveLines[len(haveLines)-1-s] == wantLines[len(wantLines)-1-s] {
+		s++
+	}
+	removed := haveLines[p : len(haveLines)-s]
+	added := wantLines[p : len(wantLines)-s]
+
+	var b strings.Builder
+	slash := filepath.ToSlash(path)
+	fmt.Fprintf(&b, "--- %s (on disk)\n", slash)
+	fmt.Fprintf(&b, "+++ %s (agnostic-ai sync)\n", slash)
+	fmt.Fprintf(&b, "@@ -%d,%d +%d,%d @@\n", p+1, len(removed), p+1, len(added))
+
+	shown := 0
+	body := len(removed) + len(added)
+	write := func(mark string, lines []string) {
+		for _, ln := range lines {
+			if shown >= maxLines {
+				return
+			}
+			fmt.Fprintf(&b, "%s%s\n", mark, ln)
+			shown++
+		}
+	}
+	write("-", removed)
+	write("+", added)
+	if body > maxLines {
+		fmt.Fprintf(&b, "... %d more changed line(s) truncated\n", body-maxLines)
+	}
+	return b.String()
+}
+
+// firstChangedLine returns the 1-based line where the on-disk file at path
+// first differs from want, or 1 when the file is unreadable. Only used to aim
+// a github annotation; never load-bearing.
+func firstChangedLine(path, want string) int {
+	disk, err := os.ReadFile(path)
+	if err != nil {
+		return 1
+	}
+	return commonPrefix(splitLines(string(disk)), splitLines(want)) + 1
+}
+
+// commonPrefix returns the count of leading lines a and b share.
+func commonPrefix(a, b []string) int {
+	n := 0
+	for n < len(a) && n < len(b) && a[n] == b[n] {
+		n++
+	}
+	return n
+}
+
+// githubData escapes a value for the message body of a github workflow
+// command. `%` is escaped first so later escapes are not re-escaped.
+func githubData(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+// githubProp escapes a value used as a github workflow command property
+// (file=...). Properties additionally escape `:` and `,`.
+func githubProp(s string) string {
+	s = githubData(filepath.ToSlash(s))
+	s = strings.ReplaceAll(s, ":", "%3A")
+	s = strings.ReplaceAll(s, ",", "%2C")
+	return s
 }
 
 // resolveGitignore picks the effective gitignore mode: the --gitignore

--- a/internal/errs/registry.go
+++ b/internal/errs/registry.go
@@ -29,13 +29,13 @@ var registry = map[Code]Entry{
 		Code:  CodeConfigMissing,
 		Title: "Config file missing",
 		Cause: "Neither `agnostic-ai.yaml` nor the legacy `agnostic.config.yaml` exists in the project root.",
-		Fix:   "Run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one.",
+		Fix:   "Run `agnostic-ai init` to scaffold a config, or `cd` into the directory that already contains one. Run `agnostic-ai doctor` for a full diagnosis.",
 	},
 	CodeConfigDecode: {
 		Code:  CodeConfigDecode,
 		Title: "Config decode failed",
 		Cause: "The config file was found but could not be parsed as YAML, or its keys do not match the expected schema.",
-		Fix:   "Validate against `docs/schemas/config.schema.json`. Check indentation and that list keys (e.g. `targets:`) hold a YAML sequence.",
+		Fix:   "Validate against `docs/schemas/config.schema.json`. Check indentation and that list keys (e.g. `targets:`) hold a YAML sequence. Run `agnostic-ai doctor` for a full diagnosis.",
 	},
 	CodeOutputCollision: {
 		Code:  CodeOutputCollision,


### PR DESCRIPTION
## Summary

Makes a failing `sync --check` self-explanatory instead of printing per-target drift counts and leaving the user to re-run sync and diff by hand.

- **`--diff`**: prints a unified diff per drifted file (on-disk content vs what sync would write). Off by default so CI logs stay lean; large diffs truncate with a summary line. Missing files show a one-line create summary.
- **`--format=github`**: emits GitHub Actions `::error file=...,line=...::` annotations so drift surfaces inline on the pull request. The default `human` table and the `--json` report are kept; `--json` takes precedence.
- **Fix hint**: a failing check prints the reconcile command (`agnostic-ai sync`) on stderr.
- **Discoverability**: the drift error and the `AAI-003` / `AAI-004` config-error hints now point at `agnostic-ai doctor` for a full diagnosis.

Presentation only: no change to what counts as drift, the emission, exit codes (non-zero on drift, zero when clean), or the `--json` schema (unchanged, additive).

Scope stayed inside the issue boundary: `internal/cli/sync.go` (flag wiring + check dispatch), `internal/cli/sync_run.go` (new print/report helpers), `internal/errs` hint strings, and docs/CHANGELOG. `printDrift`, `collectDrift`, `driftReport`, adapters, and emit logic are untouched. No new diff dependency: a small unified diff over line slices using stdlib, reusing the package's existing `splitLines`.

## Test plan

New behavior tests in `internal/cli/sync_check_output_test.go` (seed a drifted fixture, read output back, `t.TempDir`):

- `--diff` output contains the removed on-disk line, the would-be content, and a `@@` hunk header.
- `--format=github` emits `::error file=...,line=...::` for stale files and `is missing` for missing files.
- A failing check prints `agnostic-ai sync` on stderr and the error points at `agnostic-ai doctor`.
- A clean run stays fully silent (empty stdout, stderr, and summary) and exits zero.
- An invalid `--format` value fails fast.

Gate (all green): `gofmt -l .` empty, `go vet ./...`, `go build ./...`, `go test ./...`. Verified the built binary end to end for drift diff, github annotations, clean silence, `--check --json` (schema unchanged), and the `AAI-003` doctor pointer.

Final review pass over every touched file found no duplication, dead branches, or over-engineering to fix, so there is no separate `ref(...)` commit.

Closes #488
