### PR TITLE
fix(cli): enforce the capability map against declared adapter support

### DIFF
--- a/.agnostic-ai/agents/target-auditor.md
+++ b/.agnostic-ai/agents/target-auditor.md
@@ -28,8 +28,22 @@ The prompt names your targets. Everything else you fetch yourself:
    do.
 3. Fetch each doc page listed for that target. A page that 404s is a
    finding (`docs-moved`). Search for the replacement and report the new
-   URL. A page that returns 200 with an empty body is client-side
-   rendered: use WebFetch or WebSearch, never conclude "empty".
+   URL.
+
+   A page that returns 200 with an empty body is client-side rendered.
+   Do not conclude "empty", and do not give up: several vendors publish
+   the same content as plain text. Try these in order, cheapest first.
+   1. `llms.txt` on the docs host.
+   2. The page URL with `.md` appended. Qoder serves a raw markdown
+      mirror for every docs page this way.
+   3. A docs source repo on GitHub. Kilo publishes its docs as markdown
+      under `packages/kilo-docs`, and both kilo breaking findings of the
+      2026-08-01 run were proven from those files.
+   4. Any `/api/` route the SPA itself calls. Trae's changelog is served
+      as JSON from `www.trae.ai/api/changelog` while the rendered page
+      is client-side.
+
+   Only after all four fail is `unconfirmed` the honest answer.
 4. Compare, in this order (highest value first):
    - **Path drift**: does the tool still read the exact path we write? A
      moved skills, rules, or agents dir silently breaks every user. Check
@@ -48,6 +62,18 @@ The prompt names your targets. Everything else you fetch yourself:
 5. Verify before reporting. Re-read the exact sentence in the vendor doc
    and the exact line in our source. If either is ambiguous, downgrade
    the finding to `unconfirmed` and say what would settle it.
+6. Never generalize one target's answer to another, even an adjacent
+   one. The 2026-08-01 run found three different answers to the same
+   `disabled` question across six targets, under two different key
+   names, and two attempts to state a general rule were both wrong. Tool
+   vocabularies split the same way: Qoder uses Claude-style tool names,
+   Augment uses its own, so a passthrough that is correct for one
+   silently names nothing on the other. Check each target separately and
+   say so per target.
+7. Treat a lead in your prompt as a question, not a fact. Leads come
+   from the orchestrator and have been wrong: one asserted a config key
+   that turned out to be the deprecated form. Confirm the whole claim
+   against the source, including the part that was handed to you.
 
 ## Evidence rules
 

--- a/.agnostic-ai/skills/target-audit/SKILL.md
+++ b/.agnostic-ai/skills/target-audit/SKILL.md
@@ -152,6 +152,12 @@ per bucket, all in a single message, each with `isolation: "worktree"`.
 The isolation is not optional: `agnostic-ai sync` rewrites the whole
 emitted tree, so two fixers sharing a checkout overwrite each other.
 
+Settle every bucket before spawning. A fixer cannot be handed new work
+mid-flight: it is told a peer cannot widen its scope, and it cannot tell
+an orchestrator message from any other message on the same channel. That
+refusal is correct and should stay. If a finding lands after the fixers
+are running, close it yourself or spawn a fixer for it.
+
 Bucket by severity, not by target:
 
 | Bucket | Shape | Why |
@@ -170,6 +176,35 @@ has to carry.
 
 When a fixer reports the finding was wrong, reopen nothing. Add a comment
 to the issue with what the evidence missed, and label it `invalid`.
+
+## Phase 7: Land the PRs
+
+Only the first PR merges cleanly. Every adapter fix touches
+`docs/user/targets.md` and `CHANGELOG.md`, so each later PR needs a
+rebase. Budget for it.
+
+**On a conflict in a shared doc, merge both sides. Never pick one.** In
+every conflict of the 2026-08-01 run, both sides were correct about
+different things, because each branch was cut before the other landed.
+Taking one wholesale silently reverts a merged fix. Real examples: a
+capability-matrix paragraph that was right about kilo and stale about
+warp; a capability map where one side had `antigravity` and the other had
+`factory, qoder, openhands`; a count of MCP-capable targets that was
+wrong on both sides.
+
+Read the diff before merging, and check it against the evidence that
+justified it. Two fixes that run cleanly on their own branch can still be
+jointly wrong.
+
+A red CI run is a signal, not an obstacle. Read the failing log before
+concluding it is a flake, and check whether the same job fails on `main`.
+Re-run rather than merging on a theory. Note that `sync --check` drifts
+locally after any merge that changed a spec, because gitignored emitted
+copies are stale; that one is expected and `sync` fixes it.
+
+When querying check status, exclude pending jobs explicitly:
+`select(.conclusion != null and .conclusion != "SUCCESS")`. A pending job
+has a null conclusion and will otherwise read as a failure.
 
 ## What this skill does not do
 

