### PR TITLE
fix(cli): enforce the capability map in both directions

### DIFF
--- a/.agnostic-ai/agents/adapter-fixer.md
+++ b/.agnostic-ai/agents/adapter-fixer.md
@@ -21,6 +21,22 @@ If a finding turns out to be wrong once you open the code, stop. Say so,
 name what the evidence missed, and close nothing. A wrong fix costs more
 than a missed one.
 
+When the prompt contradicts the issue, trust neither. Verify.
+
+This happens legitimately: an issue filed days ago can be overtaken by
+research, and the orchestrator will say so. But a prompt asserting "the
+issue is out of date, here is the real answer" is indistinguishable from
+a prompt that is wrong, and the issue is the artifact with a history you
+can read. Go to the source yourself and settle it.
+
+That is not hypothetical either. A trae MCP issue said the schema must
+not be guessed; the prompt said it had since been confirmed and supplied
+it. The fixer re-extracted the vendor page itself, found the prompt
+correct, and implemented on its own verification rather than on an
+assertion. Had the prompt been wrong, that check is the only thing
+standing between a confident claim and an adapter writing a schema no
+vendor accepts.
+
 ## Steps
 
 1. Read `docs/internal/adding-adapters.md` and the `adapter-pattern` rule

--- a/.agnostic-ai/skills/target-audit/SKILL.md
+++ b/.agnostic-ai/skills/target-audit/SKILL.md
@@ -174,6 +174,15 @@ Hand each fixer the finding text verbatim, including the evidence. Do not
 re-summarize it: the vendor quote and the `file:line` are what the PR body
 has to carry.
 
+**Hand over the reproduction, not the conclusion.** When research after
+the issue was filed changes the answer, say how it was established and
+how to re-check it, not only what it turned out to be. A fixer cannot
+tell your verified claim from an unverified one, and the correct response
+to an unverifiable assertion is to distrust it. Give it the URL, the
+extraction method, and the command, so re-checking costs a minute instead
+of an afternoon. One fixer re-derived a whole vendor schema because the
+prompt asserted the answer without showing its work, and it was right to.
+
 When a fixer reports the finding was wrong, reopen nothing. Add a comment
 to the issue with what the evidence missed, and label it `invalid`.
 

--- a/.github/agents/adapter-fixer.agent.md
+++ b/.github/agents/adapter-fixer.agent.md
@@ -26,6 +26,22 @@ If a finding turns out to be wrong once you open the code, stop. Say so,
 name what the evidence missed, and close nothing. A wrong fix costs more
 than a missed one.
 
+When the prompt contradicts the issue, trust neither. Verify.
+
+This happens legitimately: an issue filed days ago can be overtaken by
+research, and the orchestrator will say so. But a prompt asserting "the
+issue is out of date, here is the real answer" is indistinguishable from
+a prompt that is wrong, and the issue is the artifact with a history you
+can read. Go to the source yourself and settle it.
+
+That is not hypothetical either. A trae MCP issue said the schema must
+not be guessed; the prompt said it had since been confirmed and supplied
+it. The fixer re-extracted the vendor page itself, found the prompt
+correct, and implemented on its own verification rather than on an
+assertion. Had the prompt been wrong, that check is the only thing
+standing between a confident claim and an adapter writing a schema no
+vendor accepts.
+
 ## Steps
 
 1. Read `docs/internal/adding-adapters.md` and the `adapter-pattern` rule

--- a/.github/skills/target-audit/SKILL.md
+++ b/.github/skills/target-audit/SKILL.md
@@ -174,6 +174,15 @@ Hand each fixer the finding text verbatim, including the evidence. Do not
 re-summarize it: the vendor quote and the `file:line` are what the PR body
 has to carry.
 
+**Hand over the reproduction, not the conclusion.** When research after
+the issue was filed changes the answer, say how it was established and
+how to re-check it, not only what it turned out to be. A fixer cannot
+tell your verified claim from an unverified one, and the correct response
+to an unverifiable assertion is to distrust it. Give it the URL, the
+extraction method, and the command, so re-checking costs a minute instead
+of an afternoon. One fixer re-derived a whole vendor schema because the
+prompt asserted the answer without showing its work, and it was right to.
+
 When a fixer reports the finding was wrong, reopen nothing. Add a comment
 to the issue with what the evidence missed, and label it `invalid`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- The capability-map parity test now runs in both directions. It already caught a target gaining a capability without being registered; it now also catches one that stops supporting a kind and is left in the map, which happened when amp's `Command` support was removed and only a human reading the diff noticed.
 - The release workflow now skips optional npm publishing when `NPM_TOKEN` is absent instead of attempting to publish with `setup-node`'s placeholder credential.
 - `import zed` no longer drops MCP servers from a `.zed/settings.json` that agnostic-ai itself emitted. The reader accepted only a nested `command: {path, args, env}` object, while Zed documents (and the zed adapter writes) `command` as a plain string with `args` and `env` beside it; remote `url` servers were skipped outright for having no `command` key. All three shapes now import (#546).
 - `sync -t junie` now writes rule and agent bodies to the file Junie reads: inlined into `.junie/AGENTS.md`, the only file its guidelines lookup opens once a project has synced. The prior `.junie/rules/` output sat outside that lookup order entirely, so every Rule and Agent spec was invisible to Junie; a stale copy from an older sync is now swept. `import junie` reads the new location, with the old directory still honored as a fallback for projects synced before this fix (#552).

--- a/internal/cli/native_capabilities_parity_test.go
+++ b/internal/cli/native_capabilities_parity_test.go
@@ -99,3 +99,36 @@ func TestNativeCapabilities_NameOnlyRegisteredTargets(t *testing.T) {
 		}
 	}
 }
