### PR TITLE
docs(skills): record what running target-audit taught

### DIFF
--- a/.agnostic-ai/agents/target-auditor.md
+++ b/.agnostic-ai/agents/target-auditor.md
@@ -66,6 +66,27 @@ The prompt names your targets. Everything else you fetch yourself:
    the path was undocumented. If a fetch succeeds but the content does
    not match the topic, treat that as a `docs-moved` finding rather than
    as an absent surface.
+
+   Last resort, and it works when every step above fails: many docs
+   sites ship their CMS-authored content **server-side** inside a
+   `<script>` payload such as `window._ROUTER_DATA`,
+   `window.__NEXT_DATA__`, or `__INITIAL_STATE__`. WebFetch truncates
+   these because they run to megabytes, so the page reads as empty even
+   though the full text is right there in the response.
+
+   Trae's MCP schema was settled this way after `.md`, `llms.txt`, a
+   docs repo, and the SPA's own API had all dead-ended. Fetch the page
+   to disk with `curl`, locate the payload, and parse it. In Trae's case
+   the body was a Quill-style delta where every token of every code
+   example is its own tagged run, so the reconstruction is exact rather
+   than approximate.
+
+   When a corpus of real config files is the only evidence available,
+   separate files the vendor's own tool produced from files another tool
+   wrote into the same folder. A Trae MCP file carrying `autoApprove`
+   and Cline-shaped tool names at the wrong path is evidence about
+   Cline. Averaging a contaminated corpus produces a schema no vendor
+   actually accepts.
 4. Compare, in this order (highest value first):
    - **Path drift**: does the tool still read the exact path we write? A
      moved skills, rules, or agents dir silently breaks every user. Check

--- a/.agnostic-ai/agents/target-auditor.md
+++ b/.agnostic-ai/agents/target-auditor.md
@@ -45,6 +45,27 @@ The prompt names your targets. Everything else you fetch yourself:
       is client-side.
 
    Only after all four fail is `unconfirmed` the honest answer.
+
+   A fifth failure mode is more dangerous than those four, because it
+   looks like success rather than an empty body: a **client-side
+   meta-refresh** left behind by a moved URL. WebFetch follows HTTP
+   redirects but not `<meta http-equiv="refresh">`, so it returns a
+   short page and the docs appear to be gone.
+
+   Kiro cost a full week to this. Its configuration reference moved and
+   left a 595-byte stub at the old URL; two audits read that stub and
+   shipped a coverage note claiming the tool vocabulary was
+   "unconfirmed" when it had been fully documented the whole time.
+
+   Detection: a suspiciously short body containing `http-equiv="refresh"`.
+   Remedy: read the `url=` target out of the tag and fetch that instead.
+   `curl -s <url> | head -c 400` shows it immediately.
+
+   A moved URL can also land on something unrelated. Trae's MCP page now
+   302s to a marketing page, which is why two consecutive runs concluded
+   the path was undocumented. If a fetch succeeds but the content does
+   not match the topic, treat that as a `docs-moved` finding rather than
+   as an absent surface.
 4. Compare, in this order (highest value first):
    - **Path drift**: does the tool still read the exact path we write? A
      moved skills, rules, or agents dir silently breaks every user. Check

--- a/.agnostic-ai/skills/target-audit/SKILL.md
+++ b/.agnostic-ai/skills/target-audit/SKILL.md
@@ -202,9 +202,35 @@ Re-run rather than merging on a theory. Note that `sync --check` drifts
 locally after any merge that changed a spec, because gitignored emitted
 copies are stale; that one is expected and `sync` fixes it.
 
-When querying check status, exclude pending jobs explicitly:
-`select(.conclusion != null and .conclusion != "SUCCESS")`. A pending job
-has a null conclusion and will otherwise read as a failure.
+When querying check status, prefer `gh pr checks <n>` over
+`statusCheckRollup`. The rollup serves stale conclusions: it reported
+five failures on a docs-only change whose jobs had all passed, and it
+reports closed issues as open for minutes after a merge. If you do use
+the rollup, exclude pending jobs explicitly with
+`select(.conclusion != null and .conclusion != "SUCCESS")`, since a
+pending job has a null conclusion and otherwise reads as a failure.
+
+**Never let a wait loop treat "no data" as "done".** A loop written as
+`until [ "$(gh pr checks N | grep -c pending)" = "0" ]` exits instantly
+when GitHub reports no checks at all, which is indistinguishable from
+every check having finished. Pin the wait to the current head SHA
+instead. That bug nearly merged a stale pre-rebase green run.
+
+**Check platform status before diagnosing.** A GitHub Actions outage
+produces exactly the symptoms of a broken branch: no check-runs, stale
+rollups, lagging issue lists. Six trigger attempts across two branches
+were spent before checking githubstatus.com, which reported a major
+outage. One curl would have saved all of it.
+
+**Rebuild the binary before trusting `sync --check`** after rebasing
+onto a main that changed adapters. A stale `./agnostic-ai` reports drift
+that does not exist.
+
+**A merged PR does not always close its issue.** A PR whose title lists
+issue numbers without a `Closes` keyword leaves them open, and a partial
+fix that carries `Closes` shuts an issue that is not finished. Verify
+issue state after every merge, and reopen with a scoped comment rather
+than letting a real gap sit behind a green checkmark.
 
 ## What this skill does not do
 