--- a/.github/agents/target-auditor.agent.md
+++ b/.github/agents/target-auditor.agent.md
@@ -35,8 +35,22 @@ The prompt names your targets. Everything else you fetch yourself:
    do.
 3. Fetch each doc page listed for that target. A page that 404s is a
    finding (`docs-moved`). Search for the replacement and report the new
-   URL. A page that returns 200 with an empty body is client-side
-   rendered: use WebFetch or WebSearch, never conclude "empty".
+   URL.
+
+   A page that returns 200 with an empty body is client-side rendered.
+   Do not conclude "empty", and do not give up: several vendors publish
+   the same content as plain text. Try these in order, cheapest first.
+   1. `llms.txt` on the docs host.
+   2. The page URL with `.md` appended. Qoder serves a raw markdown
+      mirror for every docs page this way.
+   3. A docs source repo on GitHub. Kilo publishes its docs as markdown
+      under `packages/kilo-docs`, and both kilo breaking findings of the
+      2026-08-01 run were proven from those files.
+   4. Any `/api/` route the SPA itself calls. Trae's changelog is served
+      as JSON from `www.trae.ai/api/changelog` while the rendered page
+      is client-side.
+
+   Only after all four fail is `unconfirmed` the honest answer.
 4. Compare, in this order (highest value first):
    - **Path drift**: does the tool still read the exact path we write? A
      moved skills, rules, or agents dir silently breaks every user. Check
@@ -55,6 +69,18 @@ The prompt names your targets. Everything else you fetch yourself:
 5. Verify before reporting. Re-read the exact sentence in the vendor doc
    and the exact line in our source. If either is ambiguous, downgrade
    the finding to `unconfirmed` and say what would settle it.
+6. Never generalize one target's answer to another, even an adjacent
+   one. The 2026-08-01 run found three different answers to the same
+   `disabled` question across six targets, under two different key
+   names, and two attempts to state a general rule were both wrong. Tool
+   vocabularies split the same way: Qoder uses Claude-style tool names,
+   Augment uses its own, so a passthrough that is correct for one
+   silently names nothing on the other. Check each target separately and
+   say so per target.
+7. Treat a lead in your prompt as a question, not a fact. Leads come
+   from the orchestrator and have been wrong: one asserted a config key
+   that turned out to be the deprecated form. Confirm the whole claim
+   against the source, including the part that was handed to you.
 
 ## Evidence rules
 

--- a/.github/skills/target-audit/SKILL.md
+++ b/.github/skills/target-audit/SKILL.md
@@ -152,6 +152,12 @@ per bucket, all in a single message, each with `isolation: "worktree"`.
 The isolation is not optional: `agnostic-ai sync` rewrites the whole
 emitted tree, so two fixers sharing a checkout overwrite each other.
 
+Settle every bucket before spawning. A fixer cannot be handed new work
+mid-flight: it is told a peer cannot widen its scope, and it cannot tell
+an orchestrator message from any other message on the same channel. That
+refusal is correct and should stay. If a finding lands after the fixers
+are running, close it yourself or spawn a fixer for it.
+
 Bucket by severity, not by target:
 
 | Bucket | Shape | Why |
@@ -170,6 +176,35 @@ has to carry.
 
 When a fixer reports the finding was wrong, reopen nothing. Add a comment
 to the issue with what the evidence missed, and label it `invalid`.
