### PR TITLE
docs: surface --watch and --check diff in README and landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ agnostic-ai init --demo   # scaffold specs with one example per folder
 agnostic-ai sync          # emit native config for every target
 ```
 
-Edit specs under `.agnostic-ai/`, run `sync` again. Already have `.cursor/rules` or `AGENTS.md`?
+Edit specs under `.agnostic-ai/` and run `sync` again, or `sync --watch` to re-emit on every save (only the affected targets). Already have `.cursor/rules` or `AGENTS.md`?
 
 ```bash
 agnostic-ai import cursor   # also: claude, codex, gemini, cline, windsurf, junie, trae, ...

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -357,7 +357,7 @@ Use Conventional Commits.</pre>
       <div class="step">
         <div class="num">03 · GUARD</div>
         <h3>Never drift</h3>
-        <p><code>sync --check</code> re-emits in memory and fails CI on any difference. <code>import</code> pulls existing configs back into specs; the round-trip stays byte-stable.</p>
+        <p><code>sync --check</code> re-emits in memory and fails CI on any difference, printing a per-file diff of what drifted. <code>import</code> pulls existing configs back into specs; the round-trip stays byte-stable.</p>
       </div>
     </div>
 


### PR DESCRIPTION
Discovery polish after the feature batch. The README dev-loop line now points at `sync --watch` (incremental, #490) and the landing page's drift step notes `sync --check`'s per-file diff (#488) — both shipped but weren't surfaced from the front door.

Audited the rest: CHANGELOG `[Unreleased]` is coherent (no dupes), every new flag (`--diff`/`--format=github`/`--profile`/`--jobs`/`new --dry-run`) is in cli-reference, import sources are 18 (kiro+crush), and all target counts are consistent. No other changes needed.

Docs-only.