### PR TITLE
perf(emit): capture-compare fast-path via size pre-check

### DIFF
--- a/docs/internal/benchmarks.md
+++ b/docs/internal/benchmarks.md
@@ -7,9 +7,10 @@ The rule blocks refactoring a hot path without a bench, so this suite is a
 prerequisite for the perf work (capture fast-path, parallel emission,
 render memoization).
 
-The benchmarks live in `internal/cli/bench_test.go`, colocated so they can
-call the unexported sync internals directly. Fixtures use `testing` only,
-no external deps.
+Most benchmarks live in `internal/cli/bench_test.go`, colocated so they can
+call the unexported sync internals directly. `BenchmarkCompareToDisk` lives
+in `internal/adapters/internal/emit` beside the compare helper it measures.
+Fixtures use `testing` only, no external deps.
 
 ## Run
 
@@ -42,6 +43,7 @@ not pass or fail.
 | `BenchmarkSyncCheck` | The `--check` capture-compare pass against an in-sync tree. |
 | `BenchmarkEntryPointRender` | Entry-point body render plus byte-dedupe across targets. |
 | `BenchmarkFolderFingerprint` | Shared-skills folder fingerprint (`folderFingerprint`). |
+| `BenchmarkCompareToDisk` | Capture-compare drift verdict: status-quo full read vs the `CompareToDisk` size-precheck fast path, swept by scenario and file size. |
 
 ## Read the output
 

--- a/internal/adapters/internal/emit/compare.go
+++ b/internal/adapters/internal/emit/compare.go
@@ -1,0 +1,80 @@
+package emit
+
+import (
+	"fmt"
+	"os"
+)
+
+// DiskState classifies how a candidate file's content relates to what is
+// currently on disk at its path. It is the verdict returned by CompareToDisk
+// and mirrors the buckets `sync --check` and `doctor` report: in-sync,
+// missing, or stale (a local edit sync would overwrite).
+type DiskState int
+
+const (
+	// DiskStale is the zero value on purpose. A dropped or unchecked verdict
+	// must surface as drift, never as a false "in sync": reporting a dirty
+	// tree as clean is the one failure mode drift detection may not have. It
+	// means the file exists but its bytes differ from the candidate content.
+	DiskStale DiskState = iota
+	// DiskInSync means the file exists and its bytes equal the candidate.
+	DiskInSync
+	// DiskMissing means no file exists at the path yet.
+	DiskMissing
+)
+
+// String renders the verdict for test output and diagnostics.
+func (s DiskState) String() string {
+	switch s {
+	case DiskInSync:
+		return "in-sync"
+	case DiskMissing:
+		return "missing"
+	case DiskStale:
+		return "stale"
+	default:
+		return fmt.Sprintf("DiskState(%d)", int(s))
+	}
+}
+
+// CompareToDisk reports how content compares to the file already at path,
+// classifying it as in-sync, missing, or stale. It is the capture-compare
+// primitive behind drift detection: a captured would-be output is diffed
+// against the artifact currently on disk.
+//
+// It short-circuits on size. A regular file whose byte size differs from
+// len(content) is provably stale, so its body is never read. The cheap stat
+// alone settles the verdict. Size is a negative signal only: equal size is
+// necessary but not sufficient for equality, so a same-size hand edit still
+// triggers a full byte compare and is reported stale. The verdict is
+// therefore identical to an unconditional full read; only the I/O differs.
+func CompareToDisk(path, content string) (DiskState, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DiskMissing, nil
+		}
+		return DiskStale, fmt.Errorf("stat %s: %w", path, err)
+	}
+	// Fast path: a size mismatch on a regular file proves drift without
+	// reading the body. Irregular entries (a directory shadowing the path,
+	// say) fall through to the read below so their error handling matches an
+	// unconditional os.ReadFile rather than being silently classified.
+	if info.Mode().IsRegular() && info.Size() != int64(len(content)) {
+		return DiskStale, nil
+	}
+	disk, err := os.ReadFile(path)
+	if err != nil {
+		// The file vanished between the stat and the read (a concurrent sync,
+		// say). Treat it as missing, exactly as a plain os.ReadFile of an
+		// absent file would be classified.
+		if os.IsNotExist(err) {
+			return DiskMissing, nil
+		}
+		return DiskStale, fmt.Errorf("read %s: %w", path, err)
+	}
+	if string(disk) != content {
+		return DiskStale, nil
+	}
+	return DiskInSync, nil
+}

