### PR TITLE
chore(config): cover all 18 targets in the dogfood, fix AGENTS.md note

### DIFF
--- a/agnostic-ai.yaml
+++ b/agnostic-ai.yaml
@@ -11,16 +11,15 @@ version: 1
 # mcps,commands}` relative to this file, so the `sources:` block is omitted.
 # Set it only to point a kind somewhere else.
 
-# AI CLIs to emit configs for. Every adapter the tool ships is enabled
-# so the project itself acts as the end-to-end fixture for each emitter.
-# Comment any out to skip.
+# AI CLIs to emit configs for. Every adapter the tool ships is enabled,
+# so this repo is the end-to-end fixture for each emitter. Comment any
+# out to skip.
 #
-# Note: codex, amp, and warp all default to root `AGENTS.md` per the
-# community AGENTS.md spec. Only one can own the root file in a project,
-# so the dogfood set keeps codex (which also emits .codex/config.toml)
-# and drops amp and warp. Real users pick the one matching their CLI.
-# `sync` now fails fast with an output-collision error if more than one
-# is enabled without an `outputs.<target>.file` override.
+# codex, amp, warp, zed, cline, junie, kiro, crush, and trae all read the
+# root `AGENTS.md`. Sync writes it once: the byte-identical pointer body
+# (plus the shared inline rules block) deduplicates across them, so they
+# coexist with no collision. Only divergent content at the same path
+# errors, which an `outputs.<target>.file` override would resolve.
 targets:
   - claude
   - codex
@@ -40,6 +39,8 @@ targets:
   - kiro
   - crush
   - trae
+  - amp
+  - warp
 
 # Per-target output overrides. Defaults work for everything below;
 # the aider conf-file is opt-in and demonstrates the merge feature.


### PR DESCRIPTION
## Summary

Optimizes the repo's own `agnostic-ai.yaml`:

- **Enable `amp` and `warp`.** The config already states its purpose is an "end-to-end fixture for each emitter" and that "every adapter the tool ships is enabled" — but amp and warp were dropped, so 2 of 18 emitters weren't dogfooded. They were dropped for a root-`AGENTS.md` collision that no longer exists: content-dedup writes the byte-identical pointer body (plus the shared inline rules block) once across all nine AGENTS.md consumers. Verified: `sync` emits all 18 with **no collision** and `sync --check` stays idempotent.
- **Fix the stale note.** The old comment claimed "only one can own the root file" and "`sync` fails fast with a collision error" — both obsolete. Rewrote it to describe the actual dedup behavior (which is why codex + zed + cline + junie + kiro + crush + trae already coexist).

Only `agnostic-ai.yaml` changes; regenerated outputs stay gitignored (amp/warp add no new ignore paths). Easy to revert if a leaner dogfood is preferred.

## Test plan
- [x] `validate` ok (25 entries)
- [x] `sync` emits 18 targets, no collision
- [x] `sync --check` clean / idempotent
- [x] `git status` shows only `agnostic-ai.yaml`