### PR TITLE
fix(import): read commandWindows back from codex hooks.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - Claude Code plugin marketplace in this repo: `/plugin marketplace add Chemaclass/agnostic-ai` then `/plugin install agnostic-ai@chemaclass`. Ships `install`, `init`, `sync`, and `import` skills.
 - `upgrade` recognizes Scoop, winget, and npm installs and prints their update command instead of falling back to a manual download.
 
+### Fixed
+
+- `import codex` reads `commandWindows` back from `.codex/hooks.json`. The codex emitter writes the field but the importer never captured it, so a sync then import cycle silently dropped a hook's Windows command override (#547).
+
 ## v0.45.0 - 2026-08-02
 
 ### Added

--- a/internal/adapters/claudehooks/claudehooks.go
+++ b/internal/adapters/claudehooks/claudehooks.go
@@ -34,6 +34,10 @@ type CommandEntry struct {
 	If                     string `json:"if,omitempty"`
 	Once                   bool   `json:"once,omitempty"`
 	AdditionalContextLimit int    `json:"additionalContextLimit,omitempty"`
+	// CommandWindows is Codex-only, like AdditionalContextLimit above: a
+	// Windows-specific command override. Captured here for the same
+	// round-trip reason, and likewise never set by claude's own emit.
+	CommandWindows string `json:"commandWindows,omitempty"`
 }
 
 // Group mirrors one `{matcher, hooks}` object in a settings.json hook

--- a/internal/cli/import_codex_native.go
+++ b/internal/cli/import_codex_native.go
@@ -627,6 +627,9 @@ type codexHookEntry struct {
 	// name (see codexHookSlot / mergeCodexHooksJSON); captured here too
 	// so a hand-authored `[[hooks.<event>]]` TOML block round-trips it.
 	AdditionalContextLimit int `toml:"additionalContextLimit"`
+	// CommandWindows mirrors the hooks.json field of the same name, for
+	// the same reason as AdditionalContextLimit above.
+	CommandWindows string `toml:"commandWindows"`
 }
 
 type codexMCPEntry struct {
@@ -775,6 +778,7 @@ func mergeCodexHooksJSON(root string, hooks map[codexHookKey]*codexHookSlot) err
 					Timeout:                h.Timeout,
 					StatusMessage:          h.StatusMessage,
 					AdditionalContextLimit: h.AdditionalContextLimit,
+					CommandWindows:         h.CommandWindows,
 				}
 				if !exists {
 					hooks[k] = &codexHookSlot{
@@ -829,6 +833,9 @@ func writeCodexHooksFromMap(hooks map[codexHookKey]*codexHookSlot, dstDir string
 		}
 		if h.AdditionalContextLimit != 0 {
 			doc["additionalContextLimit"] = h.AdditionalContextLimit
+		}
+		if h.CommandWindows != "" {
+			doc["commandWindows"] = h.CommandWindows
 		}
 		raw, err := yaml.Marshal(doc)
 		if err != nil {

--- a/internal/cli/import_codex_test.go
+++ b/internal/cli/import_codex_test.go
@@ -1194,3 +1194,32 @@ func names(entries []os.DirEntry) []string {
 	}
 	return out
 }
+
+// Round-trip for #547: commandWindows must survive an import so a
+// sync -> import -> sync cycle does not silently drop the field the
+// previous sync just wrote to .codex/hooks.json. Same shape as the
+// additionalContextLimit round-trip above; the codex emitter writes
+// both, and only this one was never read back.
+func TestImportFromCodex_HookCommandWindowsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".codex/hooks.json"), `{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {"type": "command", "command": "lint.sh", "commandWindows": "lint.ps1"}
+        ]
+      }
+    ]
+  }
+}`)
+	if err := importFromCodex(dir, rootSources()); err != nil {
+		t.Fatal(err)
+	}
+	post := findOneHookFile(t, filepath.Join(dir, "hooks"), "posttooluse")
+	data, _ := os.ReadFile(post)
+	if !strings.Contains(string(data), "commandWindows: lint.ps1") {
+		t.Errorf("expected commandWindows in spec:\n%s", data)
+	}
+}


### PR DESCRIPTION
## 🤔 Background

The codex emitter writes a hook's `commandWindows` override into `.codex/hooks.json` (`hooks_json.go:92`), but no importer struct carried the field. A `sync` then `import codex` cycle dropped it, and the next `sync` emitted a hook with no Windows command.

Pre-existing; found during the 2026-08-01 audit fix wave while checking an adjacent bucket.

## 🔖 Fix

Wired through the same four places `additionalContextLimit` already travels:

1. `claudehooks.CommandEntry` — the shared JSON struct. Codex-only, like `AdditionalContextLimit` beside it, and documented as such per that package's existing round-trip rule.
2. `codexHookEntry` — the TOML struct, so a hand-authored `[[hooks.<event>]]` block round-trips it too.
3. The `hooks.json`-over-`config.toml` merge.
4. The spec writer.

## Measurement

Real emit-then-import cycle with a hook carrying `commandWindows: lint.ps1`:

| | field in recovered spec |
|---|---|
| before | **absent** |
| after | **present** |

Re-syncing after the import is byte-identical.

## Why this survived

Same shape as #546: the round-trip tests covered the fields someone thought to check. `additionalContextLimit` got a dedicated round-trip test when it was added (#533); `commandWindows` predates that habit and never got one. It has one now, confirmed red before the change.

## Verification

- `make preflight` green, `agnostic-ai sync --check` exit 0, `go test -race` clean
- new test red before, green after
- end-to-end round trip verified with the built binary

Closes #547