--- a/internal/adapters/internal/emit/compare_test.go
+++ b/internal/adapters/internal/emit/compare_test.go
@@ -1,0 +1,212 @@
+package emit
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fullCompare is the status-quo oracle: an unconditional full read followed
+// by a byte compare, exactly what the capture-compare path does today
+// (internal/cli/check.go). CompareToDisk must return an identical verdict for
+// every input; only its I/O may differ. It is also the "status-quo" subject
+// in BenchmarkCompareToDisk.
+func fullCompare(path, content string) (DiskState, error) {
+	disk, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DiskMissing, nil
+		}
+		return DiskStale, fmt.Errorf("read %s: %w", path, err)
+	}
+	if string(disk) != content {
+		return DiskStale, nil
+	}
+	return DiskInSync, nil
+}
+
+// The fast path must never diverge from a full read. For thousands of random
+// (on-disk, candidate) pairs, deliberately weighted toward same-size but
+// different content (the one case a naive size check would get wrong), the
+// size-precheck verdict has to equal the full-compare verdict.
+func TestCompareToDisk_MatchesFullCompareOracle(t *testing.T) {
+	r := rand.New(rand.NewPCG(0x9e3779b9, 0x7f4a7c15))
+	dir := t.TempDir()
+	const iters = 3000
+	for i := 0; i < iters; i++ {
+		disk := randBytes(r, 64)
+		cand := mutate(r, disk)
+		// One file in five is left absent so the missing verdict is exercised.
+		present := r.IntN(5) != 0
+		path := filepath.Join(dir, fmt.Sprintf("f-%05d", i))
+		if present {
+			if err := os.WriteFile(path, disk, filePerm); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+		}
+
+		gotState, gotErr := CompareToDisk(path, string(cand))
+		wantState, wantErr := fullCompare(path, string(cand))
+		if (gotErr == nil) != (wantErr == nil) {
+			t.Fatalf("iter %d: error mismatch: fast=%v full=%v", i, gotErr, wantErr)
+		}
+		if gotState != wantState {
+			t.Fatalf("iter %d: verdict diverged: fast=%s full=%s (disk=%dB cand=%dB present=%v)",
+				i, gotState, wantState, len(disk), len(cand), present)
+		}
+	}
+}
+
+// The marquee correctness case, stated flatly so intent is unmistakable:
+// content that is the same length as the file on disk but different byte for
+// byte must still be caught as stale. Size may never mask drift.
+func TestCompareToDisk_SameSizeDifferentContentIsStale(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "same-size")
+	if err := os.WriteFile(path, []byte("hello world"), filePerm); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	// "hello world" and "hello WORLD" are both 11 bytes: a size collision.
+	got, err := CompareToDisk(path, "hello WORLD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != DiskStale {
+		t.Fatalf("size-equal different content must be %s, got %s", DiskStale, got)
+	}
+}
+
+func TestCompareToDisk_Verdicts(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		disk    string // on-disk content; write skipped when absent is true
+		absent  bool
+		content string // candidate content
+		want    DiskState
+	}{
+		{name: "in-sync", disk: "same", content: "same", want: DiskInSync},
+		{name: "missing", absent: true, content: "anything", want: DiskMissing},
+		{name: "stale-larger", disk: "short", content: "much longer body", want: DiskStale},
+		{name: "stale-smaller", disk: "much longer body", content: "short", want: DiskStale},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.name)
+			if !tt.absent {
+				if err := os.WriteFile(path, []byte(tt.disk), filePerm); err != nil {
+					t.Fatalf("write fixture: %v", err)
+				}
+			}
+			got, err := CompareToDisk(path, tt.content)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// randBytes returns a random byte slice of length in [0, maxLen].
+func randBytes(r *rand.Rand, maxLen int) []byte {
+	b := make([]byte, r.IntN(maxLen+1))
+	for i := range b {
+		b[i] = byte(r.IntN(256))
+	}
+	return b
+}
+
+// mutate derives a candidate from the on-disk bytes, spread across the four
+// cases the compare must distinguish: identical, same-length-but-different
+// (the size-collision stressor), a different length, and fully random.
+func mutate(r *rand.Rand, disk []byte) []byte {
+	switch r.IntN(4) {
+	case 0: // identical
+		return append([]byte(nil), disk...)
+	case 1: // same length, at least one byte guaranteed different
+		c := append([]byte(nil), disk...)
+		if len(c) == 0 {
+			return c // empty has no byte to flip; stays identical
+		}
+		c[r.IntN(len(c))] ^= byte(1 + r.IntN(255))
+		return c
+	case 2: // different length
+		return append(append([]byte(nil), disk...), byte(r.IntN(256)))
+	default: // fully random content and length
+		return randBytes(r, 64)
+	}
+}
+
+// benchStateSink defeats dead-code elimination of the benchmarked verdict.
+var benchStateSink DiskState
+
+// BenchmarkCompareToDisk is the decision artifact required by
+// bench-before-perf-refactor.md. It puts two subjects side by side over one
+// on-disk file per scenario, reporting μs/call so the crossover can be
+// computed:
+//
+//   - status-quo: fullCompare, an unconditional full read then byte compare.
+//     For a pure I/O short-circuit the naive baseline and the status-quo
+//     coincide (both always read the whole body), so two subjects capture it.
+//   - fast-path:  CompareToDisk, which stats first and reads only when the
+//     size matches.
+//
+// Scenarios model where the two diverge:
+//
+//   - insync:         candidate == disk. Sizes match, so the fast path reads
+//     anyway and pays an extra stat (its worst case).
+//   - drift-samesize: same length, different bytes. Fast path still reads
+//     (and must still catch the drift), paying the extra stat.
+//   - drift-diffsize: sizes differ. Fast path returns on the stat alone and
+//     never reads the body. This is where the win lives, growing with size.
+//
+// Sizes sweep small to large because the saved read scales with the body.
+func BenchmarkCompareToDisk(b *testing.B) {
+	sizes := []int{200, 4 << 10, 64 << 10} // 200 B, 4 KiB, 64 KiB
+	scenarios := []struct {
+		name string
+		cand func(disk string) string
+	}{
+		{"insync", func(disk string) string { return disk }},
+		{"drift-samesize", func(disk string) string {
+			return disk[:len(disk)-1] + "Z" // same length, last byte differs
+		}},
+		{"drift-diffsize", func(disk string) string { return disk + "extra" }},
+	}
+	subjects := []struct {
+		name string
+		cmp  func(path, content string) (DiskState, error)
+	}{
+		{"status-quo", fullCompare},
+		{"fast-path", CompareToDisk},
+	}
+	for _, sz := range sizes {
+		disk := strings.Repeat("a", sz)
+		for _, sc := range scenarios {
+			cand := sc.cand(disk)
+			for _, sub := range subjects {
+				b.Run(fmt.Sprintf("%s/size=%dB/%s", sc.name, sz, sub.name), func(b *testing.B) {
+					dir := b.TempDir()
+					path := filepath.Join(dir, "artifact")
+					if err := os.WriteFile(path, []byte(disk), filePerm); err != nil {
+						b.Fatalf("write fixture: %v", err)
+					}
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						st, err := sub.cmp(path, cand)
+						if err != nil {
+							b.Fatalf("compare: %v", err)
+						}
+						benchStateSink = st
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `CompareToDisk` to `internal/adapters/internal/emit`: the capture-compare primitive behind drift detection, with a size pre-check fast path.

Today the compare reads every candidate's full body off disk to byte-compare it (`internal/cli/check.go`), even when a size mismatch already proves drift. `CompareToDisk` stats first:

- On-disk size differs from `len(content)` (regular file): report **stale** without reading the body.
- Sizes equal: fall back to a full byte compare. Size is a negative signal only, so a same-size hand edit is still caught. Never a false "in sync".

Verdict is identical to an unconditional full read; only the I/O differs.

### Scope

Per the issue boundary, this lands the **primitive plus its proof only**. Wiring it into the check/dedup call sites is the separate emit-state-plumbing issue. `CompareToDisk` is exported and unused in production for now; `unused`/staticcheck do not flag it (exported API of an importable package), and `golangci-lint run ./...` is clean.

## Bench (decision artifact)

`BenchmarkCompareToDisk` lives beside the helper and is part of the permanent suite (`make bench` runs `./...`). Two subjects side by side (`status-quo` = unconditional full read = the naive baseline for a pure I/O short-circuit; `fast-path` = `CompareToDisk`), swept by scenario and file size. Apple M4 Pro, warm page cache, `-benchtime=1s`, μs/call:

| Scenario | Size | status-quo | fast-path | Δ (fast − status-quo) |
| --- | --- | --- | --- | --- |
| insync | 200 B | 9.19 | 10.35 | +1.16 |
| insync | 4 KiB | 9.53 | 10.60 | +1.07 |
| insync | 64 KiB | 15.47 | 16.89 | +1.42 |
| drift-samesize | 200 B | 9.24 | 10.52 | +1.28 |
| drift-samesize | 4 KiB | 9.58 | 10.76 | +1.18 |
| drift-samesize | 64 KiB | 15.74 | 16.89 | +1.15 |
| drift-diffsize | 200 B | 9.24 | **1.07** | **−8.17 (8.6×)** |
| drift-diffsize | 4 KiB | 9.52 | **1.06** | **−8.46 (9.0×)** |
| drift-diffsize | 64 KiB | 14.28 | **1.06** | **−13.22 (13.4×)** |

Allocations on the size-differing drift path also drop from 5 to 2 and B/op from ~74 KB to 336 B at 64 KiB (stat only, no buffer).

### Crossover

Two costs: a stat added on every read-anyway file (`S ≈ 1.2 μs/call`, size-independent) and a read saved on every size-differing drift file (`R_saved ≈ 8.2 μs` at 200 B to `13.2 μs` at 64 KiB). Over a tree with fraction `p` of size-differing drift, the fast path is a net win when `p > S / (R_saved + S)`:

- 64 KiB files: `p* ≈ 10%`
- 4 KiB files: `p* ≈ 12%`
- 200 B files: `p* ≈ 13%`

So above roughly **1 file in 8 to 1 in 10** differing in size, the fast path wins; on a fully in-sync tree it is a bounded ~1.2 μs/file loss (the extra stat; ~0.6 ms for a 500-file tree). These are warm-cache numbers: a cold cache (fresh CI checkout) makes the saved read far more expensive while the stat stays cheap, lowering the crossover and widening the win.

### Recommendation: keep

The payoff is asymmetric in the right direction. Large, size-growing win (8–13×) exactly on the case the issue names (size-differing drift, where the full read is wasted), against a small, bounded, size-independent cost otherwise. The crossover (~10%) is realistic: editing specs and regenerating flips many file sizes. Cold-cache reality favors it further. Not "no win", so shipping the helper (not closing won't-fix) is the correct outcome; the wiring issue can adopt it with these numbers in hand.

## Correctness

Verdict is identical to today's full-read compare.

- Property test `TestCompareToDisk_MatchesFullCompareOracle`: 3000 random `(on-disk, candidate)` pairs, deliberately weighted toward the same-size-different-content collision, assert fast-path verdict == full-read oracle for every input (including missing files).
- `TestCompareToDisk_SameSizeDifferentContentIsStale`: the marquee case stated flatly (`"hello world"` vs `"hello WORLD"`, both 11 bytes) must be stale.
- `TestCompareToDisk_Verdicts`: in-sync, missing, stale-larger, stale-smaller.
- Full golden/capability suite green (`make preflight`), so drift verdicts are unchanged.

## Local gates (all pass)

- `gofmt -l .`: empty
- `golangci-lint run ./...`: **0 issues**
- `go vet ./...`, `go build ./...`, `go test ./...`: green (1399 tests, 33 packages)
- `make preflight`: ok
- `sync --check`: no new drift (the only drift reported is pre-existing missing generated outputs in a fresh worktree; zero "stale" from this change)

No `ref(...)` polish commit needed: the single commit is clean (lint + plain-english).

## Files changed

- `internal/adapters/internal/emit/compare.go` (new): `CompareToDisk`, `DiskState`.
- `internal/adapters/internal/emit/compare_test.go` (new): property test, verdict tests, `BenchmarkCompareToDisk`.
- `docs/internal/benchmarks.md`: catalog the new bench and note it lives in the emit package.

Closes #492
