### PR TITLE
feat(import): kiro and crush importers for round-trip parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `import kiro` and `import crush` close the last round-trip gap: every one of the 18 emitted targets now imports back. `kiro` reads `.kiro/steering/*.md` (mapping `inclusion: always` to unscoped rules and `fileMatch` + `fileMatchPattern` to `globs:` rules, plus `agent-`/`skill-` steering files) and `.kiro/settings/mcp.json`; `crush` reads the inlined `## Rules` block in `AGENTS.md`, `.agents/skills/<name>/SKILL.md`, and the `crush.json` `mcp` map (#494).
 - `--profile <file>` (or `AGNOSTIC_AI_PROFILE`) writes a `runtime/pprof` CPU profile of the run, and `sync --verbose` appends per-target wall time (`in Nms`) to each target line, so a slow sync attributes to a specific adapter. Off by default, stdlib profiler only (#491).
 - `sync --check` gains actionable drift output: `--diff` prints a unified diff per drifted file (truncated when large), `--format=github` emits GitHub Actions `::error` annotations that surface inline on the PR, and a failing check now prints the reconcile command (`agnostic-ai sync`) on stderr and points its error and the config-error hints at `agnostic-ai doctor`. Exit codes and the `--json` schema are unchanged (#488).
 - `sync --jobs <n>` emits targets in parallel (default: one worker per CPU; `1` forces serial). The emitted tree, summary, JSON, gitignore block, and warnings stay byte-identical regardless of the worker count (#487).

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -59,7 +59,7 @@ agnostic-ai import continue       # .continue/rules/
 - Multiple sources import in order. Each mirrors its target's top-level instructions file to `.agnostic-ai/AGNOSTIC_AI.md`; with multiple sources, the last argument wins.
 - When another target's entry-point exists with different hand-authored content (e.g. a distinct `AGENTS.md` alongside `CLAUDE.md`), import warns that it holds unique content the next `sync` would overwrite. Merge that content into `.agnostic-ai/AGNOSTIC_AI.md` before syncing to keep it.
 - `all` cannot combine with other sources. It auto-detects every CLI present in the project.
-- Valid sources: `claude`, `codex`, `cursor`, `aider`, `amp`, `warp`, `gemini`, `copilot`, `opencode`, `zed`, `antigravity`, `continue`, `cline`, `windsurf`, `junie`, `trae`, plus `all`.
+- Valid sources: `claude`, `codex`, `cursor`, `aider`, `amp`, `warp`, `gemini`, `copilot`, `opencode`, `zed`, `antigravity`, `continue`, `cline`, `windsurf`, `junie`, `trae`, `kiro`, `crush`, plus `all`. Every emitted target can also be imported.
 
 `import claude`:
 
@@ -125,6 +125,30 @@ Reads `.cursor/rules/**` recursively, so nested rule directories are imported to
 | `<scope>/<file>.md` | nested under the same `<scope>` in the destination |
 
 The leading `# <heading>` block (which the adapter prepends on emit) is stripped on import, and a minimal `name:` frontmatter is injected.
+
+`import kiro` reverses the Kiro steering layout. Steering files are flat under `.kiro/steering/` and carry a frontmatter-first `inclusion:` block; the filename prefix picks the kind:
+
+| Source | Becomes |
+|--------|---------|
+| `.kiro/steering/<name>.md` (`inclusion: always`) | `<rules>/<name>.md` (unscoped rule) |
+| `.kiro/steering/<name>.md` (`inclusion: fileMatch` + `fileMatchPattern`) | `<rules>/<name>.md` with `globs: <fileMatchPattern>` |
+| `.kiro/steering/agent-<name>.md` | `<agents>/<name>.md` |
+| `.kiro/steering/skill-<name>.md` | `<skills>/<name>/SKILL.md` |
+| `.kiro/settings/mcp.json` (`mcpServers.<name>`) | `<mcps>/<name>.yaml` |
+| `AGENTS.md` | `.agnostic-ai/AGNOSTIC_AI.md` |
+
+Lossy on round-trip (Kiro's emit cannot carry these, so the reconstructed spec drops them without changing Kiro's output): a rule's source-layout scope collapses into an equivalent `globs:`, a steering agent keeps only its body, and a steering skill keeps only its SKILL.md (bundled sibling assets are flattened on emit).
+
+`import crush` reverses the Crush layout. Crush has no per-rule directory, so rules ride inside the shared `AGENTS.md`:
+
+| Source | Becomes |
+|--------|---------|
+| `AGENTS.md` inlined `## Rules` block (`### <name>` children) | `<rules>/<name>.md` per rule |
+| `.agents/skills/<name>/SKILL.md` (+ bundled assets) | `<skills>/<name>/SKILL.md` (folder copied byte-for-byte) |
+| `crush.json` (`mcp.<name>`, `type: stdio` / `type: http`) | `<mcps>/<name>.yaml` |
+| `AGENTS.md` | `.agnostic-ai/AGNOSTIC_AI.md` |
+
+Lossy on round-trip: rules reach Crush only through the inlined block, which carries no `globs`/scope, so rule scoping does not round-trip (Crush's output is unaffected either way).
 
 ## validate
 

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -48,7 +48,7 @@ func windsurfImportDir(root string) string {
 func importSources() string {
 	names := []string{
 		"aider", "amp", "antigravity", "claude", "codex", "continue", "copilot",
-		"cursor", "gemini", "opencode", "warp", "windsurf", "zed",
+		"crush", "cursor", "gemini", "kiro", "opencode", "warp", "windsurf", "zed",
 	}
 	for k := range rulesDirImporters {
 		names = append(names, k)
@@ -136,6 +136,10 @@ func runImport(root, source string, cfg *config.Config) error {
 		return importFromAntigravity(root, src, cfg)
 	case "continue":
 		return importFromContinue(root, src)
+	case "kiro":
+		return importFromKiro(root, src)
+	case "crush":
+		return importFromCrush(root, src)
 	case "windsurf":
 		return importFromRulesDir(root, source, windsurfImportDir(root), src)
 	}
@@ -179,7 +183,7 @@ func runImportMany(root string, sources []string, cfg *config.Config) error {
 func isKnownImportSource(source string) bool {
 	switch source {
 	case "claude", "codex", "cursor", "aider", "amp", "warp",
-		"gemini", "copilot", "opencode", "zed", "windsurf":
+		"gemini", "copilot", "opencode", "zed", "windsurf", "kiro", "crush":
 		return true
 	}
 	_, ok := rulesDirImporters[source]

--- a/internal/cli/import_crush.go
+++ b/internal/cli/import_crush.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"path/filepath"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const (
+	crushMainFile  = "AGENTS.md"
+	crushSkillsDir = ".agents/skills"
+	crushMCPFile   = "crush.json"
+	crushMCPKey    = "mcp"
+)
+
+// importFromCrush reads an existing Charm Crush project and writes specs
+// into the configured source directories, reversing the crush emit:
+//
+//   - `AGENTS.md` carries rule bodies inlined in a sentinel-marked
+//     `## Rules` block (Crush has no per-rule directory); each `### <name>`
+//     child becomes a rule. The same file mirrors to
+//     `.agnostic-ai/AGNOSTIC_AI.md`.
+//   - `.agents/skills/<name>/SKILL.md` folders reconstruct skills, with
+//     bundled sibling assets copied byte-for-byte.
+//   - `crush.json` (`mcp` map) reconstructs MCP specs, both `type: stdio`
+//     and `type: http` entries; user-managed keys (models, providers,
+//     lsp, options) are ignored.
+//
+// Lossy field: rules reach Crush only through the inlined block, which
+// carries no `globs`/scope, so rule scoping does not round-trip (Crush's
+// output is unaffected either way).
+func importFromCrush(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Skills, src.MCPs); err != nil {
+		return err
+	}
+	rules, err := sliceMainFileByH2(root, crushMainFile, filepath.Join(root, src.Rules))
+	if err != nil {
+		return err
+	}
+	skills, err := importSkillFolders(filepath.Join(root, crushSkillsDir), filepath.Join(root, src.Skills))
+	if err != nil {
+		return err
+	}
+	mcps, err := importJSONMCPMap(filepath.Join(root, crushMCPFile), crushMCPKey,
+		filepath.Join(root, src.MCPs))
+	if err != nil {
+		return err
+	}
+	if _, err := mirrorMainFile(root, crushMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d skills, %d mcps\n", rules, skills, mcps)
+	printImportNextSteps(root, "crush")
+	return nil
+}

--- a/internal/cli/import_crush_test.go
+++ b/internal/cli/import_crush_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// TestImportCrush_RoundTripFixedPoint emits a kit-sink bundle to crush,
+// wipes the source specs, imports the emitted tree back, then re-emits.
+// The second emit must byte-match the first: import reconstructs rules
+// (from the inlined `## Rules` block in AGENTS.md), skills (from
+// `.agents/skills/`), and MCP servers (from `crush.json`).
+func TestImportCrush_RoundTripFixedPoint(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	writeFile(t, filepath.Join(dir, "agnostic-ai.yaml"), "version: 1\ntargets: [crush]\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r1.md"),
+		"---\nname: r1\n---\n\nrule one body\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r2.md"),
+		"---\nname: r2\n---\n\nrule two body\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "skills", "my-skill", "SKILL.md"),
+		"---\nname: my-skill\ndescription: An example skill\n---\n\nSkill body here.\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "stdio-server.yaml"),
+		"name: stdio-server\ncommand: npx\nargs:\n  - -y\n  - \"@modelcontextprotocol/server-filesystem\"\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "http-server.yaml"),
+		"name: http-server\ntype: http\nurl: https://example.test/mcp\n")
+
+	execCLI(t, "sync", "-t", "crush")
+	first := snapshotEmitted(t, dir)
+	if _, ok := first["crush.json"]; !ok {
+		t.Fatalf("first emit produced no crush.json: %v", keys(first))
+	}
+	if _, ok := first[".agents/skills/my-skill/SKILL.md"]; !ok {
+		t.Fatalf("first emit produced no skill folder: %v", keys(first))
+	}
+
+	if err := os.RemoveAll(filepath.Join(dir, ".agnostic-ai")); err != nil {
+		t.Fatalf("wipe source specs: %v", err)
+	}
+	execCLI(t, "import", "crush")
+
+	// Rules come from the inlined `## Rules` block in AGENTS.md.
+	r1 := readFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r1.md"))
+	if !strings.Contains(r1, "name: r1") || !strings.Contains(r1, "rule one body") {
+		t.Errorf("rule r1 not reconstructed from AGENTS.md:\n%s", r1)
+	}
+	r2 := readFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r2.md"))
+	if !strings.Contains(r2, "rule two body") {
+		t.Errorf("rule r2 not reconstructed:\n%s", r2)
+	}
+	// Skill folder round-trips (with its description).
+	skill := readFile(t, filepath.Join(dir, ".agnostic-ai", "skills", "my-skill", "SKILL.md"))
+	if !strings.Contains(skill, "description: An example skill") || !strings.Contains(skill, "Skill body here.") {
+		t.Errorf("skill not reconstructed:\n%s", skill)
+	}
+	// MCP: crush.json carries an explicit `type` on both transports.
+	stdio := readFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "stdio-server.yaml"))
+	if !strings.Contains(stdio, "type: stdio") || !strings.Contains(stdio, "command: npx") {
+		t.Errorf("stdio mcp not reconstructed:\n%s", stdio)
+	}
+	httpMCP := readFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "http-server.yaml"))
+	if !strings.Contains(httpMCP, "type: http") || !strings.Contains(httpMCP, "url: https://example.test/mcp") {
+		t.Errorf("http mcp not reconstructed:\n%s", httpMCP)
+	}
+
+	execCLI(t, "sync", "-t", "crush")
+	second := snapshotEmitted(t, dir)
+	assertEmittedEqual(t, first, second)
+}
+
+// TestImportCrush_UnknownStaysRejected guards the wiring: crush is a
+// known source, but a typo near it still fails fast in a multi-source
+// import.
+func TestImportCrush_KnownSourceWiredIn(t *testing.T) {
+	if !isKnownImportSource("crush") {
+		t.Error("crush should be a known import source")
+	}
+	if !isKnownImportSource("kiro") {
+		t.Error("kiro should be a known import source")
+	}
+	sources := importSources()
+	for _, want := range []string{"crush", "kiro"} {
+		if !strings.Contains(sources, want) {
+			t.Errorf("importSources() missing %q: %s", want, sources)
+		}
+	}
+}

--- a/internal/cli/import_kiro.go
+++ b/internal/cli/import_kiro.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/header"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+const (
+	kiroSteeringDir = ".kiro/steering"
+	kiroMCPFile     = ".kiro/settings/mcp.json"
+	kiroMCPKey      = "mcpServers"
+	kiroMainFile    = "AGENTS.md"
+)
+
+// importFromKiro reads an existing AWS Kiro project and writes specs into
+// the configured source directories, reversing the kiro emit:
+//
+//   - `.kiro/steering/*.md` steering files carry a frontmatter-first
+//     `inclusion:` block. The filename prefix picks the kind
+//     (`agent-<name>.md` -> agent, `skill-<name>.md` -> skill, otherwise
+//     a rule) and a rule's `inclusion:` maps back to scope: `fileMatch`
+//     with `fileMatchPattern` becomes a `globs:` rule, `always` an
+//     unscoped rule.
+//   - `.kiro/settings/mcp.json` (`mcpServers` map) reconstructs MCP specs.
+//   - `AGENTS.md` (the shared entry-point Kiro reads directly) mirrors to
+//     `.agnostic-ai/AGNOSTIC_AI.md`.
+//
+// Lossy fields (Kiro's emit cannot carry them, so a round-trip drops them
+// without changing Kiro's output): a rule's source-layout scope collapses
+// into an equivalent `globs:`; a steering agent keeps only its body (Kiro
+// agents hold no description or model); a steering skill keeps only its
+// SKILL.md content (bundled sibling assets flatten away on emit).
+func importFromKiro(root string, src config.Sources) error {
+	if err := mkdirAllSources(root, src.Rules, src.Agents, src.Skills, src.MCPs); err != nil {
+		return err
+	}
+	c, err := importKiroSteering(root, src)
+	if err != nil {
+		return err
+	}
+	mcps, err := importJSONMCPMap(filepath.Join(root, kiroMCPFile), kiroMCPKey,
+		filepath.Join(root, src.MCPs))
+	if err != nil {
+		return err
+	}
+	if _, err := mirrorMainFile(root, kiroMainFile); err != nil {
+		return err
+	}
+	summaryf("imported %d rules, %d agents, %d skills, %d mcps\n",
+		c.rules, c.agents, c.skills, mcps)
+	printImportNextSteps(root, "kiro")
+	return nil
+}
+
+// importKiroSteering walks the flat `.kiro/steering/` directory and
+// reconstructs one spec per `*.md` steering file. A missing directory
+// imports nothing.
+func importKiroSteering(root string, src config.Sources) (rulesDirCounts, error) {
+	var c rulesDirCounts
+	dir := filepath.Join(root, kiroSteeringDir)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return c, nil
+	}
+	if err != nil {
+		return c, fmt.Errorf("read %s: %w", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		if err := importKiroSteeringFile(root, filepath.Join(dir, e.Name()), e.Name(), src, &c); err != nil {
+			return c, err
+		}
+	}
+	return c, nil
+}
+
+// importKiroSteeringFile reconstructs one steering file into a rule,
+// agent, or skill spec based on its filename prefix, parsing the
+// frontmatter-first `inclusion:` block the kiro adapter writes.
+func importKiroSteeringFile(root, path, filename string, src config.Sources, c *rulesDirCounts) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	meta, body := splitMdcFrontmatter([]byte(header.Strip(string(data))))
+	kind, name := classifyRulesDirFile(filename)
+	switch kind {
+	case "agents":
+		out := filepath.Join(root, src.Agents, name+".md")
+		if err := writeAgentMD(out, name, "", nil, body); err != nil {
+			return err
+		}
+		c.agents++
+	case "skills":
+		out := filepath.Join(root, src.Skills, name, "SKILL.md")
+		if err := importMkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
+		}
+		desc, _ := meta["description"].(string)
+		if err := writeAgentMD(out, name, desc, nil, body); err != nil {
+			return err
+		}
+		c.skills++
+	default:
+		out := filepath.Join(root, src.Rules, name+".md")
+		globs, _ := meta["fileMatchPattern"].(string)
+		if err := writeRuleWithGlobs(out, name, globs, body); err != nil {
+			return err
+		}
+		c.rules++
+	}
+	return nil
+}
+
+// writeRuleWithGlobs writes a rule spec with a `name:` and an optional
+// `globs:` frontmatter followed by body. Mirrors writeRule but carries
+// the glob a kiro `fileMatchPattern` reconstructs, encoded YAML-safely so
+// a leading-`*` glob is quoted rather than read back as an alias.
+func writeRuleWithGlobs(path, name, globs, body string) error {
+	var sb strings.Builder
+	sb.WriteString("---\nname: " + name + "\n")
+	if globs != "" {
+		sb.WriteString(yamlFrontmatterLine("globs", globs))
+	}
+	sb.WriteString("---\n\n")
+	sb.WriteString(strings.TrimRight(body, "\n"))
+	sb.WriteString("\n")
+	if err := importWriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/cli/import_kiro_test.go
+++ b/internal/cli/import_kiro_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// execCLI drives one agnostic-ai command in-process, failing the test on
+// error. Output is expected to be silenced by the caller.
+func execCLI(t *testing.T, args ...string) {
+	t.Helper()
+	root := NewRootCmd("test")
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("%v: %v", args, err)
+	}
+}
+
+// snapshotEmitted reads every emitted file under root (skipping the
+// `.agnostic-ai/` source tree and agnostic-ai.yaml) into a map keyed by
+// slash-form relative path, so two syncs can be compared for a
+// round-trip fixed point.
+func snapshotEmitted(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "agnostic-ai.yaml" || strings.HasPrefix(rel, ".agnostic-ai/") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// assertEmittedEqual fails the test when two emitted-tree snapshots
+// differ, naming the first offending path.
+func assertEmittedEqual(t *testing.T, want, got map[string]string) {
+	t.Helper()
+	for rel, wantBody := range want {
+		gotBody, ok := got[rel]
+		if !ok {
+			t.Errorf("re-emit dropped %s", rel)
+			continue
+		}
+		if gotBody != wantBody {
+			t.Errorf("re-emit diverged at %s\n--- first ---\n%s\n--- second ---\n%s",
+				rel, wantBody, gotBody)
+		}
+	}
+	for rel := range got {
+		if _, ok := want[rel]; !ok {
+			t.Errorf("re-emit added %s", rel)
+		}
+	}
+}
+
+// TestImportKiro_RoundTripFixedPoint emits a kit-sink bundle to kiro,
+// wipes the source specs, imports the emitted tree back, then re-emits.
+// The second emit must byte-match the first: import reconstructs every
+// spec the kiro adapter can carry.
+func TestImportKiro_RoundTripFixedPoint(t *testing.T) {
+	dir := t.TempDir()
+	testutil.Chdir(t, dir)
+	silence(t)
+
+	writeFile(t, filepath.Join(dir, "agnostic-ai.yaml"), "version: 1\ntargets: [kiro]\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r-go.md"),
+		"---\nname: r-go\nglobs: \"**/*.go\"\n---\n\nGo rule body here.\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r-always.md"),
+		"---\nname: r-always\n---\n\nAlways rule body here.\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "agents", "my-agent.md"),
+		"---\nname: my-agent\n---\n\nAgent body here.\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "skills", "my-skill", "SKILL.md"),
+		"---\nname: my-skill\ndescription: An example skill\n---\n\nSkill body here.\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "stdio-server.yaml"),
+		"name: stdio-server\ncommand: npx\nargs:\n  - -y\n  - \"@modelcontextprotocol/server-filesystem\"\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "http-server.yaml"),
+		"name: http-server\ntype: http\nurl: https://example.test/mcp\n")
+
+	execCLI(t, "sync", "-t", "kiro")
+	first := snapshotEmitted(t, dir)
+	if _, ok := first[".kiro/steering/r-go.md"]; !ok {
+		t.Fatalf("first emit produced no kiro steering files: %v", keys(first))
+	}
+
+	if err := os.RemoveAll(filepath.Join(dir, ".agnostic-ai")); err != nil {
+		t.Fatalf("wipe source specs: %v", err)
+	}
+	execCLI(t, "import", "kiro")
+
+	// Rules: fileMatch -> globs, always -> unscoped.
+	rGo := readFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r-go.md"))
+	if !strings.Contains(rGo, "globs:") || !strings.Contains(rGo, "**/*.go") {
+		t.Errorf("r-go rule lost its glob on import:\n%s", rGo)
+	}
+	if !strings.Contains(rGo, "Go rule body here.") {
+		t.Errorf("r-go rule lost its body:\n%s", rGo)
+	}
+	rAlways := readFile(t, filepath.Join(dir, ".agnostic-ai", "rules", "r-always.md"))
+	if strings.Contains(rAlways, "globs:") {
+		t.Errorf("always rule should be unscoped (no globs):\n%s", rAlways)
+	}
+	// Agent and skill round-trip through steering-file prefixes.
+	agent := readFile(t, filepath.Join(dir, ".agnostic-ai", "agents", "my-agent.md"))
+	if !strings.Contains(agent, "name: my-agent") || !strings.Contains(agent, "Agent body here.") {
+		t.Errorf("agent not reconstructed:\n%s", agent)
+	}
+	skill := readFile(t, filepath.Join(dir, ".agnostic-ai", "skills", "my-skill", "SKILL.md"))
+	if !strings.Contains(skill, "description: An example skill") {
+		t.Errorf("skill lost its description:\n%s", skill)
+	}
+	// MCP: mcpServers stdio (no type) + http (type http).
+	stdio := readFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "stdio-server.yaml"))
+	if !strings.Contains(stdio, "command: npx") {
+		t.Errorf("stdio mcp not reconstructed:\n%s", stdio)
+	}
+	httpMCP := readFile(t, filepath.Join(dir, ".agnostic-ai", "mcps", "http-server.yaml"))
+	if !strings.Contains(httpMCP, "type: http") || !strings.Contains(httpMCP, "url: https://example.test/mcp") {
+		t.Errorf("http mcp not reconstructed:\n%s", httpMCP)
+	}
+
+	execCLI(t, "sync", "-t", "kiro")
+	second := snapshotEmitted(t, dir)
+	assertEmittedEqual(t, first, second)
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