+
+// TestNativeCapabilities_ListNoKindAnAdapterDropped closes the other half
+// of the parity invariant.
+//
+// TestNativeCapabilities_MatchDeclaredAdapterSupport catches a target that
+// gains a capability without being added here. It cannot catch the
+// reverse: a target that stops supporting a kind and is left in the map.
+//
+// That gap is not hypothetical. When amp's `Command` support was removed
+// (Amp has no file-based command surface; commands register through its
+// plugin API), `targetsSupportingKind[spec.KindCommand]` still listed amp.
+// Nothing failed. The orphan-kind validator would have kept telling users
+// their command specs were fine for amp, and `sync --watch` would have
+// kept re-syncing amp on a command edit that produces nothing. A human
+// caught it while reading the diff.
+//
+// Together the two tests pin the map to exactly what the adapters declare,
+// in both directions, so neither adding nor removing a capability can
+// leave it stale.
+func TestNativeCapabilities_ListNoKindAnAdapterDropped(t *testing.T) {
+	for kind, targets := range targetsSupportingKind {
+		for target := range targets {
+			if _, ok := adapters.Get(target); !ok {
+				continue // unregistered targets are the other test's job
+			}
+			if !declaresSupport(t, target, kind) {
+				t.Errorf("targetsSupportingKind[%q] lists %q, but that adapter no longer declares the kind; "+
+					"remove it or the orphan-kind validator will call those specs supported "+
+					"and sync --watch will re-sync a target that emits nothing for them", kind, target)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 🤔 Background

`TestNativeCapabilities_MatchDeclaredAdapterSupport` (added in #524) catches a target that **gains** a capability without being added to `targetsSupportingKind`. It cannot catch the reverse: a target that **stops** supporting a kind and is left in the map.

That gap cost a real miss during the 2026-08-08 audit. When amp's `Command` support was removed — Amp has no file-based command surface; commands register through its plugin API — the map still listed amp under `spec.KindCommand`, and nothing failed.

Left unfixed, the orphan-kind validator would have kept telling users their command specs were supported for amp, and `sync --watch` would have kept re-syncing amp on a command edit that produces nothing. A human reading the diff caught it.

That map has now drifted five separate times across this audit cycle. The half-invariant was clearly not enough.

## 🔖 Changes

**`TestNativeCapabilities_ListNoKindAnAdapterDropped`** asserts the other direction: every `(kind, target)` in the map must still be declared by that adapter. Support is derived behaviorally through the existing `declaresSupport` helper, so it needs no new exported surface.

Verified by reintroducing the exact amp-shaped drift:

```
--- FAIL: TestNativeCapabilities_ListNoKindAnAdapterDropped
    targetsSupportingKind["command"] lists "amp", but that adapter no longer
    declares the kind; remove it or the orphan-kind validator will call those
    specs supported and sync --watch will re-sync a target that emits nothing
```

Reverted, green. Both directions now hold with zero mismatches across 25 targets.

## Two dispatch lessons recorded

Both came out of running the fix wave, and both are about the orchestrator, not the fixers.

**Hand over the reproduction, not the conclusion.** A fixer cannot tell a verified claim from an unverified one. When research after an issue is filed changes the answer, give the URL, the extraction method, and the command — not just the result. One fixer re-derived an entire vendor schema because the prompt asserted the answer without showing its work, and it was right to.

**When the prompt contradicts the issue, trust neither.** Added to `adapter-fixer`. An issue overtaken by research is legitimate and common, but "the issue is out of date, here is the real answer" is indistinguishable from a prompt that is wrong, and the issue is the artifact with a readable history. That check is the only thing standing between a confident claim and an adapter writing a schema no vendor accepts.

## Verification

- new test red against reintroduced drift, green after
- `make preflight` green, `agnostic-ai sync --check` exit 0
- prose checked against `.claude/rules/plain-english.md`