+
+## Phase 7: Land the PRs
+
+Only the first PR merges cleanly. Every adapter fix touches
+`docs/user/targets.md` and `CHANGELOG.md`, so each later PR needs a
+rebase. Budget for it.
+
+**On a conflict in a shared doc, merge both sides. Never pick one.** In
+every conflict of the 2026-08-01 run, both sides were correct about
+different things, because each branch was cut before the other landed.
+Taking one wholesale silently reverts a merged fix. Real examples: a
+capability-matrix paragraph that was right about kilo and stale about
+warp; a capability map where one side had `antigravity` and the other had
+`factory, qoder, openhands`; a count of MCP-capable targets that was
+wrong on both sides.
+
+Read the diff before merging, and check it against the evidence that
+justified it. Two fixes that run cleanly on their own branch can still be
+jointly wrong.
+
+A red CI run is a signal, not an obstacle. Read the failing log before
+concluding it is a flake, and check whether the same job fails on `main`.
+Re-run rather than merging on a theory. Note that `sync --check` drifts
+locally after any merge that changed a spec, because gitignored emitted
+copies are stale; that one is expected and `sync` fixes it.
+
+When querying check status, exclude pending jobs explicitly:
+`select(.conclusion != null and .conclusion != "SUCCESS")`. A pending job
+has a null conclusion and will otherwise read as a failure.
 
 ## What this skill does not do
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,46 +9,25 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Added
 
 - MCP servers propagate to three more targets: `factory` (`.factory/mcp.json`, including native `disabled` support), `qoder` (`.mcp.json`, the identical file and schema Claude Code already writes there, deduplicated when both are enabled), and `openhands` (`./config.toml` `[mcp]`, split into `stdio_servers`/`sse_servers`/`shttp_servers` arrays since OpenHands has no `type` field). MCP coverage is now 17 of 25 targets. `validate` and `sync --watch` also stop treating MCP specs as orphaned or unaffected on a `qoder`/`factory`/`openhands`-only project.
