### PR TITLE
feat(cli): sync perf observability (--profile, per-target timing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `--profile <file>` (or `AGNOSTIC_AI_PROFILE`) writes a `runtime/pprof` CPU profile of the run, and `sync --verbose` appends per-target wall time (`in Nms`) to each target line, so a slow sync attributes to a specific adapter. Off by default, stdlib profiler only (#491).
 - `sync --check` gains actionable drift output: `--diff` prints a unified diff per drifted file (truncated when large), `--format=github` emits GitHub Actions `::error` annotations that surface inline on the PR, and a failing check now prints the reconcile command (`agnostic-ai sync`) on stderr and points its error and the config-error hints at `agnostic-ai doctor`. Exit codes and the `--json` schema are unchanged (#488).
 - `sync --jobs <n>` emits targets in parallel (default: one worker per CPU; `1` forces serial). The emitted tree, summary, JSON, gitignore block, and warnings stay byte-identical regardless of the worker count (#487).
 

--- a/docs/internal/benchmarks.md
+++ b/docs/internal/benchmarks.md
@@ -77,3 +77,37 @@ When you propose a hot-path change, add a third `proposed` sub-benchmark
 next to these two, run all three side by side, and compute the crossover
 before touching the production code. Keep the bench after the proposal
 closes: future runtime or compiler changes can re-measure it cheaply.
+
+## Profiling a slow sync
+
+The benchmark suite measures the hot paths in-repo. To diagnose a slow
+`sync` in the field (a large monorepo, a specific adapter), `sync` has two
+opt-in hooks that need no benchmark harness.
+
+`--profile <file>` (or `AGNOSTIC_AI_PROFILE=<file>`) writes a
+`runtime/pprof` CPU profile of the whole run. It uses the stdlib profiler
+only and is off by default. Read it with the standard tool:
+
+```bash
+agnostic-ai sync --profile cpu.prof
+go tool pprof -top cpu.prof
+go tool pprof -http=:0 cpu.prof   # flame graph in the browser
+```
+
+`sync --verbose` appends per-target wall time to each target line, so a
+slow run attributes to a specific adapter without a profile:
+
+```
+→ claude: 12 created, 3 updated, 0 unchanged in 42ms
+→ codex: 40 created, 0 updated, 2 unchanged in 210ms
+✓ synced 2 targets · 55 files · 260ms
+```
+
+Each per-target time is measured around that target's emit and reported
+independently, so under `--jobs > 1` the times overlap. Read them as
+per-adapter cost, not a serial breakdown of the run total.
+
+The flag lives on the root command (`internal/cli/root.go`): profiling
+starts in the persistent pre-run hook and stops in the persistent post-run
+hook, so the profile covers a completed run. The per-target stopwatch wraps
+the emit call in `emitTargetsConcurrent` (`internal/cli/sync_run.go`).

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -12,6 +12,7 @@ agnostic-ai [command] [flags]
 | `--version` | Print version and exit |
 | `-q, --quiet` | Errors only |
 | `-v, --verbose` | Increase output verbosity (repeatable). Mutually exclusive with `--quiet`. |
+| `--profile <file>` | Write a `runtime/pprof` CPU profile of the run to `<file>` (or set `AGNOSTIC_AI_PROFILE`). Off by default; stdlib profiler only. Read it with `go tool pprof <file>`. |
 
 ## init
 
@@ -241,6 +242,20 @@ agnostic-ai sync [flags]
 | `--all` | Emit every configured target without the first-sync picker. Useful for ad-hoc full emission or scripted runs that bypass prompts. |
 | `--jobs <n>` | Number of targets to emit in parallel. `0` (default) uses one worker per CPU; `1` forces serial emission. Output (files, summary, JSON, gitignore, warnings) is byte-identical regardless of the value, so lower it only to debug or pin ordering. |
 | `--json` | Output as JSON instead of plain text. Stable schema; breaking changes bump `version`. |
+
+### Profiling a slow sync
+
+Two opt-in hooks show where `sync` spends its time.
+
+- `--profile <file>` (or `AGNOSTIC_AI_PROFILE=<file>`) writes a `runtime/pprof` CPU profile of the whole run. Open it with `go tool pprof <file>`. Off by default, stdlib profiler only.
+- `--verbose` appends per-target wall time to each target line, so cost attributes to a specific adapter.
+
+```
+→ claude: 12 created, 3 updated, 0 unchanged in 42ms
+✓ synced 1 target · 3 files · 44ms
+```
+
+The top summary line keeps the run total. Per-target times are measured around each emit, so under `--jobs > 1` they overlap: read them as per-adapter cost, not a serial breakdown.
 
 ### First-sync target picker
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,8 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
+	"runtime/pprof"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,6 +14,11 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
 )
+
+// envProfile is the env-var fallback for --profile. When set (and --profile
+// is empty), the command writes a runtime/pprof CPU profile of the run to
+// this path. Off by default; the flag wins when both are set.
+const envProfile = "AGNOSTIC_AI_PROFILE"
 
 // NewRootCmd builds the root command tree.
 func NewRootCmd(version string) *cobra.Command {
@@ -37,6 +44,14 @@ func NewRootCmd(version string) *cobra.Command {
 	root.PersistentFlags().CountP("verbose", "v", "Increase output verbosity")
 	root.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress non-error output")
 
+	// profilePath drives opt-in CPU profiling of the whole run. profileFile
+	// is captured by the pre/post hooks so the file opened before the command
+	// runs is flushed and closed after it finishes.
+	var profilePath string
+	var profileFile *os.File
+	root.PersistentFlags().StringVar(&profilePath, "profile", "",
+		"Write a runtime/pprof CPU profile of the run to this file (or set AGNOSTIC_AI_PROFILE); off by default")
+
 	// Cobra auto binds -v to --version when Version is set so
 	// So here taking -v back for verbosity by clearing the shorthand on the version flag.
 	root.InitDefaultVersionFlag()
@@ -56,7 +71,15 @@ func NewRootCmd(version string) *cobra.Command {
 		default:
 			verbosity = v
 		}
+		f, err := startCPUProfile(profilePath)
+		if err != nil {
+			return err
+		}
+		profileFile = f
 		return nil
+	}
+	root.PersistentPostRunE = func(_ *cobra.Command, _ []string) error {
+		return stopCPUProfile(profileFile)
 	}
 
 	root.AddCommand(
@@ -103,4 +126,41 @@ func loadProject(root string) (*config.Config, spec.Bundle, error) {
 		return nil, spec.Bundle{}, err
 	}
 	return cfg, b, nil
+}
+
+// startCPUProfile begins a runtime/pprof CPU profile for the current run. The
+// path comes from the --profile flag, or AGNOSTIC_AI_PROFILE when the flag is
+// empty. An empty path leaves profiling off and returns a nil file. Hand the
+// returned file to stopCPUProfile to flush and close it. Profiling is
+// stdlib-only and opt-in; an existing file at path is truncated.
+func startCPUProfile(path string) (*os.File, error) {
+	if path == "" {
+		path = os.Getenv(envProfile)
+	}
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("start cpu profile: %w", err)
+	}
+	return f, nil
+}
+
+// stopCPUProfile stops the CPU profile and closes its file. A nil file means
+// profiling was off, so it is a no-op. Stopping flushes the pprof payload, so
+// the file is a complete profile only after this returns.
+func stopCPUProfile(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	pprof.StopCPUProfile()
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("%s: %w", f.Name(), err)
+	}
+	return nil
 }

--- a/internal/cli/sync_profile_test.go
+++ b/internal/cli/sync_profile_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// TestSync_ProfileFlagWritesCPUProfile verifies --profile writes a non-empty
+// runtime/pprof CPU profile for the run. runtime/pprof frames the profile as
+// gzip, so a valid file decodes back to a non-empty payload with the stdlib
+// alone (no external pprof parser, per the profiling scope).
+func TestSync_ProfileFlagWritesCPUProfile(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	prof := filepath.Join(t.TempDir(), "cpu.prof")
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude", "--profile", prof})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync --profile: %v", err)
+	}
+
+	assertValidCPUProfile(t, prof)
+}
+
+// TestSync_ProfileEnvWritesCPUProfile verifies AGNOSTIC_AI_PROFILE is the
+// env-var fallback for --profile, so profiling can be turned on without
+// touching the command line.
+func TestSync_ProfileEnvWritesCPUProfile(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	prof := filepath.Join(t.TempDir(), "cpu.prof")
+	t.Setenv("AGNOSTIC_AI_PROFILE", prof)
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync with AGNOSTIC_AI_PROFILE: %v", err)
+	}
+
+	assertValidCPUProfile(t, prof)
+}
+
+// TestSync_VerboseShowsPerTargetTiming verifies the --verbose summary appends
+// per-target wall time to each target line, so a slow sync can be attributed
+// to a specific adapter.
+func TestSync_VerboseShowsPerTargetTiming(t *testing.T) {
+	dir := setupFixture(t)
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	prev := logOut
+	buf := &bytes.Buffer{}
+	logOut = buf
+	t.Cleanup(func() { logOut = prev })
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"-v", "sync", "-t", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync -v: %v", err)
+	}
+
+	out := buf.String()
+	if !regexp.MustCompile(`→ claude:.*\bin \d+ms`).MatchString(out) {
+		t.Errorf("expected a per-target ms token in verbose output, got:\n%s", out)
+	}
+}
+
+// assertValidCPUProfile fails unless path holds a non-empty CPU profile.
+// runtime/pprof writes a gzip-framed protobuf, so the check reads the file,
+// confirms the gzip framing, and decodes it to a non-empty payload using the
+// stdlib only.
+func assertValidCPUProfile(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("profile file is empty")
+	}
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("profile is not a gzip-framed pprof: %v", err)
+	}
+	defer func() { _ = gr.Close() }()
+	payload, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("decode profile: %v", err)
+	}
+	if len(payload) == 0 {
+		t.Fatal("profile payload is empty")
+	}
+}

