### PR TITLE
docs: onboarding polish (install, completion, new --dry-run)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `new --dry-run` previews a spec scaffold (destination path plus rendered frontmatter and body) without writing it, and `init`'s post-scaffold next steps now point at `agnostic-ai completion <shell>` for shell tab-completion (#495).
 - `import kiro` and `import crush` close the last round-trip gap: every one of the 18 emitted targets now imports back. `kiro` reads `.kiro/steering/*.md` (mapping `inclusion: always` to unscoped rules and `fileMatch` + `fileMatchPattern` to `globs:` rules, plus `agent-`/`skill-` steering files) and `.kiro/settings/mcp.json`; `crush` reads the inlined `## Rules` block in `AGENTS.md`, `.agents/skills/<name>/SKILL.md`, and the `crush.json` `mcp` map (#494).
 - `--profile <file>` (or `AGNOSTIC_AI_PROFILE`) writes a `runtime/pprof` CPU profile of the run, and `sync --verbose` appends per-target wall time (`in Nms`) to each target line, so a slow sync attributes to a specific adapter. Off by default, stdlib profiler only (#491).
 - `sync --check` gains actionable drift output: `--diff` prints a unified diff per drifted file (truncated when large), `--format=github` emits GitHub Actions `::error` annotations that surface inline on the PR, and a failing check now prints the reconcile command (`agnostic-ai sync`) on stderr and points its error and the config-error hints at `agnostic-ai doctor`. Exit codes and the `--json` schema are unchanged (#488).

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Edit specs under `.agnostic-ai/`, run `sync` again. Already have `.cursor/rules`
 agnostic-ai import cursor   # also: claude, codex, gemini, cline, windsurf, junie, trae, ...
 ```
 
+Enable shell tab-completion (optional): `agnostic-ai completion <shell>` for bash, zsh, fish, or powershell.
+
 CI gate to fail PRs that drift from source specs:
 
 ```yaml

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -49,6 +49,17 @@ The generated `agnostic-ai.yaml` carries a `yaml-language-server` comment pointi
     └── mcps/
 ```
 
+### Add a single spec
+
+`new <kind> <name>` scaffolds one spec (agent, skill, rule, hook, or MCP) with kind-appropriate frontmatter, under the source dir configured for that kind:
+
+```bash
+agnostic-ai new rule no-console-log            # writes .agnostic-ai/rules/no-console-log.md
+agnostic-ai new rule no-console-log --dry-run  # preview the path and rendered body, write nothing
+```
+
+`--dry-run` prints the destination path plus the frontmatter and body it would write, so you can check the shape before it lands on disk.
+
 ### Import an existing AI CLI config
 
 After `init`, run `import <source>` to translate an existing config into agnostic specs under the configured `sources:` paths:

--- a/internal/cli/init_scaffold.go
+++ b/internal/cli/init_scaffold.go
@@ -213,6 +213,8 @@ func listPresetFiles(baseDir, preset string) error {
 // suggested next step is `sync` (the source dirs are not empty).
 // Otherwise the suggested next step is `import <target>`. Detected
 // CLI configs under root are surfaced as concrete `import` follow-ups.
+// A closing tip points at `completion` so first-time users discover
+// shell tab-completion (never auto-installed; instructions only).
 func printNextSteps(root, base string, targets []string, seeded bool) {
 	summaryf("✓ initialized agnostic-ai project at %s\n", baseLabel(base))
 	if len(targets) > 0 {
@@ -227,19 +229,19 @@ func printNextSteps(root, base string, targets []string, seeded bool) {
 		summaryf("  agnostic-ai import <target>   # mirror an existing CLI's config into specs\n")
 		summaryf("  agnostic-ai sync              # emit to your configured targets\n")
 	}
-	detected := detectExistingTargets(root)
-	if len(detected) == 0 {
-		return
+	if detected := detectExistingTargets(root); len(detected) > 0 {
+		summaryf("\n")
+		summaryf("detected existing config:\n")
+		for i, d := range detected {
+			if i >= 3 {
+				summaryf("  (and %d more)\n", len(detected)-3)
+				break
+			}
+			summaryf("  agnostic-ai import %s\n", d)
+		}
 	}
 	summaryf("\n")
-	summaryf("detected existing config:\n")
-	for i, d := range detected {
-		if i >= 3 {
-			summaryf("  (and %d more)\n", len(detected)-3)
-			return
-		}
-		summaryf("  agnostic-ai import %s\n", d)
-	}
+	summaryf("tip: enable shell tab-completion with `agnostic-ai completion <shell>` (bash, zsh, fish, powershell).\n")
 }
 
 // baseLabel renders the user-facing label for the scaffold root. "."

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -590,3 +590,14 @@ func TestScaffold_DetectsExistingTargetsAndSuggestsImports(t *testing.T) {
 		t.Errorf("expected codex import hint:\n%s", out)
 	}
 }
+
+func TestScaffold_NextStepsPointAtCompletion(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureSummary(t)
+	if err := scaffold(scaffoldOptions{Root: dir, Base: "", Targets: allTargetNames()}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "agnostic-ai completion <shell>") {
+		t.Errorf("next steps should point at shell completion:\n%s", buf.String())
+	}
+}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -26,14 +26,19 @@ var newSpecKinds = []string{
 var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
 func newNewCmd() *cobra.Command {
+	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "new <kind> <name>",
 		Short: "Scaffold a single spec file with kind-appropriate frontmatter.",
 		Long: "Creates one spec file under the directory configured for <kind> " +
 			"in agnostic-ai.yaml. Replaces 'copy from --demo and edit' as " +
-			"the starting point for a single new agent, skill, rule, hook, or MCP.",
+			"the starting point for a single new agent, skill, rule, hook, or MCP. " +
+			"Pass --dry-run to preview the path and rendered body without writing.",
 		Example: `  # Add a new rule
   agnostic-ai new rule no-console-log
+
+  # Preview the scaffold without writing it
+  agnostic-ai new rule no-console-log --dry-run
 
   # Add a new agent
   agnostic-ai new agent code-reviewer
@@ -63,13 +68,17 @@ func newNewCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			body := newSpecTemplate(kind, name)
+			if dryRun {
+				summaryf("would create %s\n\n%s", path, body)
+				return nil
+			}
 			if _, err := os.Stat(path); err == nil {
 				return fmt.Errorf("%s already exists", path)
 			}
 			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 				return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 			}
-			body := newSpecTemplate(kind, name)
 			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 				return fmt.Errorf("write %s: %w", path, err)
 			}
@@ -78,6 +87,8 @@ func newNewCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"Print the spec that would be scaffolded (path plus rendered frontmatter and body) without writing it.")
 	return cmd
 }
 

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -53,6 +53,35 @@ func TestNew_WritesRule(t *testing.T) {
 	}
 }
 
