### PR TITLE
test: enable parallel tests by removing global-cwd dependence

### DIFF
--- a/internal/adapters/aider/aider_test.go
+++ b/internal/adapters/aider/aider_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/spec"
-	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
 
 // TestEmit_ConfFileCaptureReadsExistingUserKeys regresses #465. Under
@@ -20,8 +19,8 @@ import (
 // Otherwise doctor reports false drift and --fix writes the managed keys
 // only, deleting the user's config.
 func TestEmit_ConfFileCaptureReadsExistingUserKeys(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	testutil.Chdir(t, dir)
 
 	const existing = "auto-commits: false\nmodel: legacy-model\n"
 	if err := os.WriteFile(filepath.Join(dir, ".aider.conf.yml"), []byte(existing), 0o644); err != nil {
@@ -29,7 +28,7 @@ func TestEmit_ConfFileCaptureReadsExistingUserKeys(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Outputs: map[string]config.Output{
-			"aider": {ConfFile: ".aider.conf.yml"},
+			"aider": {ConfFile: filepath.Join(dir, ".aider.conf.yml")},
 		},
 	}
 	entries := []spec.Entry{
@@ -61,8 +60,8 @@ func TestEmit_ConfFileCaptureReadsExistingUserKeys(t *testing.T) {
 }
 
 func TestEmit_NoConventionsByDefault(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	testutil.Chdir(t, dir)
 
 	a := New()
 	if a.Name() != "aider" {
@@ -84,11 +83,11 @@ func TestEmit_NoConventionsByDefault(t *testing.T) {
 }
 
 func TestEmit_LegacyRulesFile_WritesConcatenated(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	testutil.Chdir(t, dir)
 
 	cfg := &config.Config{
-		Outputs: map[string]config.Output{"aider": {RulesFile: "CONVENTIONS.md"}},
+		Outputs: map[string]config.Output{"aider": {RulesFile: filepath.Join(dir, "CONVENTIONS.md")}},
 	}
 	entries := []spec.Entry{
 		{Kind: spec.KindRule, Name: "r1", Path: "rules/r1.md", Body: "rule body"},
@@ -114,13 +113,13 @@ func TestEmit_LegacyRulesFile_WritesConcatenated(t *testing.T) {
 }
 
 func TestEmit_WritesConfFileWhenConfigured(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	testutil.Chdir(t, dir)
 
 	cfg := &config.Config{
 		Outputs: map[string]config.Output{
 			"aider": {
-				ConfFile:  ".aider.conf.yml",
+				ConfFile:  filepath.Join(dir, ".aider.conf.yml"),
 				Model:     "gpt-4o",
 				WeakModel: "gpt-4o-mini",
 			},
@@ -146,8 +145,8 @@ func TestEmit_WritesConfFileWhenConfigured(t *testing.T) {
 }
 
 func TestEmit_ConfFileMergesPreservingUserKeys(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	testutil.Chdir(t, dir)
 
 	existing := "auto-commits: false\nread:\n  - notes.md\nmodel: legacy-model\n"
 	if err := os.WriteFile(filepath.Join(dir, ".aider.conf.yml"), []byte(existing), 0o644); err != nil {
@@ -156,7 +155,7 @@ func TestEmit_ConfFileMergesPreservingUserKeys(t *testing.T) {
 
 	cfg := &config.Config{
 		Outputs: map[string]config.Output{
-			"aider": {ConfFile: ".aider.conf.yml"},
+			"aider": {ConfFile: filepath.Join(dir, ".aider.conf.yml")},
 		},
 	}
 	entries := []spec.Entry{
@@ -180,8 +179,8 @@ func TestEmit_ConfFileMergesPreservingUserKeys(t *testing.T) {
 }
 
 func TestEmit_ConfFileDoesNotDuplicateReadEntry(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	testutil.Chdir(t, dir)
 
 	existing := "read:\n  - CONVENTIONS.md\n"
 	if err := os.WriteFile(filepath.Join(dir, ".aider.conf.yml"), []byte(existing), 0o644); err != nil {
@@ -190,7 +189,7 @@ func TestEmit_ConfFileDoesNotDuplicateReadEntry(t *testing.T) {
 
 	cfg := &config.Config{
 		Outputs: map[string]config.Output{
-			"aider": {ConfFile: ".aider.conf.yml"},
+			"aider": {ConfFile: filepath.Join(dir, ".aider.conf.yml")},
 		},
 	}
 	if err := New().Emit(emit.NewSession(), spec.NewBundle(nil), cfg, false); err != nil {
@@ -205,8 +204,8 @@ func TestEmit_ConfFileDoesNotDuplicateReadEntry(t *testing.T) {
 }
 
 func TestEmit_ConfFilePromotesScalarRead(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	testutil.Chdir(t, dir)
 
 	existing := "read: notes.md\n"
 	if err := os.WriteFile(filepath.Join(dir, ".aider.conf.yml"), []byte(existing), 0o644); err != nil {
@@ -215,7 +214,7 @@ func TestEmit_ConfFilePromotesScalarRead(t *testing.T) {
 
 	cfg := &config.Config{
 		Outputs: map[string]config.Output{
-			"aider": {ConfFile: ".aider.conf.yml"},
+			"aider": {ConfFile: filepath.Join(dir, ".aider.conf.yml")},
 		},
 	}
 	if err := New().Emit(emit.NewSession(), spec.NewBundle(nil), cfg, false); err != nil {

--- a/internal/adapters/external/external_test.go
+++ b/internal/adapters/external/external_test.go
@@ -77,6 +77,7 @@ func helperCommand(mode string) func() *exec.Cmd {
 }
 
 func TestAdapter_Emit_RoundTrips(t *testing.T) {
+	t.Parallel()
 	adapter := NewWithCommand("fake", helperCommand("echo"))
 
 	bundle := spec.Bundle{
@@ -107,6 +108,7 @@ func TestAdapter_Emit_RoundTrips(t *testing.T) {
 }
 
 func TestAdapter_Emit_AdapterErrorBubbles(t *testing.T) {
+	t.Parallel()
 	adapter := NewWithCommand("fake", helperCommand("fail"))
 	err := adapter.Emit(emit.NewSession(), spec.Bundle{}, &config.Config{}, false)
 	if err == nil || !strings.Contains(err.Error(), "adapter said no") {
@@ -134,6 +136,7 @@ func TestAdapter_Emit_WarningsRoutedToWarner(t *testing.T) {
 }
 
 func TestAdapter_Emit_RejectsBadJSON(t *testing.T) {
+	t.Parallel()
 	adapter := NewWithCommand("fake", helperCommand("bad-json"))
 	err := adapter.Emit(emit.NewSession(), spec.Bundle{}, &config.Config{}, false)
 	if err == nil || !strings.Contains(err.Error(), "decode output") {
@@ -153,6 +156,7 @@ func TestNew_ReturnsErrNotFound_OnMissingBinary(t *testing.T) {
 }
 
 func TestValidateName(t *testing.T) {
+	t.Parallel()
 	bad := []string{"", "foo/bar", `foo\bar`, "-foo"}
 	for _, n := range bad {
 		if err := validateName(n); err == nil {
@@ -168,6 +172,7 @@ func TestValidateName(t *testing.T) {
 }
 
 func TestBuildInput_PreservesEntryFields(t *testing.T) {
+	t.Parallel()
 	b := spec.Bundle{
 		Agents: []spec.Entry{{
 			Kind:  spec.KindAgent,
@@ -193,6 +198,7 @@ func TestBuildInput_PreservesEntryFields(t *testing.T) {
 }
 
 func TestEncodeOutput_DefaultsProtocolVersion(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	if err := EncodeOutput(&buf, Output{Files: []File{{Path: "x"}}}); err != nil {
 		t.Fatal(err)

--- a/internal/adapters/internal/emit/agents_tree_test.go
+++ b/internal/adapters/internal/emit/agents_tree_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRouteScope_SourceLayoutWinsOverGlobs(t *testing.T) {
+	t.Parallel()
 	r := spec.Entry{
 		Scope: "backend",
 		Meta:  map[string]any{"globs": "frontend/**"},
@@ -18,6 +19,7 @@ func TestRouteScope_SourceLayoutWinsOverGlobs(t *testing.T) {
 }
 
 func TestRouteScope_GlobsPrefixWhenNoSourceScope(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		globs string
 		want  string
@@ -38,6 +40,7 @@ func TestRouteScope_GlobsPrefixWhenNoSourceScope(t *testing.T) {
 }
 
 func TestGroupRulesByScope_BucketsByRouteScope(t *testing.T) {
+	t.Parallel()
 	rules := []spec.Entry{
 		{Name: "root1"},
 		{Name: "scoped", Scope: "backend"},

--- a/internal/adapters/internal/emit/backup_test.go
+++ b/internal/adapters/internal/emit/backup_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestWriteFile_BackupCreatesBakWhenContentDiffers(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CLAUDE.md")
@@ -36,6 +37,7 @@ func TestWriteFile_BackupCreatesBakWhenContentDiffers(t *testing.T) {
 }
 
 func TestWriteFile_BackupSkippedWhenContentEqual(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CLAUDE.md")
@@ -56,6 +58,7 @@ func TestWriteFile_BackupSkippedWhenContentEqual(t *testing.T) {
 }
 
 func TestWriteFile_BackupSkippedForNewFile(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "fresh.md")
@@ -71,6 +74,7 @@ func TestWriteFile_BackupSkippedForNewFile(t *testing.T) {
 }
 
 func TestWriteFile_BackupOffByDefault(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CLAUDE.md")

--- a/internal/adapters/internal/emit/compare_test.go
+++ b/internal/adapters/internal/emit/compare_test.go
@@ -33,6 +33,7 @@ func fullCompare(path, content string) (DiskState, error) {
 // different content (the one case a naive size check would get wrong), the
 // size-precheck verdict has to equal the full-compare verdict.
 func TestCompareToDisk_MatchesFullCompareOracle(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewPCG(0x9e3779b9, 0x7f4a7c15))
 	dir := t.TempDir()
 	const iters = 3000
@@ -64,6 +65,7 @@ func TestCompareToDisk_MatchesFullCompareOracle(t *testing.T) {
 // content that is the same length as the file on disk but different byte for
 // byte must still be caught as stale. Size may never mask drift.
 func TestCompareToDisk_SameSizeDifferentContentIsStale(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "same-size")
 	if err := os.WriteFile(path, []byte("hello world"), filePerm); err != nil {
@@ -80,6 +82,7 @@ func TestCompareToDisk_SameSizeDifferentContentIsStale(t *testing.T) {
 }
 
 func TestCompareToDisk_Verdicts(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	tests := []struct {
 		name    string

--- a/internal/adapters/internal/emit/document_test.go
+++ b/internal/adapters/internal/emit/document_test.go
@@ -3,6 +3,7 @@ package emit
 import "testing"
 
 func TestDocument_EmptyMetaReturnsBodyOnly(t *testing.T) {
+	t.Parallel()
 	got := Document(nil, "hello body\n", "claude")
 	if got != "hello body\n" {
 		t.Errorf("expected body-only, got %q", got)
@@ -10,6 +11,7 @@ func TestDocument_EmptyMetaReturnsBodyOnly(t *testing.T) {
 }
 
 func TestDocument_EmptyMetaMapReturnsBodyOnly(t *testing.T) {
+	t.Parallel()
 	got := Document(map[string]any{}, "hello body\n", "claude")
 	if got != "hello body\n" {
 		t.Errorf("expected body-only, got %q", got)
@@ -17,6 +19,7 @@ func TestDocument_EmptyMetaMapReturnsBodyOnly(t *testing.T) {
 }
 
 func TestDocument_PrependsFrontmatterWithSeparatingNewline(t *testing.T) {
+	t.Parallel()
 	got := Document(map[string]any{"name": "r1"}, "body line\n", "claude")
 	want := "---\nname: r1\n---\n\nbody line\n"
 	if got != want {
@@ -25,6 +28,7 @@ func TestDocument_PrependsFrontmatterWithSeparatingNewline(t *testing.T) {
 }
 
 func TestDocument_ResolvesTargetSpecificMeta(t *testing.T) {
+	t.Parallel()
 	meta := map[string]any{
 		"name":     "r1",
 		"x-claude": map[string]any{"allowed-tools": []any{"Read"}},

--- a/internal/adapters/internal/emit/hook_path_test.go
+++ b/internal/adapters/internal/emit/hook_path_test.go
@@ -3,6 +3,7 @@ package emit
 import "testing"
 
 func TestRewriteHookPath_TranslatesSiblingPrefix(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name, cmd, target, want string
 	}{

--- a/internal/adapters/internal/emit/ignore_test.go
+++ b/internal/adapters/internal/emit/ignore_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestIgnoreBody_ConcatenatesTrimmed(t *testing.T) {
+	t.Parallel()
 	got := IgnoreBody([]spec.Entry{
 		{Body: "*.env\n"},
 		{Body: "  \n"}, // blank-only: skipped
@@ -22,6 +23,7 @@ func TestIgnoreBody_ConcatenatesTrimmed(t *testing.T) {
 }
 
 func TestWriteIgnoreFile_WritesHeaderAndPatterns(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".cursorignore")
@@ -42,6 +44,7 @@ func TestWriteIgnoreFile_WritesHeaderAndPatterns(t *testing.T) {
 }
 
 func TestWriteIgnoreFile_NoOpWhenEmpty(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".cursorignore")

--- a/internal/adapters/internal/emit/json_indent_test.go
+++ b/internal/adapters/internal/emit/json_indent_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestDetectJSONIndent(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   string
@@ -28,6 +29,7 @@ func TestDetectJSONIndent(t *testing.T) {
 }
 
 func TestMarshalJSONIndentWith_PreservesIndent(t *testing.T) {
+	t.Parallel()
 	doc := NewOrderedJSON()
 	_ = doc.Set("a", 1)
 

--- a/internal/adapters/internal/emit/mcp_test.go
+++ b/internal/adapters/internal/emit/mcp_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestMCPDocument_ServersMap(t *testing.T) {
+	t.Parallel()
 	mcps := []spec.Entry{
 		{
 			Kind: spec.KindMCP,
@@ -49,6 +50,7 @@ func TestMCPDocument_ServersMap(t *testing.T) {
 }
 
 func TestMCPDocument_VSCodeServers(t *testing.T) {
+	t.Parallel()
 	mcps := []spec.Entry{
 		{
 			Kind: spec.KindMCP,
@@ -72,6 +74,7 @@ func TestMCPDocument_VSCodeServers(t *testing.T) {
 }
 
 func TestMCPDocument_HTTPTransport(t *testing.T) {
+	t.Parallel()
 	mcps := []spec.Entry{
 		{
 			Kind: spec.KindMCP,
@@ -98,6 +101,7 @@ func TestMCPDocument_HTTPTransport(t *testing.T) {
 }
 
 func TestMCPDocument_DescriptionAndDisabled(t *testing.T) {
+	t.Parallel()
 	mcps := []spec.Entry{
 		{
 			Kind: spec.KindMCP,
@@ -127,6 +131,7 @@ func TestMCPDocument_DescriptionAndDisabled(t *testing.T) {
 }
 
 func TestMCPDocument_Roots(t *testing.T) {
+	t.Parallel()
 	mcps := []spec.Entry{
 		{
 			Kind: spec.KindMCP,
@@ -149,6 +154,7 @@ func TestMCPDocument_Roots(t *testing.T) {
 }
 
 func TestMCPDocument_SSETransport(t *testing.T) {
+	t.Parallel()
 	mcps := []spec.Entry{
 		{
 			Kind: spec.KindMCP,
@@ -183,6 +189,7 @@ func TestMCPDocument_SSETransport(t *testing.T) {
 }
 
 func TestMCPDocument_StdioTypeOnlyWhenVSCodeSchema(t *testing.T) {
+	t.Parallel()
 	mcps := []spec.Entry{
 		{
 			Kind: spec.KindMCP,
@@ -208,6 +215,7 @@ func TestMCPDocument_StdioTypeOnlyWhenVSCodeSchema(t *testing.T) {
 }
 
 func TestMCPDocument_EmptySkips(t *testing.T) {
+	t.Parallel()
 	got, err := MCPDocument(nil, MCPSchemaServersMap)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/adapters/internal/emit/merged_test.go
+++ b/internal/adapters/internal/emit/merged_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestMergedDocument_SkipsWhenEmpty(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "OUT.md")
@@ -25,6 +26,7 @@ func TestMergedDocument_SkipsWhenEmpty(t *testing.T) {
 }
 
 func TestMergedDocument_WritesWhenNonEmpty(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "OUT.md")

--- a/internal/adapters/internal/emit/meta_test.go
+++ b/internal/adapters/internal/emit/meta_test.go
@@ -11,6 +11,7 @@ import (
 // order would vary the emitted frontmatter bytes per run and break
 // sync --check.
 func TestResolveMetaOrdered_DeterministicKeyOrder(t *testing.T) {
+	t.Parallel()
 	meta := map[string]any{
 		"name":        "a",
 		"zeta":        "z", // unhinted top-level
@@ -44,6 +45,7 @@ func cloneMeta(m map[string]any) map[string]any {
 }
 
 func TestResolveMeta_DropsOtherTargets(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":     "r1",
 		"x-claude": map[string]any{"allowed-tools": []any{"Read"}},
@@ -60,6 +62,7 @@ func TestResolveMeta_DropsOtherTargets(t *testing.T) {
 }
 
 func TestCustomTargetMeta_ReturnsSortedNonExcludedKeys(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"description": "top-level wins",
 		"x-codex": map[string]any{
@@ -82,6 +85,7 @@ func TestCustomTargetMeta_ReturnsSortedNonExcludedKeys(t *testing.T) {
 }
 
 func TestCustomTargetMeta_AbsentOrEmptyReturnsNil(t *testing.T) {
+	t.Parallel()
 	for _, in := range []map[string]any{
 		{"name": "r1"},
 		{"x-codex": map[string]any{}},
@@ -95,6 +99,7 @@ func TestCustomTargetMeta_AbsentOrEmptyReturnsNil(t *testing.T) {
 }
 
 func TestResolveMeta_TargetOverridesTopLevel(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":     "r1",
 		"model":    "haiku",
@@ -107,6 +112,7 @@ func TestResolveMeta_TargetOverridesTopLevel(t *testing.T) {
 }
 
 func TestResolveMeta_NoMatchingNamespaceLeaves(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":     "r1",
 		"x-cursor": map[string]any{"globs": "src/**"},
@@ -119,12 +125,14 @@ func TestResolveMeta_NoMatchingNamespaceLeaves(t *testing.T) {
 }
 
 func TestResolveMeta_NilMap(t *testing.T) {
+	t.Parallel()
 	if got := ResolveMeta(nil, "claude"); got != nil {
 		t.Errorf("expected nil pass-through, got %#v", got)
 	}
 }
 
 func TestResolveMeta_StripsRoutingKeys(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":            "r1",
 		"description":     "desc",
@@ -141,6 +149,7 @@ func TestResolveMeta_StripsRoutingKeys(t *testing.T) {
 }
 
 func TestResolveMetaOrdered_StripsRoutingKeysFromOrder(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":        "r1",
 		"target":      "claude",
@@ -162,6 +171,7 @@ func TestResolveMetaOrdered_StripsRoutingKeysFromOrder(t *testing.T) {
 // (#304). Without this, a codex agent that never had `model:` inherited
 // claude's `model: haiku` after a round-trip import.
 func TestResolveMeta_NilUnderXTargetDeletesKey(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":  "agent",
 		"model": "haiku",
@@ -183,6 +193,7 @@ func TestResolveMeta_NilUnderXTargetDeletesKey(t *testing.T) {
 // `x-<target>.<key>` with a value overrides the top-level value for
 // that target while leaving every other target's view alone (#304).
 func TestResolveMeta_XTargetOverridesValue(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":        "agent",
 		"description": "claude-side description",
@@ -201,6 +212,7 @@ func TestResolveMeta_XTargetOverridesValue(t *testing.T) {
 // Deletion under x-<target> must also drop the key from the ordered key
 // slice so renderers that iterate `ordered` don't emit a stray entry.
 func TestResolveMetaOrdered_NilUnderXTargetDropsOrder(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":  "agent",
 		"model": "haiku",
@@ -217,6 +229,7 @@ func TestResolveMetaOrdered_NilUnderXTargetDropsOrder(t *testing.T) {
 }
 
 func TestResolveMeta_StringModelPassesThrough(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{"name": "a", "model": "gpt-4o"}
 	got := ResolveMeta(in, "codex")
 	if got["model"] != "gpt-4o" {
@@ -225,6 +238,7 @@ func TestResolveMeta_StringModelPassesThrough(t *testing.T) {
 }
 
 func TestResolveMeta_PerTargetModelPicksTarget(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name": "a",
 		"model": map[string]any{
@@ -242,6 +256,7 @@ func TestResolveMeta_PerTargetModelPicksTarget(t *testing.T) {
 }
 
 func TestResolveMeta_PerTargetModelFallsBackToDefault(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name": "a",
 		"model": map[string]any{
@@ -255,6 +270,7 @@ func TestResolveMeta_PerTargetModelFallsBackToDefault(t *testing.T) {
 }
 
 func TestResolveMeta_PerTargetModelNoMatchNoDefaultDrops(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":  "a",
 		"model": map[string]any{"claude": "claude-opus-4-8"},
@@ -266,6 +282,7 @@ func TestResolveMeta_PerTargetModelNoMatchNoDefaultDrops(t *testing.T) {
 }
 
 func TestResolveMetaOrdered_PerTargetModelDropKeepsOrderClean(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":  "a",
 		"model": map[string]any{"claude": "opus"},
@@ -279,6 +296,7 @@ func TestResolveMetaOrdered_PerTargetModelDropKeepsOrderClean(t *testing.T) {
 }
 
 func TestResolveMeta_XTargetOverridesPerTargetMap(t *testing.T) {
+	t.Parallel()
 	in := map[string]any{
 		"name":     "a",
 		"model":    map[string]any{"claude": "opus", "default": "gpt-4o"},

--- a/internal/adapters/internal/emit/output_test.go
+++ b/internal/adapters/internal/emit/output_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestOutputResolvers_FallbackWhenUnset(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{}
 	cases := []struct {
 		name string
@@ -26,6 +27,7 @@ func TestOutputResolvers_FallbackWhenUnset(t *testing.T) {
 }
 
 func TestOutputResolvers_OverrideWins(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{
 		Outputs: map[string]config.Output{
 			"x": {
@@ -55,6 +57,7 @@ func TestOutputResolvers_OverrideWins(t *testing.T) {
 }
 
 func TestOutputResolvers_EmptyOverrideUsesFallback(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{Outputs: map[string]config.Output{"x": {}}}
 	if got := OutputFile(cfg, "x", "fallback"); got != "fallback" {
 		t.Errorf("expected fallback when override empty, got %q", got)

--- a/internal/adapters/internal/emit/overview_test.go
+++ b/internal/adapters/internal/emit/overview_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestRenderTargetOverview_SingleTargetFlatBullets(t *testing.T) {
+	t.Parallel()
 	out := RenderTargetOverview([]TargetArtifacts{{
 		Target: "claude",
 		Artifacts: []NativeArtifact{
@@ -28,6 +29,7 @@ func TestRenderTargetOverview_SingleTargetFlatBullets(t *testing.T) {
 }
 
 func TestRenderTargetOverview_SharedPathRendersPerTargetHeadings(t *testing.T) {
+	t.Parallel()
 	out := RenderTargetOverview([]TargetArtifacts{
 		{Target: "codex", Artifacts: []NativeArtifact{{Label: "Agents", Location: ".codex/agents/"}}},
 		{Target: "amp", Artifacts: []NativeArtifact{{Label: "Skills", Location: ".agents/skills/"}}},
@@ -38,6 +40,7 @@ func TestRenderTargetOverview_SharedPathRendersPerTargetHeadings(t *testing.T) {
 }
 
 func TestRenderTargetOverview_EmptyWhenNoArtifacts(t *testing.T) {
+	t.Parallel()
 	if out := RenderTargetOverview(nil); out != "" {
 		t.Errorf("nil sections: got %q, want empty", out)
 	}
@@ -48,6 +51,7 @@ func TestRenderTargetOverview_EmptyWhenNoArtifacts(t *testing.T) {
 }
 
 func TestStripTargetOverview_RoundTrip(t *testing.T) {
+	t.Parallel()
 	body := "# Conventions\n\nEdit sources.\n"
 	overview := RenderTargetOverview([]TargetArtifacts{{
 		Target:    "claude",
@@ -60,6 +64,7 @@ func TestStripTargetOverview_RoundTrip(t *testing.T) {
 }
 
 func TestStripTargetOverview_NoBlockUnchanged(t *testing.T) {
+	t.Parallel()
 	body := "# Conventions\n\nNo block here.\n"
 	if got := StripTargetOverview(body); got != body {
 		t.Errorf("got %q, want unchanged", got)
@@ -67,6 +72,7 @@ func TestStripTargetOverview_NoBlockUnchanged(t *testing.T) {
 }
 
 func TestStripTargetOverview_TruncatedBlockHeals(t *testing.T) {
+	t.Parallel()
 	body := "# Conventions\n\n" + OverviewStartMarker + "\ntruncated, no end marker"
 	got := StripTargetOverview(body)
 	if got != "# Conventions\n" {
@@ -75,6 +81,7 @@ func TestStripTargetOverview_TruncatedBlockHeals(t *testing.T) {
 }
 
 func TestAppendTargetOverview_DoesNotStack(t *testing.T) {
+	t.Parallel()
 	body := "# Conventions\n"
 	overview := RenderTargetOverview([]TargetArtifacts{{
 		Target:    "claude",

--- a/internal/adapters/internal/emit/rules_appendix_test.go
+++ b/internal/adapters/internal/emit/rules_appendix_test.go
@@ -16,6 +16,7 @@ func ruleBundle() spec.Bundle {
 }
 
 func TestRenderRulesAppendix_EmitsEachRuleBody(t *testing.T) {
+	t.Parallel()
 	got := RenderRulesAppendix(ruleBundle())
 	for _, want := range []string{
 		RulesStartMarker, RulesEndMarker,
@@ -29,12 +30,14 @@ func TestRenderRulesAppendix_EmitsEachRuleBody(t *testing.T) {
 }
 
 func TestRenderRulesAppendix_EmptyWhenNoRules(t *testing.T) {
+	t.Parallel()
 	if got := RenderRulesAppendix(spec.Bundle{}); got != "" {
 		t.Errorf("want empty appendix for ruleless bundle, got %q", got)
 	}
 }
 
 func TestAppendRulesAppendix_DoesNotStack(t *testing.T) {
+	t.Parallel()
 	body := "# Pointer body\n"
 	app := RenderRulesAppendix(ruleBundle())
 	once := AppendRulesAppendix(body, app)
@@ -48,6 +51,7 @@ func TestAppendRulesAppendix_DoesNotStack(t *testing.T) {
 }
 
 func TestStripRulesAppendix_RoundTrips(t *testing.T) {
+	t.Parallel()
 	body := "# Pointer body\n"
 	withRules := AppendRulesAppendix(body, RenderRulesAppendix(ruleBundle()))
 	if got := StripRulesAppendix(withRules); got != body {
@@ -56,6 +60,7 @@ func TestStripRulesAppendix_RoundTrips(t *testing.T) {
 }
 
 func TestStripGeneratedAppendices_RemovesRulesAndOverview(t *testing.T) {
+	t.Parallel()
 	body := "# Pointer body\n"
 	withRules := AppendRulesAppendix(body, RenderRulesAppendix(ruleBundle()))
 	withBoth := AppendTargetOverview(withRules, RenderTargetOverview([]TargetArtifacts{
@@ -71,6 +76,7 @@ func importCfg(mode string) *config.Config {
 }
 
 func TestImportsRulesIntoEntryPoint(t *testing.T) {
+	t.Parallel()
 	if !ImportsRulesIntoEntryPoint(importCfg("import"), "claude") {
 		t.Error("claude with rules-mode: import should import rules into CLAUDE.md")
 	}
@@ -86,6 +92,7 @@ func TestImportsRulesIntoEntryPoint(t *testing.T) {
 }
 
 func TestImportsRulesIntoEntryPoint_LegacyRulesFileOverrides(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{Outputs: map[string]config.Output{
 		"claude": {RulesMode: "import", RulesFile: "CLAUDE.md"},
 	}}
@@ -95,6 +102,7 @@ func TestImportsRulesIntoEntryPoint_LegacyRulesFileOverrides(t *testing.T) {
 }
 
 func TestRenderRulesImportAppendix_EmitsImportLines(t *testing.T) {
+	t.Parallel()
 	got := RenderRulesImportAppendix(importCfg("import"), "claude", ruleBundle())
 	for _, want := range []string{
 		RulesStartMarker, RulesEndMarker, "## Rules",
@@ -111,6 +119,7 @@ func TestRenderRulesImportAppendix_EmitsImportLines(t *testing.T) {
 }
 
 func TestRenderRulesImportAppendix_HonorsRulesDirOverride(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{Outputs: map[string]config.Output{
 		"claude": {RulesMode: "import", RulesDir: ".claude/conventions"},
 	}}
@@ -121,12 +130,14 @@ func TestRenderRulesImportAppendix_HonorsRulesDirOverride(t *testing.T) {
 }
 
 func TestRenderRulesImportAppendix_EmptyWhenNoRules(t *testing.T) {
+	t.Parallel()
 	if got := RenderRulesImportAppendix(importCfg("import"), "claude", spec.Bundle{}); got != "" {
 		t.Errorf("want empty import appendix for ruleless bundle, got %q", got)
 	}
 }
 
 func TestRenderRulesImportAppendix_RoundTrips(t *testing.T) {
+	t.Parallel()
 	body := "# Pointer body\n"
 	withImports := AppendRulesAppendix(body, RenderRulesImportAppendix(importCfg("import"), "claude", ruleBundle()))
 	if got := StripRulesAppendix(withImports); got != body {
@@ -135,6 +146,7 @@ func TestRenderRulesImportAppendix_RoundTrips(t *testing.T) {
 }
 
 func TestInlinesRulesIntoEntryPoint(t *testing.T) {
+	t.Parallel()
 	inline := []string{"codex", "amp", "warp", "zed", "gemini", "aider", "opencode", "crush"}
 	for _, tgt := range inline {
 		if !InlinesRulesIntoEntryPoint(tgt) {

--- a/internal/adapters/internal/emit/skill_assets_test.go
+++ b/internal/adapters/internal/emit/skill_assets_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestFolderBasedSkill(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		path string
@@ -31,6 +32,7 @@ func TestFolderBasedSkill(t *testing.T) {
 // propagation must copy nothing — otherwise every sibling skill body leaks
 // into this skill's folder (#387).
 func TestPropagateSkillAssets_FlatFileSkipsSiblings(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	skillsDir := filepath.Join(dir, "skills")
@@ -57,6 +59,7 @@ func TestPropagateSkillAssets_FlatFileSkipsSiblings(t *testing.T) {
 // A folder-based skill owns its directory, so every sibling asset (minus the
 // re-rendered SKILL.md) propagates into the emitted folder.
 func TestPropagateSkillAssets_FolderCopiesSiblings(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	srcSkill := filepath.Join(dir, "skills", "alpha")
@@ -88,6 +91,7 @@ func TestPropagateSkillAssets_FolderCopiesSiblings(t *testing.T) {
 func skipNothing(string) bool { return false }
 
 func TestSkillHasBundledAssets(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	withAssets := filepath.Join(dir, "skills", "alpha")

--- a/internal/adapters/internal/emit/state_test.go
+++ b/internal/adapters/internal/emit/state_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCapture_SuppressesIOAndRecordsContent(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "captured.md")
@@ -29,6 +30,7 @@ func TestCapture_SuppressesIOAndRecordsContent(t *testing.T) {
 }
 
 func TestStopCapture_AfterStartCaptureClearsState(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	sess.StartCapture()
 	if err := sess.WriteFile("a.md", "x", false); err != nil {
@@ -47,6 +49,7 @@ func TestStopCapture_AfterStartCaptureClearsState(t *testing.T) {
 }
 
 func TestRecording_DoesNotSuppressIO(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "recorded.md")
@@ -66,6 +69,7 @@ func TestRecording_DoesNotSuppressIO(t *testing.T) {
 }
 
 func TestStopRecording_AfterStartClearsState(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	sess.StartRecording()
@@ -84,6 +88,7 @@ func TestStopRecording_AfterStartClearsState(t *testing.T) {
 }
 
 func TestSourceComment(t *testing.T) {
+	t.Parallel()
 	if got := SourceComment(""); got != "" {
 		t.Errorf("empty path should return empty, got %q", got)
 	}
@@ -93,6 +98,7 @@ func TestSourceComment(t *testing.T) {
 }
 
 func TestWriteSection_RendersHeadingProvenanceDescBody(t *testing.T) {
+	t.Parallel()
 	var sb stringBuilder
 	WriteSection(sb.Builder(), "my-heading", entryFixture())
 	got := sb.String()

--- a/internal/adapters/internal/emit/toml_test.go
+++ b/internal/adapters/internal/emit/toml_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestWriteTOMLString_EscapesQuotesAndBackslashes(t *testing.T) {
+	t.Parallel()
 	var sb strings.Builder
 	WriteTOMLString(&sb, "description", `Says "hi" with a \ slash`)
 	got := sb.String()
@@ -16,6 +17,7 @@ func TestWriteTOMLString_EscapesQuotesAndBackslashes(t *testing.T) {
 }
 
 func TestWriteTOMLMultiline_PreservesNewlinesEscapesDelimiter(t *testing.T) {
+	t.Parallel()
 	var sb strings.Builder
 	WriteTOMLMultiline(&sb, "prompt", "line1\nline2 with \"quotes\"\n")
 	got := sb.String()
@@ -32,6 +34,7 @@ func TestWriteTOMLMultiline_PreservesNewlinesEscapesDelimiter(t *testing.T) {
 }
 
 func TestWriteTOMLMultiline_AppendsTrailingNewlineWhenMissing(t *testing.T) {
+	t.Parallel()
 	var sb strings.Builder
 	WriteTOMLMultiline(&sb, "prompt", "no-trailing-newline")
 	got := sb.String()
@@ -41,6 +44,7 @@ func TestWriteTOMLMultiline_AppendsTrailingNewlineWhenMissing(t *testing.T) {
 }
 
 func TestWriteTOMLStringArray(t *testing.T) {
+	t.Parallel()
 	var sb strings.Builder
 	WriteTOMLStringArray(&sb, "names", []string{"alpha", "beta"})
 	got := sb.String()
@@ -51,6 +55,7 @@ func TestWriteTOMLStringArray(t *testing.T) {
 }
 
 func TestWriteTOMLValue_TypedScalarsAndArrays(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		v    any
@@ -78,6 +83,7 @@ func TestWriteTOMLValue_TypedScalarsAndArrays(t *testing.T) {
 }
 
 func TestWriteTOMLValue_SkipsUnsupported(t *testing.T) {
+	t.Parallel()
 	for _, v := range []any{
 		map[string]any{"nested": "table"},
 		[]any{"a", 1}, // mixed-type array
@@ -94,6 +100,7 @@ func TestWriteTOMLValue_SkipsUnsupported(t *testing.T) {
 }
 
 func TestEscapeTOMLBasic(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		in, want string
 	}{

--- a/internal/adapters/internal/emit/transaction_test.go
+++ b/internal/adapters/internal/emit/transaction_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestTransaction_RollbackRestoresOverwrittenFile(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CLAUDE.md")
@@ -32,6 +33,7 @@ func TestTransaction_RollbackRestoresOverwrittenFile(t *testing.T) {
 }
 
 func TestTransaction_RollbackDeletesNewFile(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "newfile.md")
@@ -50,6 +52,7 @@ func TestTransaction_RollbackDeletesNewFile(t *testing.T) {
 }
 
 func TestTransaction_CommitPreservesWrites(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CLAUDE.md")
@@ -73,6 +76,7 @@ func TestTransaction_CommitPreservesWrites(t *testing.T) {
 }
 
 func TestTransaction_RollbackMultipleFilesInReverseOrder(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	fileA := filepath.Join(dir, "a.md")
@@ -105,6 +109,7 @@ func TestTransaction_RollbackMultipleFilesInReverseOrder(t *testing.T) {
 }
 
 func TestTransaction_RollbackNoOpsWithoutStart(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	if err := sess.Rollback(); err != nil {
 		t.Errorf("rollback with no transaction should be a no-op, got %v", err)
@@ -112,6 +117,7 @@ func TestTransaction_RollbackNoOpsWithoutStart(t *testing.T) {
 }
 
 func TestTransaction_CommitClearsLog(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.md")
@@ -136,6 +142,7 @@ func TestTransaction_CommitClearsLog(t *testing.T) {
 }
 
 func TestTransaction_RollbackWithDetailedRecordingMode(t *testing.T) {
+	t.Parallel()
 	sess := NewSession()
 	dir := t.TempDir()
 	existing := filepath.Join(dir, "existing.md")

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestCoded_PrefixIncludesCode(t *testing.T) {
+	t.Parallel()
 	err := Coded(CodeSpecParse, "boom")
 	want := "[AAI-001] boom"
 	if err.Error() != want {
@@ -17,6 +18,7 @@ func TestCoded_PrefixIncludesCode(t *testing.T) {
 }
 
 func TestCoded_FormatArgsExpand(t *testing.T) {
+	t.Parallel()
 	err := Coded(CodeConfigDecode, "parse %s: %s", "agnostic-ai.yaml", "bad indent")
 	if !strings.Contains(err.Error(), "parse agnostic-ai.yaml: bad indent") {
 		t.Errorf("missing formatted args: %q", err.Error())
@@ -27,6 +29,7 @@ func TestCoded_FormatArgsExpand(t *testing.T) {
 }
 
 func TestCoded_WrapPreservesIs(t *testing.T) {
+	t.Parallel()
 	err := Coded(CodeConfigMissing, "read %s: %w", "agnostic-ai.yaml", fs.ErrNotExist)
 	if !errors.Is(err, fs.ErrNotExist) {
 		t.Error("errors.Is should still match wrapped sentinel")
@@ -37,6 +40,7 @@ func TestCoded_WrapPreservesIs(t *testing.T) {
 }
 
 func TestCoded_WrapPreservesAs(t *testing.T) {
+	t.Parallel()
 	original := &fs.PathError{Op: "open", Path: "x", Err: fs.ErrNotExist}
 	err := Coded(CodeUnsupportedKind, "missing dir: %w", original)
 	var pe *fs.PathError
@@ -49,6 +53,7 @@ func TestCoded_WrapPreservesAs(t *testing.T) {
 }
 
 func TestCodeOf_NilAndPlainReturnEmpty(t *testing.T) {
+	t.Parallel()
 	if got := CodeOf(nil); got != "" {
 		t.Errorf("CodeOf(nil)=%q, want empty", got)
 	}
@@ -58,6 +63,7 @@ func TestCodeOf_NilAndPlainReturnEmpty(t *testing.T) {
 }
 
 func TestIsCode_ShapeOnly(t *testing.T) {
+	t.Parallel()
 	cases := map[string]bool{
 		"AAI-001":  true,
 		"AAI-9999": true,
@@ -74,6 +80,7 @@ func TestIsCode_ShapeOnly(t *testing.T) {
 }
 
 func TestRegistry_AllCoveredCodesHaveEntries(t *testing.T) {
+	t.Parallel()
 	codes := []Code{
 		CodeSpecParse, CodeUnsupportedKind, CodeConfigMissing, CodeConfigDecode,
 		CodeOutputCollision,
@@ -93,6 +100,7 @@ func TestRegistry_AllCoveredCodesHaveEntries(t *testing.T) {
 }
 
 func TestAll_SortedByCode(t *testing.T) {
+	t.Parallel()
 	all := All()
 	if len(all) == 0 {
 		t.Fatal("All(): want non-empty")

--- a/internal/lsp/rpc_test.go
+++ b/internal/lsp/rpc_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRoundTrip_SimpleMessage(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 	msg := map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize"}
@@ -26,6 +27,7 @@ func TestRoundTrip_SimpleMessage(t *testing.T) {
 }
 
 func TestReader_MultipleMessages(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 	for i := range 3 {
@@ -44,6 +46,7 @@ func TestReader_MultipleMessages(t *testing.T) {
 }
 
 func TestServer_Initialize(t *testing.T) {
+	t.Parallel()
 	var in, out bytes.Buffer
 	w := NewWriter(&in)
 	_ = w.Send(map[string]any{
@@ -70,6 +73,7 @@ func TestServer_Initialize(t *testing.T) {
 }
 
 func TestURIConversion(t *testing.T) {
+	t.Parallel()
 	cases := []struct{ uri, path string }{
 		{"file:///tmp/foo.md", "/tmp/foo.md"},
 		{"file:///home/user/proj/rules/x.md", "/home/user/proj/rules/x.md"},

--- a/internal/spec/body_for_test.go
+++ b/internal/spec/body_for_test.go
@@ -8,6 +8,7 @@ import (
 // Bodies without `::target` fences pass through unchanged. The common
 // case carries no fence — keep it cheap.
 func TestEntry_BodyFor_NoFences_Unchanged(t *testing.T) {
+	t.Parallel()
 	body := "# Test\n\n## Workflow\n\nStep 1.\n"
 	e := Entry{Body: body}
 	if got := e.BodyFor("claude"); got != body {
@@ -21,6 +22,7 @@ func TestEntry_BodyFor_NoFences_Unchanged(t *testing.T) {
 // A fenced section pinned to the matching target emits without the
 // fence markers but with surrounding whitespace preserved.
 func TestEntry_BodyFor_MatchingFence_RendersInline(t *testing.T) {
+	t.Parallel()
 	body := "Intro line.\n\n::target codex\nCodex-only paragraph.\n::end\n\nOutro.\n"
 	e := Entry{Body: body}
 	got := e.BodyFor("codex")
@@ -34,6 +36,7 @@ func TestEntry_BodyFor_MatchingFence_RendersInline(t *testing.T) {
 // (including the marker lines) so the rendered body reads cleanly for
 // the active target.
 func TestEntry_BodyFor_NonMatchingFence_Dropped(t *testing.T) {
+	t.Parallel()
 	body := "Intro.\n\n::target codex\nCodex stuff.\n::end\n\nOutro.\n"
 	e := Entry{Body: body}
 	got := e.BodyFor("claude")
@@ -46,6 +49,7 @@ func TestEntry_BodyFor_NonMatchingFence_Dropped(t *testing.T) {
 // Multiple consecutive fences for different targets emit only the
 // matching one.
 func TestEntry_BodyFor_MultipleFences_MatchOneOnly(t *testing.T) {
+	t.Parallel()
 	body := "Shared header.\n\n::target claude\nClaude paragraph.\n::end\n\n::target codex\nCodex paragraph.\n::end\n\nShared footer.\n"
 	e := Entry{Body: body}
 	if got := e.BodyFor("claude"); !strings.Contains(got, "Claude paragraph.") || strings.Contains(got, "Codex paragraph.") {
@@ -61,6 +65,7 @@ func TestEntry_BodyFor_MultipleFences_MatchOneOnly(t *testing.T) {
 
 // `::targets <a> <b>` allow-lists multiple targets in one fence.
 func TestEntry_BodyFor_TargetsList_MatchesAny(t *testing.T) {
+	t.Parallel()
 	body := "::targets claude codex\nShared section.\n::end\n"
 	e := Entry{Body: body}
 	if got := e.BodyFor("claude"); !strings.Contains(got, "Shared section.") {
@@ -77,6 +82,7 @@ func TestEntry_BodyFor_TargetsList_MatchesAny(t *testing.T) {
 // An unterminated fence runs to end-of-body. Avoids dropping the rest
 // of the file on a typo while still rendering deterministically.
 func TestEntry_BodyFor_UnterminatedFence_RunsToEnd(t *testing.T) {
+	t.Parallel()
 	body := "Intro.\n\n::target codex\nNo end marker.\n"
 	e := Entry{Body: body}
 	if got := e.BodyFor("codex"); !strings.Contains(got, "No end marker.") {
@@ -91,6 +97,7 @@ func TestEntry_BodyFor_UnterminatedFence_RunsToEnd(t *testing.T) {
 // for the source view / round-trip emit where the fence syntax is the
 // canonical form on disk.
 func TestEntry_BodyFor_EmptyTarget_PreservesFences(t *testing.T) {
+	t.Parallel()
 	body := "::target codex\nx\n::end\n"
 	e := Entry{Body: body}
 	if got := e.BodyFor(""); got != body {

--- a/internal/spec/parse_bytes_test.go
+++ b/internal/spec/parse_bytes_test.go
@@ -3,6 +3,7 @@ package spec
 import "testing"
 
 func TestParseMarkdownBytes_RuleWithFrontmatter(t *testing.T) {
+	t.Parallel()
 	body := []byte("---\nname: my-rule\ndescription: short\nglobs: \"**/*\"\nalwaysApply: true\n---\n\nrule body line one.\n")
 	e, err := ParseMarkdownBytes(KindRule, body)
 	if err != nil {
@@ -32,6 +33,7 @@ func TestParseMarkdownBytes_RuleWithFrontmatter(t *testing.T) {
 }
 
 func TestParseMarkdownBytes_NoFrontmatter(t *testing.T) {
+	t.Parallel()
 	e, err := ParseMarkdownBytes(KindRule, []byte("just body, no frontmatter\n"))
 	if err != nil {
 		t.Fatal(err)
@@ -45,6 +47,7 @@ func TestParseMarkdownBytes_NoFrontmatter(t *testing.T) {
 }
 
 func TestParseMarkdownBytes_CRLF(t *testing.T) {
+	t.Parallel()
 	body := []byte("---\r\nname: crlf\r\n---\r\nbody\r\n")
 	e, err := ParseMarkdownBytes(KindRule, body)
 	if err != nil {
@@ -56,6 +59,7 @@ func TestParseMarkdownBytes_CRLF(t *testing.T) {
 }
 
 func TestParseMarkdownBytes_MalformedYAMLErrors(t *testing.T) {
+	t.Parallel()
 	body := []byte("---\nname: ok\nbroken: [unterminated\n---\nbody\n")
 	if _, err := ParseMarkdownBytes(KindRule, body); err == nil {
 		t.Error("expected error for malformed YAML in frontmatter")
@@ -63,6 +67,7 @@ func TestParseMarkdownBytes_MalformedYAMLErrors(t *testing.T) {
 }
 
 func TestParseYAMLBytes_HookFields(t *testing.T) {
+	t.Parallel()
 	body := []byte("name: fmt-hook\nevent: PostToolUse\ncommand: \"echo\"\n")
 	e, err := ParseYAMLBytes(KindHook, body)
 	if err != nil {
@@ -80,6 +85,7 @@ func TestParseYAMLBytes_HookFields(t *testing.T) {
 }
 
 func TestParseYAMLBytes_EmptyDocument(t *testing.T) {
+	t.Parallel()
 	e, err := ParseYAMLBytes(KindMCP, []byte(""))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
+	t.Parallel()
 	meta, keys, _, body, err := splitFrontmatter([]byte("hello world"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -25,6 +26,7 @@ func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
 }
 
 func TestSplitFrontmatter_WithFrontmatter(t *testing.T) {
+	t.Parallel()
 	input := []byte("---\nname: foo\ndescription: bar\n---\nbody here\n")
 	meta, keys, _, body, err := splitFrontmatter(input)
 	if err != nil {
@@ -42,6 +44,7 @@ func TestSplitFrontmatter_WithFrontmatter(t *testing.T) {
 }
 
 func TestSplitFrontmatter_EmptyMeta(t *testing.T) {
+	t.Parallel()
 	input := []byte("---\n---\nbody only\n")
 	meta, _, _, body, err := splitFrontmatter(input)
 	if err != nil {
@@ -56,6 +59,7 @@ func TestSplitFrontmatter_EmptyMeta(t *testing.T) {
 }
 
 func TestSplitFrontmatter_MalformedYAML(t *testing.T) {
+	t.Parallel()
 	input := []byte("---\n: : :\n---\nbody\n")
 	if _, _, _, _, err := splitFrontmatter(input); err == nil {
 		t.Fatal("expected error on malformed yaml")
@@ -63,6 +67,7 @@ func TestSplitFrontmatter_MalformedYAML(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
+	t.Parallel()
 	entries := []Entry{
 		{Kind: KindAgent, Name: "a"},
 		{Kind: KindRule, Name: "r"},
@@ -77,6 +82,7 @@ func TestFilter(t *testing.T) {
 }
 
 func TestLoadAll_ParsesEachKind(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	mustWrite(t, filepath.Join(dir, "agents", "a1.md"),
@@ -108,6 +114,7 @@ func TestLoadAll_ParsesEachKind(t *testing.T) {
 }
 
 func TestLoadAll_NameFromFilenameIfMissing(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "rules", "implicit-name.md"), "body without frontmatter")
 
@@ -122,6 +129,7 @@ func TestLoadAll_NameFromFilenameIfMissing(t *testing.T) {
 }
 
 func TestLoadAll_SkillNameFromParentDirWhenFrontmatterMissing(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "skills", "my-skill", "SKILL.md"), "skill body without frontmatter")
 
@@ -145,6 +153,7 @@ func TestLoadAll_SkillNameFromParentDirWhenFrontmatterMissing(t *testing.T) {
 // bundled asset, not a skill of its own. It must not be promoted to a
 // top-level skill (#431).
 func TestLoadAll_MarkdownAssetInsideSkillNotPromoted(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "skills", "alpha", "SKILL.md"), "---\nname: alpha\n---\nskill body")
 	mustWrite(t, filepath.Join(dir, "skills", "alpha", "examples.md"), "extra markdown asset")
@@ -172,6 +181,7 @@ func TestLoadAll_MarkdownAssetInsideSkillNotPromoted(t *testing.T) {
 // Flat-file skills, including ones nested in a scope subdir, stay skills.
 // They have no SKILL.md ancestor, so the asset-detection must not eat them.
 func TestLoadAll_FlatFileSkillsSurviveAssetDetection(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "skills", "alpha.md"), "flat skill")
 	mustWrite(t, filepath.Join(dir, "skills", "backend", "loader.md"), "scoped flat skill")
@@ -201,6 +211,7 @@ func TestLoadAll_FlatFileSkillsSurviveAssetDetection(t *testing.T) {
 // A YAML file under the settings source dir loads as a settings spec
 // (#432), parsed like hooks and MCPs, with its fields kept in Meta.
 func TestLoadAll_ParsesSettingsKind(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "settings", "defaults.yaml"),
 		"model: claude-opus-4-8\npermissions:\n  allow:\n    - Bash(go test:*)\n")
@@ -227,6 +238,7 @@ func TestLoadAll_ParsesSettingsKind(t *testing.T) {
 // traversal: the name becomes a filename/dir segment in every adapter, so
 // the loader rejects it instead of letting sync write outside the tree.
 func TestLoadAll_RejectsPathTraversalName(t *testing.T) {
+	t.Parallel()
 	for _, bad := range []string{"../escape", "../../etc/passwd", "a/b", ".."} {
 		dir := t.TempDir()
 		mustWrite(t, filepath.Join(dir, "rules", "r.md"), "---\nname: "+bad+"\n---\nbody")
@@ -238,6 +250,7 @@ func TestLoadAll_RejectsPathTraversalName(t *testing.T) {
 }
 
 func TestLoadAll_AcceptsSafeNames(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "rules", "ok.md"), "---\nname: code-style\n---\nbody")
 	cfg := defaultsForTest()
@@ -251,6 +264,7 @@ func TestLoadAll_AcceptsSafeNames(t *testing.T) {
 }
 
 func TestLoadAll_MissingDirsAreSkipped(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	cfg := defaultsForTest()
 	entries, err := LoadAll(dir, cfg)
@@ -263,6 +277,7 @@ func TestLoadAll_MissingDirsAreSkipped(t *testing.T) {
 }
 
 func TestLoadAll_DerivesScopeFromLayout(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "rules", "root.md"), "body")
 	mustWrite(t, filepath.Join(dir, "rules", "backend", "auth.md"), "body")
@@ -300,6 +315,7 @@ func TestLoadAll_DerivesScopeFromLayout(t *testing.T) {
 }
 
 func TestEffectiveScope_FrontmatterFallback(t *testing.T) {
+	t.Parallel()
 	e := Entry{Meta: map[string]any{"scope": "/frontend/"}}
 	if got := e.EffectiveScope(); got != "frontend" {
 		t.Errorf("expected scope frontend, got %q", got)
@@ -311,6 +327,7 @@ func TestEffectiveScope_FrontmatterFallback(t *testing.T) {
 }
 
 func TestParseYAML_HookFields(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hook.yaml")
 	mustWrite(t, path, "name: foo\nevent: PreToolUse\ncommand: \"true\"\n")
@@ -325,6 +342,7 @@ func TestParseYAML_HookFields(t *testing.T) {
 }
 
 func TestLoadLayered_HigherLayerOverridesByName(t *testing.T) {
+	t.Parallel()
 	base := t.TempDir()
 	over := t.TempDir()
 
@@ -368,6 +386,7 @@ func TestLoadLayered_HigherLayerOverridesByName(t *testing.T) {
 }
 
 func TestLoadLayered_PreservesOrderForExistingNames(t *testing.T) {
+	t.Parallel()
 	base := t.TempDir()
 	over := t.TempDir()
 
@@ -395,6 +414,7 @@ func TestLoadLayered_PreservesOrderForExistingNames(t *testing.T) {
 }
 
 func TestLoadBundle_TagsLayerProject(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "rules", "x.md"), "---\nname: x\n---\nbody")
 	bundle, err := LoadBundle(dir, defaultsForTest())
@@ -407,6 +427,7 @@ func TestLoadBundle_TagsLayerProject(t *testing.T) {
 }
 
 func TestEntry_EmitsTo(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		meta   map[string]any
@@ -449,6 +470,7 @@ func TestEntry_EmitsTo(t *testing.T) {
 // entries scoped to their target. Mirrors Bundle.HooksFor across
 // agents/skills/rules/mcps/commands. Closes #292.
 func TestBundle_For(t *testing.T) {
+	t.Parallel()
 	b := Bundle{
 		Agents: []Entry{
 			{Kind: KindAgent, Name: "a1"},
@@ -529,6 +551,7 @@ func equalSlices(a, b []string) bool {
 }
 
 func TestBundle_HooksFor(t *testing.T) {
+	t.Parallel()
 	all := Bundle{Hooks: []Entry{
 		{Kind: KindHook, Name: "a"},
 		{Kind: KindHook, Name: "b", Meta: map[string]any{"target": "claude"}},

--- a/internal/spec/yamlerr_test.go
+++ b/internal/spec/yamlerr_test.go
@@ -16,6 +16,7 @@ import (
 const codePrefix = "[AAI-001] "
 
 func TestFormatYAMLError_LineAndCol(t *testing.T) {
+	t.Parallel()
 	err := errors.New("yaml: line 3: column 5: did not find expected key")
 	got := formatYAMLError("rules/x.md", err, 1).Error()
 	want := codePrefix + "rules/x.md:4:5: did not find expected key"
@@ -25,6 +26,7 @@ func TestFormatYAMLError_LineAndCol(t *testing.T) {
 }
 
 func TestFormatYAMLError_LineOnly(t *testing.T) {
+	t.Parallel()
 	err := errors.New("yaml: line 2: mapping values are not allowed in this context")
 	got := formatYAMLError("hooks/h.yaml", err, 0).Error()
 	want := codePrefix + "hooks/h.yaml:2:1: mapping values are not allowed in this context"
@@ -34,6 +36,7 @@ func TestFormatYAMLError_LineOnly(t *testing.T) {
 }
 
 func TestFormatYAMLError_Unparseable(t *testing.T) {
+	t.Parallel()
 	err := errors.New("totally unrecognized format")
 	got := formatYAMLError("p.md", err, 0).Error()
 	want := codePrefix + "p.md:1:1: totally unrecognized format"
@@ -43,12 +46,14 @@ func TestFormatYAMLError_Unparseable(t *testing.T) {
 }
 
 func TestFormatYAMLError_NilReturnsNil(t *testing.T) {
+	t.Parallel()
 	if formatYAMLError("x", nil, 0) != nil {
 		t.Error("expected nil error to round-trip")
 	}
 }
 
 func TestFormatYAMLError_TypeErrorUsesFirstMessage(t *testing.T) {
+	t.Parallel()
 	te := &yaml.TypeError{Errors: []string{
 		"yaml: line 4: column 1: cannot unmarshal !!str into int",
 	}}
@@ -60,6 +65,7 @@ func TestFormatYAMLError_TypeErrorUsesFirstMessage(t *testing.T) {
 }
 
 func TestParseMarkdown_FrontmatterErrorIncludesPathAndLine(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "broken.md")
 	// `:` at start of yaml line is invalid; yaml reports the offending
@@ -84,6 +90,7 @@ func TestParseMarkdown_FrontmatterErrorIncludesPathAndLine(t *testing.T) {
 }
 
 func TestParseYAML_ErrorIncludesPathAndPosition(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "h.yaml")
 	// yaml.v3 reports a position for this construct; the exact line


### PR DESCRIPTION
## What

Enables `t.Parallel()` on the tests that do not depend on the two shared
process globals (the working directory and the `cli` package's log sink).
Before this change only one test file (`emit/json_test.go`) ran in
parallel; every other test was serialized.

Test-only change. No production code is touched, no assertions are
weakened. `.golangci.yml`, `gofmt`, `go vet`, `go build` all clean.

## Approach

- **aider adapter** (drops `testutil.Chdir`): the conf-file / rules-file
  tests set an explicit output path, so they now root that path at
  `t.TempDir()` and pass it to `Emit` instead of switching the cwd. The
  emit layer already accepts absolute paths (`escapesProjectRoot` exempts
  them), so the adapter reads and writes the same files without a cwd
  switch. 7 tests converted.
- **external adapter**: each round-trip test re-execs the race-instrumented
  test binary as a fake adapter subprocess. Those launches dominate the
  package wall time. Running the independent ones in parallel cuts the
  package from ~5.4s to ~3.4s. The two that mutate a global (`emit.Warner`)
  or call `t.Setenv` stay serial.
- **emit / spec / errs / lsp**: pure or per-`Session` unit tests, so they
  parallelize with no behavior change (~156 test cases).

## Stayed serial (documented)

| Area | Why |
| --- | --- |
| `internal/cli` (Execute-based) | read the cwd (`.`) and mutate the package globals `logOut` / `verbosity` via `captureSummary` / `silence`; a data race is real under `-race` |
| `tests/integration` | chdir into a fixture and shell out to the built binary |
| full-bundle adapter tests (claude, cursor, kiro, copilot, ... + shared kitsink/header/coverage/parity) | emit a whole bundle to **default relative** paths, so they need the cwd; making them parallel needs a production `root` parameter |
| `emit` capabilities / coverage-note / provenance tests | assert on package-global state (`capabilityWarnState`, `coverageNoteState`, `provenanceEnabled`) |
| `emit/hook_scripts` | uses `t.Chdir` |
| `internal/config` | `TestLoad_LegacyWarningFiresOncePerPath` resets and asserts the global `legacyWarnedPaths` that `Load` populates |

Parallelizing the `cli` package (the single tallest execution pole) would
require threading the log writer and a root path through production call
sites. That is a production signature change and out of scope for a
test-only PR.

## Wall time (before / after)

Measured locally, `go test -race`, 14-core machine.

| Metric | Before | After |
| --- | --- | --- |
| `external` package alone | ~5.4s | ~3.4s |
| full suite, cold | ~9.5s | ~9.1s |
| full suite, execution only (compile cached) | ~7.85s | ~7.85s |

The full-suite wall on this machine is bound by the serial `cli` package
(~5.8s), so the aggregate drop is small; the concrete win is the
`external` package and broad parallel-readiness. On core-constrained CI
runners, where packages queue instead of all running at once, the
per-package parallelism compounds.

## Test plan

- `gofmt -l .` -> empty
- `golangci-lint run ./...` -> 0 issues
- `go vet ./...`, `go build ./...` -> clean
- `go test -count=3 -race ./...` -> green (run 3x to shake out ordering
  assumptions from the new parallelism; no data races, no flakes)

No separate polish commit needed.

Closes #493