--- a/.github/agents/target-auditor.agent.md
+++ b/.github/agents/target-auditor.agent.md
@@ -50,6 +50,27 @@ The prompt names your targets. Everything else you fetch yourself:
       is client-side.
 
    Only after all four fail is `unconfirmed` the honest answer.
+
+   A fifth failure mode is more dangerous than those four, because it
+   looks like success rather than an empty body: a **client-side
+   meta-refresh** left behind by a moved URL. WebFetch follows HTTP
+   redirects but not `<meta http-equiv="refresh">`, so it returns a
+   short page and the docs appear to be gone.
+
+   Kiro cost a full week to this. Its configuration reference moved and
+   left a 595-byte stub at the old URL; two audits read that stub and
+   shipped a coverage note claiming the tool vocabulary was
+   "unconfirmed" when it had been fully documented the whole time.
+
+   Detection: a suspiciously short body containing `http-equiv="refresh"`.
+   Remedy: read the `url=` target out of the tag and fetch that instead.
+   `curl -s <url> | head -c 400` shows it immediately.
+
+   A moved URL can also land on something unrelated. Trae's MCP page now
+   302s to a marketing page, which is why two consecutive runs concluded
+   the path was undocumented. If a fetch succeeds but the content does
+   not match the topic, treat that as a `docs-moved` finding rather than
+   as an absent surface.
 4. Compare, in this order (highest value first):
    - **Path drift**: does the tool still read the exact path we write? A
      moved skills, rules, or agents dir silently breaks every user. Check

--- a/.github/agents/target-auditor.agent.md
+++ b/.github/agents/target-auditor.agent.md
@@ -71,6 +71,27 @@ The prompt names your targets. Everything else you fetch yourself:
    the path was undocumented. If a fetch succeeds but the content does
    not match the topic, treat that as a `docs-moved` finding rather than
    as an absent surface.
+
+   Last resort, and it works when every step above fails: many docs
+   sites ship their CMS-authored content **server-side** inside a
+   `<script>` payload such as `window._ROUTER_DATA`,
+   `window.__NEXT_DATA__`, or `__INITIAL_STATE__`. WebFetch truncates
+   these because they run to megabytes, so the page reads as empty even
+   though the full text is right there in the response.
+
+   Trae's MCP schema was settled this way after `.md`, `llms.txt`, a
+   docs repo, and the SPA's own API had all dead-ended. Fetch the page
+   to disk with `curl`, locate the payload, and parse it. In Trae's case
+   the body was a Quill-style delta where every token of every code
+   example is its own tagged run, so the reconstruction is exact rather
+   than approximate.
+
+   When a corpus of real config files is the only evidence available,
+   separate files the vendor's own tool produced from files another tool
+   wrote into the same folder. A Trae MCP file carrying `autoApprove`
+   and Cline-shaped tool names at the wrong path is evidence about
+   Cline. Averaging a contaminated corpus produces a schema no vendor
+   actually accepts.
 4. Compare, in this order (highest value first):
    - **Path drift**: does the tool still read the exact path we write? A
      moved skills, rules, or agents dir silently breaks every user. Check

--- a/.github/skills/target-audit/SKILL.md
+++ b/.github/skills/target-audit/SKILL.md
@@ -202,9 +202,35 @@ Re-run rather than merging on a theory. Note that `sync --check` drifts
 locally after any merge that changed a spec, because gitignored emitted
 copies are stale; that one is expected and `sync` fixes it.
 