--- a/internal/cli/sync_run.go
+++ b/internal/cli/sync_run.go
@@ -112,6 +112,7 @@ type targetEmit struct {
 	recorded []string // gitignore paths; empty unless gitignore recording is on
 	resolved bool     // false when the adapter could not be resolved (skippable)
 	err      error
+	dur      time.Duration // wall time the target's emit took, for the verbose summary
 }
 
 // resolveJobs maps the --jobs flag to a worker count: 0 or negative means
@@ -216,12 +217,14 @@ func emitTargetsConcurrent(targets []string, b spec.Bundle, cfg *config.Config, 
 				if gitignoreOn {
 					sess.StartRecording()
 				}
+				emitStart := time.Now()
 				writes, resolved, err := emitTarget(sess, targets[idx], b, cfg, dryRun)
+				emitDur := time.Since(emitStart)
 				var recorded []string
 				if gitignoreOn {
 					recorded = sess.StopRecording()
 				}
-				results[idx] = targetEmit{target: targets[idx], writes: writes, recorded: recorded, resolved: resolved, err: err}
+				results[idx] = targetEmit{target: targets[idx], writes: writes, recorded: recorded, resolved: resolved, err: err, dur: emitDur}
 				if failFast && err != nil && resolved {
 					return fmt.Errorf("%s: %w", targets[idx], err)
 				}
@@ -390,7 +393,7 @@ func runSyncOnce(root string, targets []string, dryRun, backup bool, gitignoreFl
 		created, updated, skipped := classifyDetailedWrites(e.writes)
 		filesChanged += created + updated
 		if verbose {
-			verbosef("→ %s: %d created, %d updated, %d unchanged\n", e.target, created, updated, skipped)
+			verbosef("→ %s: %d created, %d updated, %d unchanged in %dms\n", e.target, created, updated, skipped, e.dur.Milliseconds())
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds opt-in sync perf observability so a slow sync can be diagnosed in the field, complementing the in-repo benchmark suite (which measures in-repo; this measures in the field).

- `--profile <file>` (or `AGNOSTIC_AI_PROFILE`) writes a `runtime/pprof` CPU profile of the whole run. Stdlib profiler only, off by default. Profiling starts in the root persistent pre-run hook and stops in the post-run hook, so it covers a completed run.
- `sync --verbose` appends per-target wall time (`in Nms`) to each target line, so cost attributes to a specific adapter. The stopwatch wraps the existing per-target emit call; the emission loop and the top-line total (`synced N targets, M files, Xms`) are unchanged.

## Scope

Stays within the issue boundary:

- `internal/cli/root.go`: `--profile` persistent flag, `AGNOSTIC_AI_PROFILE` env fallback, and the CPU-profile start/stop helpers.
- `internal/cli/sync_run.go`: per-target stopwatch around the existing emit call (no loop restructure); the verbose line gains `in Nms`.
- Docs: `docs/user/cli-reference.md`, `docs/internal/benchmarks.md`, `CHANGELOG.md`.

No external dependencies (`go.mod` / `go.sum` unchanged).

## Test plan

New tests in `internal/cli/sync_profile_test.go`:

- `--profile` writes a non-empty, gzip-framed pprof file that decodes back with the stdlib (no external pprof parser).
- `AGNOSTIC_AI_PROFILE` is the env fallback for the flag.
- `--verbose` output carries a per-target `ms` token.

Local gates, all green:

- `gofmt -l .` empty
- `golangci-lint run ./...` reported `0 issues`
- `go vet ./...`, `go build ./...`, `go test ./...` pass

Also smoke-tested end to end: `go tool pprof` reads the emitted profile (`Type: cpu`), and `-v sync` prints per-target `in Nms` while the total summary stays intact.

No follow-up `ref(...)` polish commit was needed; the review pass found nothing to change.

Closes #491
