### PR TITLE
fix(import): read every documented zed context_servers shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Fixed
 
 - The release workflow now skips optional npm publishing when `NPM_TOKEN` is absent instead of attempting to publish with `setup-node`'s placeholder credential.
+- `import zed` no longer drops MCP servers from a `.zed/settings.json` that agnostic-ai itself emitted. The reader accepted only a nested `command: {path, args, env}` object, while Zed documents (and the zed adapter writes) `command` as a plain string with `args` and `env` beside it; remote `url` servers were skipped outright for having no `command` key. All three shapes now import (#546).
 
 ## v0.46.0 - 2026-08-07
 
@@ -19,6 +20,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - npm wrapper: `npx agnostic-ai <command>` with no install, or `npm install -g agnostic-ai`. The package downloads the prebuilt binary for the platform and verifies its checksum. It fetches on first run when npm blocks install scripts, which npm 11 does by default.
 - Claude Code plugin marketplace in this repo: `/plugin marketplace add Chemaclass/agnostic-ai` then `/plugin install agnostic-ai@chemaclass`. Ships `install`, `init`, `sync`, and `import` skills.
 - `upgrade` recognizes Scoop, winget, and npm installs and prints their update command instead of falling back to a manual download.
+
 ### Fixed
 
 - `sync` no longer fails intermittently with `mkdir <dir>: invalid argument` (or `no such file or directory`) when parallel emitters create the first two children of a shared directory. `os.MkdirAll` transiently rejects a concurrent create of the same parent with an error it does not absorb; directory creation now retries briefly. Affects any target pair sharing an output root, and surfaced as `.agents/` gained a second child (#526).

--- a/internal/cli/import_zed.go
+++ b/internal/cli/import_zed.go
@@ -149,8 +149,18 @@ func toStringSlice(v any) []string {
 }
 
 // importZedContextServers reads `.zed/settings.json` and writes one
-// yaml per `context_servers` entry. Each server has a nested `command:
-// {path, args, env}` block which we flatten to `command`/`args`/`env`.
+// yaml per `context_servers` entry.
+//
+// Zed documents two server shapes (zed.dev/docs/ai/mcp). A stdio server
+// is `command` as a plain string with `args` and `env` as siblings; a
+// remote server is `url` with optional `headers`. Both map straight onto
+// the cross-tool MCP spec fields.
+//
+// A nested `command: {path, args, env}` object is also accepted. That is
+// the only shape this importer used to read, which meant importing a
+// `.zed/settings.json` that agnostic-ai itself emitted dropped every
+// stdio server, and remote servers were skipped outright for having no
+// `command` key at all (#546).
 func importZedContextServers(root, dstDir string) (int, error) {
 	src := filepath.Join(root, zedSettings)
 	data, err := os.ReadFile(src)
@@ -175,7 +185,20 @@ func importZedContextServers(root, dstDir string) (int, error) {
 			continue
 		}
 		out := map[string]any{}
-		if cmd, ok := entry["command"].(map[string]any); ok {
+		switch cmd := entry["command"].(type) {
+		case string:
+			// Documented stdio shape: args and env sit beside command.
+			if cmd != "" {
+				out["command"] = cmd
+			}
+			if args := toStringSlice(entry["args"]); len(args) > 0 {
+				out["args"] = args
+			}
+			if env, ok := entry["env"].(map[string]any); ok && len(env) > 0 {
+				out["env"] = env
+			}
+		case map[string]any:
+			// Legacy nested shape: args and env live inside command.
 			if p, ok := cmd["path"].(string); ok && p != "" {
 				out["command"] = p
 			}
@@ -187,7 +210,15 @@ func importZedContextServers(root, dstDir string) (int, error) {
 			}
 		}
 		if _, hasCmd := out["command"]; !hasCmd {
-			continue
+			// Remote shape: url plus optional headers, no command at all.
+			if u, ok := entry["url"].(string); ok && u != "" {
+				out["url"] = u
+				if h, ok := entry["headers"].(map[string]any); ok && len(h) > 0 {
+					out["headers"] = h
+				}
+			} else {
+				continue
+			}
 		}
 		flat[name] = out
 	}

--- a/internal/cli/import_zed_test.go
+++ b/internal/cli/import_zed_test.go
@@ -117,3 +117,57 @@ func TestImportFromZed_ImportsContextServers(t *testing.T) {
 		}
 	}
 }
+
+// TestImportFromZed_ImportsFlatStdioContextServer covers the shape Zed
+// documents and the shape this repo's own zed adapter emits: `command`
+// as a plain string with `args` and `env` as siblings.
+//
+// The importer previously accepted only a nested `command: {path, args,
+// env}` object, so importing a `.zed/settings.json` that agnostic-ai had
+// just written silently dropped every stdio server (#546).
+func TestImportFromZed_ImportsFlatStdioContextServer(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "context_servers": {
+    "fs": {"command": "fs-server", "args": ["--root", "."], "env": {"TOKEN": "x"}}
+  }
+}`
+	writeFile(t, filepath.Join(dir, zedSettings), settings)
+	if err := importFromZed(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "mcps", "fs.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/fs.yaml: %v", err)
+	}
+	for _, want := range []string{"command: fs-server", "args:", "--root", "TOKEN"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("expected %q in mcp file: %s", want, got)
+		}
+	}
+}
+
+// TestImportFromZed_ImportsRemoteContextServer covers Zed's remote shape
+// (`url` plus optional `headers`). The importer required a `command` key
+// and skipped anything without one, so remote servers were dropped too.
+func TestImportFromZed_ImportsRemoteContextServer(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+  "context_servers": {
+    "remote": {"url": "https://example.test/mcp", "headers": {"Authorization": "Bearer t"}}
+  }
+}`
+	writeFile(t, filepath.Join(dir, zedSettings), settings)
+	if err := importFromZed(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "mcps", "remote.yaml"))
+	if err != nil {
+		t.Fatalf("missing mcps/remote.yaml: %v", err)
+	}
+	for _, want := range []string{"https://example.test/mcp", "Authorization"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("expected %q in mcp file: %s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## 🤔 Background

`importZedContextServers` accepted only a nested `command: {path, args, env}` object.

Zed documents a stdio server as `command` as a **plain string**, with `args` and `env` as siblings ([zed.dev/docs/ai/mcp](https://zed.dev/docs/ai/mcp)):

```json
{"context_servers": {"local-mcp-server": {"command": "some-command", "args": ["arg-1"], "env": {}}}}
```

That is also exactly what this repo's own zed adapter emits (`zed.go:172` reads `e.Meta["command"].(string)`). So `sync` then `import zed` recovered nothing.

Remote servers were lost too: the reader required a `command` key and `continue`d past any entry without one, so the documented `url` / `headers` shape never survived either. The issue only described the stdio half.

## Measurement

Real emit-then-import cycle, one stdio and one remote server:

| | specs recovered |
|---|---|
| before | **0 of 2** |
| after | **2 of 2** |

Re-syncing after the import is byte-identical, so the round trip is whole.

## 🔖 Fix

`command` is now read as either a plain string (documented) or a nested object (legacy), and an entry with no `command` falls through to the remote `url` / `headers` shape instead of being skipped.

The nested form still imports, so any project carrying it keeps working.

## Why this survived

`TestImportFromZed_ImportsContextServers` used the nested shape exclusively. The test encoded the reader's assumption rather than checking it against what the adapter writes, so it passed while the round trip was broken. Both documented shapes are now covered, and both new tests were confirmed red first.

## Verification

- `make preflight` green, `agnostic-ai sync --check` exit 0
- new tests red before the change, green after
- end-to-end round trip verified with the built binary

Closes #546