+func TestNew_DryRunPrintsScaffoldWithoutWriting(t *testing.T) {
+	dir := setupEmptyProject(t)
+	testutil.Chdir(t, dir)
+	out := captureSummary(t)
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"new", "rule", "no-console-log", "--dry-run"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	// The preview names the destination path...
+	if !strings.Contains(got, filepath.Join(".agnostic-ai", "rules", "no-console-log.md")) {
+		t.Errorf("dry-run output missing target path:\n%s", got)
+	}
+	// ...and prints the rendered frontmatter and body.
+	if !strings.Contains(got, "name: no-console-log") {
+		t.Errorf("dry-run output missing rendered frontmatter:\n%s", got)
+	}
+	if !strings.Contains(got, "alwaysApply: true") {
+		t.Errorf("dry-run output missing rendered body:\n%s", got)
+	}
+	// Nothing may land on disk.
+	if _, err := os.Stat(filepath.Join(dir, ".agnostic-ai", "rules", "no-console-log.md")); !os.IsNotExist(err) {
+		t.Errorf("dry-run wrote a file, want none: %v", err)
+	}
+}
+
 func TestNew_HookEmitsYAML(t *testing.T) {
 	dir := setupEmptyProject(t)
 	testutil.Chdir(t, dir)


### PR DESCRIPTION
## What

Onboarding polish for the first five minutes: install, scaffold, preview, enable completion.

- **`new --dry-run`**: prints the destination path plus the rendered frontmatter and body it would write, then exits without touching disk. Lets users check a spec's shape before it lands.
- **`init` next steps**: the post-scaffold guidance now points at `agnostic-ai completion <shell>` so the existing (previously unadvertised) shell-completion command is discoverable. No shell rc is modified and no installer runs: instructions only.
- **README quickstart**: adds a one-line pointer to `agnostic-ai completion <shell>` (the `go install` one-liner and release-binary path were already current).
- **Docs**: `getting-started.md` gains an "Add a single spec" section covering `new` and `--dry-run`; `CHANGELOG.md` records the new flag under `[Unreleased] > Added`.

## Boundary

In scope only: `README.md`, `docs/user/getting-started.md`, `internal/cli/init*.go`, `internal/cli/new*.go`, `CHANGELOG.md`. No changes to `sync`/emit. No shell rc edits, no installers.

## Test plan

New unit tests (package `internal/cli`):

- `TestNew_DryRunPrintsScaffoldWithoutWriting`: asserts the preview prints the path + rendered frontmatter/body and that `os.Stat` on the target reports it does not exist.
- `TestScaffold_NextStepsPointAtCompletion`: asserts the next-steps block points at `agnostic-ai completion <shell>`. Existing init scaffold tests stay green.

Local gates (all pass):

- `gofmt -l .` empty
- `golangci-lint run ./...` (v2.12.2) -> 0 issues
- `go vet ./...` clean
- `go build ./...` clean
- `go test ./...` -> 1404 passed in 33 packages

Manual smoke: `new rule x --dry-run` prints the scaffold and leaves the rules dir empty; `init` prints the next-steps block including the completion tip.

No `ref(...)` polish commit was needed.

Closes #495