-
-### Fixed
-
-- Kilo Code MCP servers now write `"enabled": false` when a spec sets `disabled: true`; Kilo Code's own documented schema carries an `enabled` key and this adapter previously wrote no disable state at all, so a disabled spec produced a fully enabled server with no warning.
-
-### Added
-
 - `target-audit` skill plus a `target-auditor` agent: a repeatable, parallel audit of every registered adapter against its vendor's current docs, reporting evidence-backed drift (moved paths, new native surfaces, schema changes, deprecations) and optionally filing one issue per finding. Backed by `scripts/target-facts.sh`, which derives batches from the adapter registry and dumps a target's declared capabilities, default output paths, adapter package doc, and `docs/user/targets.md` rows in one call, and by a per-target list of vendor doc and changelog URLs that `tests/integration/target_audit_sources_test.go` keeps in sync with the registry.
 - `target-audit --fix` closes what it finds: after filing issues it spawns one `adapter-fixer` agent per fix bucket, each in its own git worktree, each opening a PR with the finding's evidence and `Closes #N`. Buckets by severity, not by tool: one PR per breaking finding, one batched PR for additive native surfaces, one docs PR for the rest. It never merges, so audit, fix, and merge stay three separate actors.
 - MCP servers accept `type: ws`. A WebSocket entry previously matched no transport branch and was written with no `command`, no `url`, and no `type`: a malformed server object emitted with no warning on both `.mcp.json` (Claude Code) and `.cursor/mcp.json`. It now shares the remote shape (`url`, `headers`, explicit `type`), which is what Claude Code and Qoder both document.
 - Seven new targets (#479): `qoder` (Alibaba Qoder: native `.qoder/rules/<name>.md`, one file per rule), `openhands` (All Hands OpenHands: the shared `.agents/skills/<name>/SKILL.md` tree), `factory` (Factory Droid: `.factory/droids/<name>.md` with `x-factory` passthrough), `kilo` (Kilo Code: `.kilo/agents/<name>.md` + `kilo.jsonc` `mcp`), `jules` (Google Jules, cloud: shared `AGENTS.md` only), `goose` (Block Goose: opt-in `.goosehints`), and `augment` (Augment Code: opt-in `.augment-guidelines`). All seven read the shared root `AGENTS.md` pointer. `qoder`, `openhands`, `factory`, and `kilo` join the default set (now 20 of 25); `jules`, `goose`, and `augment` stay opt-in; `kilo` brings MCP to 14 of 25 targets; `import qoder` captures its rules dir.
+- Antigravity MCP servers land in `.agents/mcp_config.json` under `mcpServers`. Remote entries use `serverUrl`: Antigravity's doc says the legacy `url` / `httpUrl` names are not supported, so the shared `mcpServers`-with-`url` builder does not apply here. stdio entries carry `command`, `args`, and `env`.
+- Augment gets three native surfaces it was missing entirely: one file per rule at `.augment/rules/<name>.md` (`type: agent_requested` with `alwaysApply: false`, otherwise the vendor default `always_apply` stays implicit), one file per agent at `.augment/agents/<name>.md`, and skills into the shared `.agents/skills/<name>/SKILL.md` tree. An agent's generic `tools` list is never Augment's own vocabulary, so it now surfaces a coverage note instead of silently restricting nothing; `x-augment.tools` / `x-augment.disabled_tools` reach Augment's real per-tool access control directly.
 
 ### Fixed
 
+- Kilo Code MCP servers now write `"enabled": false` when a spec sets `disabled: true`; Kilo Code's own documented schema carries an `enabled` key and this adapter previously wrote no disable state at all, so a disabled spec produced a fully enabled server with no warning.
 - Kilo Code MCP servers now write under the `mcp` key with `type: "local"`/`"remote"`, one combined `command` array, and `environment` in place of `env`; the previous `mcpServers` shape was never read by Kilo Code. Agent frontmatter drops `name` (Kilo Code takes it from the filename) and `tools` (Kilo Code has no such key); a spec's `tools` allowlist now surfaces a coverage note instead of looking like it restricted the agent.
-
-### Fixed
-
 - `docs/user/targets.md` drops Warp from the MCP `type`-field list (Warp's schema has no such key), adds the `SessionEnd` Codex hook event the emitter already sends, marks Gemini's hook list as a non-exhaustive example instead of all 11 events, and confirms the Amp `.agents/commands/` path is no longer read now that command removal has held since 2026-01-29.
 - Refreshed ten stale vendor doc URLs in the target-audit skill's `references/sources.md`: Codex's six doc pages moved to `learn.chatgpt.com` (one, `/rules`, pointed at the wrong topic), Kilo moved to `kilo.ai`, and Claude, Gemini, Antigravity, Junie, Cline, Continue, and Cursor each get a corrected or added entry. Trae joins the client-rendered-docs warning list.
-
-### Fixed
-
 - Codex exec-policy `decision` now accepts `allow`, `forbidden`, `prompt`; `ask` was never a valid Codex CLI literal and rendered a rule Codex silently ignored, and the vendor-correct `prompt` used to fail validation.
 - `outputs.claude.settings.enabledPlugins` is now a map of `plugin-id@marketplace-id` to boolean, matching Claude Code's own settings schema; the previous list-of-strings shape could not express the required marketplace qualifier and never actually enabled a plugin.
 - MCP `disabled: true` now maps to Codex's real `enabled = false` key instead of a `disabled` key Codex never reads. Claude Code, Cursor, and Copilot have no file-based way to pre-disable a project-scoped MCP server at all, so agnostic-ai stops writing the field for them and reports a coverage note instead of silently doing nothing.
-
-### Fixed
-
 - Cline and Windsurf skills emit as a folder per skill (`.cline/skills/<name>/SKILL.md`, `.agents/skills/<name>/SKILL.md`, the latter shared with Codex, Amp, Zed, Crush, and OpenHands) instead of a flat `skill-<name>.md` file that neither tool ever loaded as a skill. `import cline` and `import windsurf` reconstruct skills from the new folder tree, and still read the old flat form for projects synced before this fix.
-
-### Added
-
-- Antigravity MCP servers land in `.agents/mcp_config.json` under `mcpServers`. Remote entries use `serverUrl`: Antigravity's doc says the legacy `url` / `httpUrl` names are not supported, so the shared `mcpServers`-with-`url` builder does not apply here. stdio entries carry `command`, `args`, and `env`.
-
-- Augment gets three native surfaces it was missing entirely: one file per rule at `.augment/rules/<name>.md` (`type: agent_requested` with `alwaysApply: false`, otherwise the vendor default `always_apply` stays implicit), one file per agent at `.augment/agents/<name>.md`, and skills into the shared `.agents/skills/<name>/SKILL.md` tree. An agent's generic `tools` list is never Augment's own vocabulary, so it now surfaces a coverage note instead of silently restricting nothing; `x-augment.tools` / `x-augment.disabled_tools` reach Augment's real per-tool access control directly.
-### Fixed
-
 - Antigravity rules and skills now default to `.agents/rules` / `.agents/skills`, the plural paths Antigravity itself now prefers. The old `.agent/rules` / `.agent/skills` singular form still reads for backward compatibility, but a stale managed copy there is swept on sync, and `.agents/skills` is also the tree Codex, Amp, Zed, Crush, and OpenHands already write, so skills dedupe there too. `import antigravity` reads whichever path exists, preferring the plural form.
-
+- The `targetsSupportingKind` map in `internal/cli` is now enforced against what each adapter declares, so a target that gains a capability can no longer be omitted from it. That map drives the orphan-kind validator and incremental `sync --watch`; when it drifted, users were told their specs were dead weight and the affected targets were skipped on re-sync. It had drifted for `antigravity` (skills), `factory`/`qoder`/`openhands` (MCP), and `augment` (agents and skills). All four are corrected.
 ## v0.44.0 - 2026-07-24
 
 ### Added

--- a/internal/cli/native_capabilities.go
+++ b/internal/cli/native_capabilities.go
@@ -75,8 +75,8 @@ var matcherAcceptingEvents = setOf(
 // validator: if a project has hook specs but no enabled target maps
 // to a hook surface, the specs are dead weight.
 var targetsSupportingKind = map[spec.Kind]map[string]struct{}{
-	spec.KindAgent:       setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity", "junie", "kiro", "trae", "factory", "kilo"),
-	spec.KindSkill:       setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity", "junie", "kiro", "crush", "trae", "openhands"),
+	spec.KindAgent:       setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity", "junie", "kiro", "trae", "augment", "factory", "kilo"),
+	spec.KindSkill:       setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity", "junie", "kiro", "crush", "trae", "augment", "openhands"),
 	spec.KindRule:        setOf("claude", "codex", "gemini", "cursor", "copilot", "aider", "cline", "windsurf", "continue", "amp", "zed", "warp", "opencode", "antigravity", "junie", "kiro", "crush", "trae", "jules", "goose", "augment", "qoder", "openhands", "factory", "kilo"),
 	spec.KindHook:        setOf("claude", "codex", "gemini", "cursor", "zed"),
 	spec.KindMCP:         setOf("claude", "codex", "gemini", "cursor", "copilot", "continue", "amp", "zed", "warp", "opencode", "antigravity", "junie", "kiro", "crush", "kilo", "factory", "qoder", "openhands"),

--- a/internal/cli/native_capabilities_parity_test.go
+++ b/internal/cli/native_capabilities_parity_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/errs"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// declaresSupport reports whether the named target's adapter accepts the
+// given kind, determined by behavior rather than by reading the adapter's
+// unexported caps value: emit a bundle holding only that kind with
+// `on-unsupported: error` and see whether the run rejects it.
+//
+// Any other error means the adapter accepted the kind and then failed for
+// an unrelated reason (missing config, unwritable path), which still
+// counts as "declares support".
+func declaresSupport(t *testing.T, target string, kind spec.Kind) bool {
+	t.Helper()
+	testutil.TempCwd(t)
+
+	a, err := adapters.Resolve(target)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", target, err)
+	}
+	b := spec.NewBundle([]spec.Entry{sampleEntryForKind(kind)})
+	cfg := &config.Config{OnUnsupported: "error"}
+
+	adapters.ResetCapabilityWarnings()
+	t.Cleanup(adapters.ResetCapabilityWarnings)
+
+	err = adapters.EmitWithProvenance(adapters.NewSession(), a, b, cfg, true)
+	return errs.CodeOf(err) != errs.CodeUnsupportedKind
+}
+
+// sampleEntryForKind builds the minimal spec entry an adapter needs to
+// route the kind far enough to accept or reject it.
+func sampleEntryForKind(kind spec.Kind) spec.Entry {
+	e := spec.Entry{Kind: kind, Name: "probe", Body: "probe body"}
+	switch kind {
+	case spec.KindSkill:
+		e.Path = "skills/probe/SKILL.md"
+	case spec.KindHook:
+		e.Meta = map[string]any{"event": "PostToolUse", "command": "true"}
+	case spec.KindMCP:
+		e.Meta = map[string]any{"command": "probe-server"}
+	case spec.KindCommand:
+		e.Path = "commands/probe.md"
+	}
+	return e
+}
+
+// TestNativeCapabilities_MatchDeclaredAdapterSupport enforces that the
+// hand-maintained targetsSupportingKind map stays in step with what the
+// adapters declare.
+//
+// The map drives two user-visible behaviors: the orphan-kind validator
+// (specs of a kind no enabled target supports are reported as dead
+// weight) and incremental `sync --watch` (a spec edit only re-syncs the
+// targets mapped to its kind). Nothing enforced the relationship, so
+// every adapter that gained a capability had to remember to update a
+// second list in another package.
+//
+// It drifted three separate times during the 2026-08-01 target audit:
+// antigravity was missing for skills, factory/qoder/openhands for MCP,
+// and augment for agents and skills. Each one silently told users their
+// specs were dead weight and skipped those targets on watch re-sync.
+func TestNativeCapabilities_MatchDeclaredAdapterSupport(t *testing.T) {
+	for _, target := range adapters.Names() {
+		for _, kind := range spec.AllKinds {
+			if !declaresSupport(t, target, kind) {
+				continue
+			}
+			if _, ok := targetsSupportingKind[kind][target]; !ok {
+				t.Errorf("adapter %q declares support for %q but targetsSupportingKind[%q] omits it; "+
+					"add it there or the orphan-kind validator will call those specs dead weight "+
+					"and sync --watch will skip the target", target, kind, kind)
+			}
+		}
+	}
+}
+
+// TestNativeCapabilities_NameOnlyRegisteredTargets catches the reverse
+// drift: an entry left behind after a target is renamed or dropped, which
+// would keep the validator quiet about a kind nothing emits.
+func TestNativeCapabilities_NameOnlyRegisteredTargets(t *testing.T) {
+	registered := make(map[string]bool, len(adapters.Names()))
+	for _, name := range adapters.Names() {
+		registered[name] = true
+	}
+	for kind, targets := range targetsSupportingKind {
+		for target := range targets {
+			if !registered[target] {
+				t.Errorf("targetsSupportingKind[%q] lists %q, which is not a registered target", kind, target)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 🤔 Background

`targetsSupportingKind` in `internal/cli/native_capabilities.go` is a hand-maintained mirror of every adapter's `caps.Supports`. Nothing kept the two in step.

It drives two user-visible behaviors:

- the **orphan-kind validator** — specs of a kind no enabled target supports are reported as dead weight
- **incremental `sync --watch`** — a spec edit only re-syncs the targets mapped to its kind

So when it drifts, a user is told their specs are useless and the affected targets silently stop re-syncing.

During the 2026-08-01 target audit it drifted **three separate times**, each found by accident from a different direction:

| Missing | Found while |
|---|---|
| `antigravity` → skills | reviewing the antigravity PR |
| `factory`, `qoder`, `openhands` → MCP | a fixer declared `KindMCP` and noticed |
| `augment` → agents, skills | this PR's new test, on first run |

Three discoveries of one root cause is the argument for an invariant rather than a fourth patch.

## 💡 Goal

Make it impossible for an adapter to gain a capability and be omitted from the map.

## 🔖 Changes

**`internal/cli/native_capabilities_parity_test.go`** — asserts every kind an adapter declares appears in the map, plus the reverse (no entry for an unregistered target).

Support is derived **behaviorally**, not by reading the adapters' unexported `caps`: emit a single-kind bundle with `on-unsupported: error` and check for `errs.CodeUnsupportedKind`. Any other error means the kind was accepted and something unrelated failed, which still counts as support. No new exported surface on the adapters, no source parsing.

It found the `augment` gap on first run — a PR merged an hour earlier.

**`internal/cli/native_capabilities.go`** — adds `augment` to `KindAgent` and `KindSkill`.

**Skill and agent hardening**, from what this audit run cost:

- Phase 6: settle every bucket before spawning. A fixer can't be handed new work mid-flight; it can't distinguish an orchestrator message from any other on the same channel, and refusing is the safer default.
- New Phase 7 on landing PRs: **on a shared-doc conflict, merge both sides, never pick one.** In every conflict this run, both sides were correct about different things because each branch was cut before the other landed. Picking one silently reverts a merged fix.
- Auditor: four ways past a client-rendered vendor doc (`llms.txt`, `.md` suffix, docs source repo, the SPA's own `/api/` route). Both kilo breaking findings and the qoder schema were proven this way after `curl` returned empty bodies.
- Auditor: never generalize one target's answer to another. The `disabled` question produced three answers across six targets under two key names, and two attempts at a general rule were both wrong.
- Auditor: treat a handed-down lead as a question. One lead this run asserted a config key that was actually the deprecated form; the agent caught it.

**`CHANGELOG.md`** — seven sequential merges fragmented `[Unreleased]` into three `### Added` and five `### Fixed` headings. Collapsed to one section per type.

## Verification

- New test confirmed red against the pre-fix map, green after
- `make preflight` ok, `agnostic-ai sync --check` exit 0