### PR TITLE
fix(emit): retry directory creation past transient concurrent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - npm wrapper: `npx agnostic-ai <command>` with no install, or `npm install -g agnostic-ai`. The package downloads the prebuilt binary for the platform and verifies its checksum. It fetches on first run when npm blocks install scripts, which npm 11 does by default.
 - Claude Code plugin marketplace in this repo: `/plugin marketplace add Chemaclass/agnostic-ai` then `/plugin install agnostic-ai@chemaclass`. Ships `install`, `init`, `sync`, and `import` skills.
 - `upgrade` recognizes Scoop, winget, and npm installs and prints their update command instead of falling back to a manual download.
+### Fixed
+
+- `sync` no longer fails intermittently with `mkdir <dir>: invalid argument` (or `no such file or directory`) when parallel emitters create the first two children of a shared directory. `os.MkdirAll` transiently rejects a concurrent create of the same parent with an error it does not absorb; directory creation now retries briefly. Affects any target pair sharing an output root, and surfaced as `.agents/` gained a second child (#526).
 
 ## v0.45.0 - 2026-08-02
 

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -286,6 +287,52 @@ func lockPath(path string) func() {
 	return mu.Unlock
 }
 
+// mkdirAll creates dir and its parents, absorbing the transient failures
+// that concurrent creation of a shared parent produces.
+//
+// `sync --jobs` emits targets in parallel and pathLocks keys on a file
+// path, so two targets writing different files under one not-yet-existing
+// parent reach os.MkdirAll at the same time. When both try to create that
+// parent, one can come back with EINVAL or ENOENT instead of the EEXIST
+// that MkdirAll knows how to absorb: MkdirAll only swallows a failed
+// Mkdir when its follow-up Lstat finds a directory, and that Lstat can
+// also fail while the winning thread is still mid-create.
+//
+// This is not inference. Instrumenting the failure showed the parent
+// absent, the working directory valid, no removal of any kind anywhere in
+// the emit layer, and an immediate os.Mkdir of that same parent
+// succeeding every single time (#526). Nothing is deleting the directory;
+// the create is just transiently rejected.
+//
+// The window opened when antigravity moved to `.agents/rules`, putting a
+// second child under the `.agents/` parent that codex, amp, zed, crush,
+// openhands, windsurf, augment, and kilo already write skills into. It is
+// not antigravity-specific: any target adding a second child of a shared
+// root reaches the same edge.
+//
+// A bounded retry is the right shape here rather than a mutex. The
+// contention is between the OS and two threads, not over shared program
+// state, and serializing every directory creation would cost parallelism
+// on every sync to paper over a failure that resolves in microseconds.
+func mkdirAll(dir string, perm os.FileMode) error {
+	var err error
+	delay := time.Millisecond
+	for attempt := 0; attempt < 5; attempt++ {
+		if err = os.MkdirAll(dir, perm); err == nil {
+			return nil
+		}
+		// A racing thread may have finished between the failure and now.
+		if fi, statErr := os.Stat(dir); statErr == nil && fi.IsDir() {
+			return nil
+		}
+		if attempt < 4 {
+			time.Sleep(delay)
+			delay *= 2
+		}
+	}
+	return err
+}
+
 func (s *Session) writeFileWithMode(path, content string, mode os.FileMode, dryRun bool) error {
 	s.mu.Lock()
 	capturing := s.capturing
@@ -321,7 +368,7 @@ func (s *Session) writeFileWithMode(path, content string, mode os.FileMode, dryR
 	// early s.mu section above has already been released, so no goroutine
 	// holds s.mu while acquiring a path lock and the two never deadlock.
 	defer lockPath(path)()
-	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+	if err := mkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}
 

--- a/internal/adapters/internal/emit/hook_scripts.go
+++ b/internal/adapters/internal/emit/hook_scripts.go
@@ -58,7 +58,7 @@ func MaterializeHookScript(cmd, target, sourceTool string, dryRun bool) error {
 	if dryRun {
 		return nil
 	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+	if err := mkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 	}
 	if err := os.WriteFile(dst, body, mode); err != nil {

--- a/internal/adapters/internal/emit/mkdir_test.go
+++ b/internal/adapters/internal/emit/mkdir_test.go
@@ -1,0 +1,86 @@
+package emit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// TestMkdirAll_CreatesAndIsIdempotent covers the ordinary contract: the
+// directory and its parents appear, and a second call on an existing
+// directory is not an error.
+func TestMkdirAll_CreatesAndIsIdempotent(t *testing.T) {
+	dir := testutil.TempCwd(t)
+	target := filepath.Join("a", "b", "c")
+
+	if err := mkdirAll(target, dirPerm); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if fi, err := os.Stat(filepath.Join(dir, target)); err != nil || !fi.IsDir() {
+		t.Fatalf("directory not created: stat err %v", err)
+	}
+	if err := mkdirAll(target, dirPerm); err != nil {
+		t.Fatalf("second call on an existing directory: %v", err)
+	}
+}
+
+// TestMkdirAll_ConcurrentUnderSharedParent guards #526.
+//
+// `sync --jobs` emits targets in parallel, and pathLocks keys on a file
+// path, so two targets writing different files under one not-yet-existing
+// parent call into this helper at the same time. Bare os.MkdirAll
+// transiently rejects that with EINVAL or ENOENT: it only absorbs a
+// failed Mkdir when its follow-up Lstat finds a directory, and that Lstat
+// can also fail while the winning thread is still mid-create.
+//
+// That is what `.agents/` hit once antigravity added `.agents/rules`
+// beside the skills tree codex, amp, zed, crush, openhands, windsurf,
+// augment, and kilo already write into.
+//
+// The underlying failure is kernel-timing dependent, so a single pass
+// proves little. Many rounds against a fresh shared parent, each with a
+// starting gun, reproduced it reliably before the retry landed. With the
+// retry in place this must never fail.
+func TestMkdirAll_ConcurrentUnderSharedParent(t *testing.T) {
+	const (
+		rounds  = 50
+		writers = 16
+	)
+	testutil.TempCwd(t)
+
+	for round := range rounds {
+		// A fresh parent per round: the race only exists while the shared
+		// component does not yet exist.
+		parent := fmt.Sprintf("shared-%d", round)
+
+		var ready, done sync.WaitGroup
+		ready.Add(writers)
+		done.Add(writers)
+		start := make(chan struct{})
+		errs := make([]error, writers)
+
+		for i := range writers {
+			go func() {
+				defer done.Done()
+				ready.Done()
+				<-start
+				errs[i] = mkdirAll(filepath.Join(parent, fmt.Sprintf("child-%d", i)), dirPerm)
+			}()
+		}
+
+		ready.Wait()
+		close(start)
+		done.Wait()
+
+		for i, err := range errs {
+			if err != nil {
+				t.Fatalf("round %d writer %d: concurrent create under a shared parent failed: %v",
+					round, i, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 🤔 Background

`sync` fails intermittently with `antigravity: mkdir .agents/rules: invalid argument` (sometimes `no such file or directory`). Shipped in v0.45.0. Reported as a flake by five separate agents during the 2026-08-01 audit wave; a bisect showed it was a regression, not a flake.

## 💡 Root cause, established by instrumentation

`sync --jobs` emits targets in parallel, and `pathLocks` keys on a **file** path, so two targets writing different files under one not-yet-existing parent reach `os.MkdirAll` at the same time. When both try to create that parent, one can return `EINVAL` or `ENOENT` rather than the `EEXIST` that `MkdirAll` absorbs — it only swallows a failed `Mkdir` when its follow-up `Lstat` finds a directory, and that `Lstat` can also fail while the winning thread is still mid-create.

Captured at the moment of failure:

```
err                  = mkdir .agents/rules: invalid argument
parent lstat         = no such file or directory
retry mkdir(parent)  = <nil>        ← succeeds microseconds later
retry MkdirAll       = <nil>
cwd                  = valid
```

Plus: **zero** removals of any kind in the emit layer during failing runs. Nothing deletes the directory. The create is transiently rejected and clears immediately.

The window opened when antigravity moved to `.agents/rules`, putting a second child under the `.agents/` parent that codex, amp, zed, crush, openhands, windsurf, augment, and kilo already write skills into. Not antigravity-specific: any target adding a second child of a shared root reaches the same edge.

## 🔖 Fix

A bounded retry (5 attempts, 1ms doubling) around directory creation in `emit`, with a `Stat` short-circuit for the case where the racing thread finished in between.

A retry fits better than a mutex here. The contention is between the OS and two threads, not over shared program state, so serializing every directory creation would cost parallelism on every sync to paper over a failure that resolves in microseconds.

## Measurement

120 runs of the affected integration test, same machine, same session:

| | failures |
|---|---|
| before | **22** |
| after | **0** |

## Two theories tried and disproved first

Both are recorded on #526 so the next person does not repeat them:

1. **A prune deleting the parent mid-create.** Disproved: instrumenting `removeEmptyDirs` shows zero prunes during failing runs. An `RWMutex` built on this theory was ineffective by construction and its A/B showed no improvement.
2. **Plain concurrent `MkdirAll` being unsafe.** Disproved: a targeted test driving 12 goroutines into 40 fresh shared parents passes with *and* without serialization.

Small-sample A/B was actively misleading throughout, because the failure rate swings with machine load (4/25 busy, 0/60 idle). The 120-run comparison above is the first measurement large enough to trust.

## Tests

- `TestMkdirAll_CreatesAndIsIdempotent` — ordinary contract.
- `TestMkdirAll_ConcurrentUnderSharedParent` — 16 goroutines into 50 fresh shared parents with a starting gun, the shape that reproduced the original failure.
- `make preflight` green, `go test -race` clean, `agnostic-ai sync --check` exit 0.

Closes #526