`sync` emits 18 targets but `import` accepted only 16: `kiro` and `crush` had no importer (deferred when #474 added them). A project configured for either could not migrate its existing config into agnostic specs. This closes the round-trip asymmetry so every emitted target can also be imported.

- **kiro** (`internal/cli/import_kiro.go`): reads `.kiro/steering/*.md` (flat, frontmatter-first `inclusion:` steering files) classified by filename prefix (`agent-`/`skill-`/rule). A rule's `inclusion:` maps back to scope: `fileMatch` + `fileMatchPattern` → `globs:` rule, `always` → unscoped rule. `.kiro/settings/mcp.json` (`mcpServers` map) → MCP specs. `AGENTS.md` mirrors to `.agnostic-ai/AGNOSTIC_AI.md`.
- **crush** (`internal/cli/import_crush.go`): reads the inlined `## Rules` block in `AGENTS.md` → rules, `.agents/skills/<name>/SKILL.md` → skills, and the `crush.json` `mcp` map (`type: stdio` / `type: http`) → MCP specs.
- Both wired into `importSources()` (now 18), `isKnownImportSource`, and the `runImport` dispatch. They reuse the shared MCP, skill-folder, and entry-point helpers so the importers stay in `internal/cli` and honor `no-cross-adapter-imports` (no adapter-package imports).

## Round-trip test note

The strongest oracle is an **emit → import → re-emit fixed point**: each test writes source specs, `sync -t <target>` into a temp dir (snapshot K1), wipes `.agnostic-ai/`, `import <target>` to reconstruct the specs, then `sync -t <target>` again (K2) and asserts **K1 == K2 byte-for-byte**. Both `TestImportKiro_RoundTripFixedPoint` and `TestImportCrush_RoundTripFixedPoint` pass, plus targeted assertions on the reconstructed specs (kiro preserves `globs` from `fileMatchPattern`; MCP transports round-trip). Documented lossy fields (kiro scope→glob, agent metadata, flattened skill assets; crush rule scoping) do not affect the emitted output, so the fixed point still holds.

## Test plan

- `gofmt -l .` → empty
- `golangci-lint run ./...` → **0 issues** (the CI Lint check)
- `go vet ./...` · `go build ./...` → clean
- `go test ./...` → 1402 passed; `go test -race ./internal/cli/ -run Import` → 184 passed
- `agnostic-ai import --help` lists `crush` and `kiro` (18 sources total)
- Manual emit→import→re-emit fixed point verified for both targets outside the test harness

Docs: `docs/user/cli-reference.md` import-sources list updated to 18 with per-target source→spec tables and lossy-field notes; `CHANGELOG.md` entry under `## [Unreleased]` → `### Added`.

No `ref(...)` polish commit was needed (lint clean on the first pass).

Closes #494