-When querying check status, exclude pending jobs explicitly:
-`select(.conclusion != null and .conclusion != "SUCCESS")`. A pending job
-has a null conclusion and will otherwise read as a failure.
+When querying check status, prefer `gh pr checks <n>` over
+`statusCheckRollup`. The rollup serves stale conclusions: it reported
+five failures on a docs-only change whose jobs had all passed, and it
+reports closed issues as open for minutes after a merge. If you do use
+the rollup, exclude pending jobs explicitly with
+`select(.conclusion != null and .conclusion != "SUCCESS")`, since a
+pending job has a null conclusion and otherwise reads as a failure.
+
+**Never let a wait loop treat "no data" as "done".** A loop written as
+`until [ "$(gh pr checks N | grep -c pending)" = "0" ]` exits instantly
+when GitHub reports no checks at all, which is indistinguishable from
+every check having finished. Pin the wait to the current head SHA
+instead. That bug nearly merged a stale pre-rebase green run.
+
+**Check platform status before diagnosing.** A GitHub Actions outage
+produces exactly the symptoms of a broken branch: no check-runs, stale
+rollups, lagging issue lists. Six trigger attempts across two branches
+were spent before checking githubstatus.com, which reported a major
+outage. One curl would have saved all of it.
+
+**Rebuild the binary before trusting `sync --check`** after rebasing
+onto a main that changed adapters. A stale `./agnostic-ai` reports drift
+that does not exist.
+
+**A merged PR does not always close its issue.** A PR whose title lists
+issue numbers without a `Closes` keyword leaves them open, and a partial
+fix that carries `Closes` shuts an issue that is not finished. Verify
+issue state after every merge, and reopen with a scoped comment rather
+than letting a real gap sit behind a green checkmark.
 
 ## What this skill does not do
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ## [Unreleased]
 
+### Changed
+
+- The `target-audit` skill and its auditor agent record what two weeks of running them taught: a client-side meta-refresh stub defeats WebFetch and reads as an absent doc rather than a moved one, `gh pr checks` beats `statusCheckRollup` because the rollup serves stale conclusions, a wait loop must not read "no data" as "finished", platform status is worth checking before diagnosing a broken branch, and a merged PR does not reliably close its issue.
+
 ### Fixed
 
 - The release workflow now skips optional npm publishing when `NPM_TOKEN` is absent instead of attempting to publish with `setup-node`'s placeholder credential.


### PR DESCRIPTION
## 🤔 Background

The `target-audit` skill has now run several times and driven ~20 merged fixes. Five things cost real time during those runs, each at least once, and none of them were written down. Next week's run would have paid for them again.

## 🔖 Auditor: a fifth doc-fetch failure mode

The agent already documents four ways a client-rendered vendor doc defeats a fetch (`llms.txt`, `.md` suffix, docs source repo, the SPA's own `/api/` route). This adds the one that is worse than all four, because **it looks like success**:

A moved URL that leaves a **client-side meta-refresh** stub. WebFetch follows HTTP redirects but not `<meta http-equiv="refresh">`, so it returns a short page and the documentation appears absent rather than moved.

**Kiro cost a full week to exactly this.** Its configuration reference moved and left a 595-byte stub behind. Two consecutive audits read that stub and concluded the tool vocabulary was undocumented, so we shipped a coverage note telling users the field could not be honored — while the vocabulary had been fully documented the entire time. Wayback shows the content unchanged since 2026-07-09; only the URL moved.

Detection and remedy are both one line, now recorded.

Also added: a moved URL can land on something unrelated. Trae's MCP page now 302s to a marketing page, which is why two runs concluded the path was undocumented. That is a `docs-moved` finding, not an absent surface.

## 🔖 Phase 7: four landing lessons

- **`gh pr checks` over `statusCheckRollup`.** The rollup serves stale conclusions — it reported five failures on a docs-only change whose jobs had all passed, and showed closed issues as open for minutes after a merge.
- **A wait loop must not treat "no data" as "done".** `until [ "$(gh pr checks N | grep -c pending)" = "0" ]` exits instantly when GitHub reports no checks at all. That is indistinguishable from every check having finished, and it nearly merged a stale pre-rebase green run. Pin the wait to the head SHA.
- **Check platform status before diagnosing.** An Actions outage produces exactly the symptoms of a broken branch: no check-runs, stale rollups, lagging issue lists. Six trigger attempts across two branches were spent before one curl to githubstatus.com reported a major outage.
- **Rebuild the binary before trusting `sync --check`** after rebasing onto a main that changed adapters. A stale `./agnostic-ai` reports drift that is not there.
- **A merged PR does not reliably close its issue.** A PR listing issue numbers without a `Closes` keyword leaves them open; a partial fix carrying one shuts an issue that is not finished. Both happened. Verify after every merge, and reopen with a scoped comment rather than letting a real gap sit behind a green checkmark.

## Verification

- `agnostic-ai validate`, `sync --check` exit 0, `make preflight` green
- prose checked against `.claude/rules/plain-english.md`
- emitted skill and agent copies regenerated by `sync`