### PR TITLE
fix(cursor): note that a tools list cannot restrict a subagent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- A `tools` list on a Cursor agent now surfaces a coverage note instead of vanishing. Cursor subagents document only `name`, `description`, `model`, `readonly`, and `is_background`, so an allowlist cannot restrict them; kilo, augment, and codex already warned in the identical situation while cursor stayed silent. `docs/user/spec-format.md` gains a per-target `tools` table, since one `tools: [Read, Bash]` spec produces five different outcomes across targets and Kiro's translation grants more than the name it came from.
 - The capability-map parity test now runs in both directions. It already caught a target gaining a capability without being registered; it now also catches one that stops supporting a kind and is left in the map, which happened when amp's `Command` support was removed and only a human reading the diff noticed.
 - The release workflow now skips optional npm publishing when `NPM_TOKEN` is absent instead of attempting to publish with `setup-node`'s placeholder credential.
 - `import zed` no longer drops MCP servers from a `.zed/settings.json` that agnostic-ai itself emitted. The reader accepted only a nested `command: {path, args, env}` object, while Zed documents (and the zed adapter writes) `command` as a plain string with `args` and `env` beside it; remote `url` servers were skipped outright for having no `command` key. All three shapes now import (#546).

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -70,7 +70,7 @@ Report concise findings with `file:line` references.
 |-------|----------|---------|-------------|
 | `name` | no | filename without `.md` | Agent identifier. Used for the output filename. |
 | `description` | no | empty | One-liner shown in tool listings. |
-| `tools` | no | unset | Tools the agent may invoke. Format depends on target CLI. |
+| `tools` | no | unset | Tools the agent may invoke. Behavior varies by target; see [`tools` support by target](#tools-support-by-target) below. |
 | `model` | no | unset | Preferred model. String applies everywhere; a map selects per target (see below). |
 
 Any other frontmatter field passes through to the target CLI unchanged.
@@ -405,6 +405,27 @@ Confirmed per target, never generalized: a target not listed here has not been c
 | OpenCode | Maps to `"enabled": false` in `opencode.json`; an enabled server gets no key at all. `import opencode` reads it back into `disabled: true`. |
 | Claude Code, Cursor, Copilot, Trae | No file-based way to pre-disable a project-scoped MCP server; the field has no effect and agnostic-ai does not emit it. Disable the server from the target's own UI instead. |
 | Qoder | Not vendor-confirmed either way. `.mcp.json` is the same file Claude Code reads, so agnostic-ai drops the field there too rather than risk the two targets disagreeing on one shared file. |
+
+### `tools` support by target
+
+Confirmed per target, never generalized: a target not listed here has not
+been checked. One `tools: [Read, Bash]` spec produces five different
+outcomes, so read this before assuming an allowlist restricts anything.
+
+| Target | Behavior |
+|--------|----------|
+| Claude Code, Copilot, Factory | Passes through verbatim as a YAML list. The vendor vocabulary matches agnostic-ai's Claude-style names. |
+| Qoder | Passes through as a comma-separated string (`tools: Read, Bash`), the only form Qoder documents. Its built-in vocabulary is Claude-style, so the names carry over unchanged. |
+| Kiro | **Translated**, not passed through. Kiro's vocabulary is lowercase categories, so `Read`/`Grep`/`Glob` become `read`, `Write`/`Edit` become `write`, `Bash` becomes `shell`, and `WebFetch`/`WebSearch` become `web`. A category grants more than the single name it came from: `Edit` alone also permits `delete_file`. Names outside the table surface a coverage note rather than being dropped. `x-kiro.tools` bypasses translation entirely. |
+| Codex | No effect. Codex uses `tools` as a configuration table rather than a Claude-style allowlist, so the field is not written and a coverage note fires. Set `x-codex.tools` for Codex-native settings. |
+| Cursor | No effect. Cursor subagents document only `name`, `description`, `model`, `readonly`, and `is_background`. `readonly: true` is the coarse equivalent. A coverage note fires. |
+| Augment | No effect. Augment's names (`view`, `codebase-retrieval`, `str-replace-editor`, ...) are its own vocabulary, and no vendor-published mapping exists. Set `x-augment.tools` / `x-augment.disabled_tools`. A coverage note fires. |
+| Kilo Code | No effect. Kilo Code's agent schema has no `tools` key at all; access is controlled by a `permission` object. Set `x-kilo.permission`. A coverage note fires. |
+
+Every target that cannot honor the field says so at sync time. A silently
+dropped restriction is the failure this table and those notes exist to
+prevent: an author who writes `tools: [Read]` and gets an unrestricted
+agent has no way to notice.
 
 ## Commands
 

--- a/internal/adapters/cursor/agent.go
+++ b/internal/adapters/cursor/agent.go
@@ -13,13 +13,25 @@ import (
 // documented fields (`name`, `description`, `model`, `readonly`,
 // `is_background`) when the spec declares them; arbitrary `x-cursor`
 // keys pass through. The body is the agent's system prompt.
-func emitAgent(sess *emit.Session, a spec.Entry, agentsDir string, dryRun bool) error {
+//
+// Returns whether the spec declared a `tools` list, which Cursor has no
+// frontmatter field for. The caller folds that into one coverage note per
+// sync so the dropped restriction is never silent.
+func emitAgent(sess *emit.Session, a spec.Entry, agentsDir string, dryRun bool) (bool, error) {
 	path := filepath.Join(agentsDir, a.Name+".md")
-	return sess.WriteFile(path, emit.WithHeader(agentMarkdown(a), emit.FormatMarkdown), dryRun)
+	md, hadTools := agentMarkdown(a)
+	return hadTools, sess.WriteFile(path, emit.WithHeader(md, emit.FormatMarkdown), dryRun)
 }
 
-func agentMarkdown(a spec.Entry) string {
+// agentMarkdown renders one subagent file and reports whether the spec
+// declared `tools`. Cursor's documented subagent frontmatter is `name`,
+// `description`, `model`, `readonly`, and `is_background`; there is no
+// tools field, so an allowlist cannot restrict a Cursor subagent and is
+// deliberately not written. `readonly: true` is the coarse equivalent
+// Cursor does document.
+func agentMarkdown(a spec.Entry) (string, bool) {
 	resolved := emit.ResolveMeta(a.Meta, target)
+	hadTools := len(emit.StringSlice(resolved["tools"])) > 0
 	desc, _ := resolved["description"].(string)
 	if desc == "" {
 		desc = a.Name
@@ -35,12 +47,14 @@ func agentMarkdown(a spec.Entry) string {
 			keys = append(keys, k)
 		}
 	}
-	exclude := append([]string(nil), keys...)
+	// `tools` joins the exclude list so an x-cursor escape-hatch attempt
+	// cannot reintroduce a key Cursor does not read.
+	exclude := append(append([]string(nil), keys...), "tools")
 	emit.MergeCustomTargetMeta(meta, &keys, a.Meta, target, exclude...)
 	front := emit.FrontmatterOrdered(meta, keys)
 	body := strings.TrimSpace(a.Body)
 	if body == "" {
-		return front + "\n"
+		return front + "\n", hadTools
 	}
-	return front + "\n" + body + "\n"
+	return front + "\n" + body + "\n", hadTools
 }

--- a/internal/adapters/cursor/coverage_note_test.go
+++ b/internal/adapters/cursor/coverage_note_test.go
@@ -101,3 +101,43 @@ func TestEmit_MCP_DisabledHasNoFileBasedEffect(t *testing.T) {
 		t.Errorf("expected a field no-op note, got: %s", buf.String())
 	}
 }
+
+// Cursor's subagent frontmatter documents name, description, model,
+// readonly, and is_background. There is no tools field, so a spec's
+// tools list cannot restrict a Cursor subagent.
+//
+// Dropping it silently is the failure this note exists to prevent: kilo,
+// augment, and codex are in the identical position and all three warn,
+// while cursor said nothing. An author would reasonably believe the
+// restriction applied.
+func TestEmit_Agent_ToolsNotesFieldNoOp(t *testing.T) {
+	testutil.TempCwd(t)
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+
+	entries := []spec.Entry{
+		{Kind: spec.KindAgent, Name: "a1", Meta: map[string]any{"tools": []any{"Read", "Bash"}}, Body: "body"},
+		{Kind: spec.KindAgent, Name: "a2", Body: "body"},
+	}
+	if err := New().Emit(emit.NewSession(), spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if n := emit.PendingCoverageNotesCount(); n != 1 {
+		t.Errorf("expected one coverage note (only a1 declares tools), got %d", n)
+	}
+}
+
+// No agent setting tools means no note.
+func TestEmit_Agent_NoToolsNoNote(t *testing.T) {
+	testutil.TempCwd(t)
+	emit.ResetCoverageNotes()
+	t.Cleanup(emit.ResetCoverageNotes)
+
+	entries := []spec.Entry{{Kind: spec.KindAgent, Name: "a1", Body: "body"}}
+	if err := New().Emit(emit.NewSession(), spec.NewBundle(entries), &config.Config{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if n := emit.PendingCoverageNotesCount(); n != 0 {
+		t.Errorf("expected no coverage note when no agent sets tools, got %d", n)
+	}
+}

--- a/internal/adapters/cursor/cursor.go
+++ b/internal/adapters/cursor/cursor.go
@@ -91,11 +91,18 @@ func (Adapter) Emit(sess *emit.Session, b spec.Bundle, cfg *config.Config, dryRu
 		return err
 	}
 	agentsDir := emit.OutputAgentsDir(cfg, target, defaultAgentsDir)
+	droppedTools := 0
 	for _, a := range b.Agents {
-		if err := emitAgent(sess, a, agentsDir, dryRun); err != nil {
+		hadTools, err := emitAgent(sess, a, agentsDir, dryRun)
+		if err != nil {
 			return err
 		}
+		if hadTools {
+			droppedTools++
+		}
 	}
+	emit.NoteFieldNoOp(target, spec.KindAgent, "tools", droppedTools,
+		"Cursor subagents have no tools field (name, description, model, readonly, is_background); use readonly: true for a coarse restriction")
 	skillsDir := emit.OutputSkillsDir(cfg, target, defaultSkillsDir)
 	for _, s := range b.Skills {
 		if err := emitSkill(sess, s, skillsDir, dryRun); err != nil {


### PR DESCRIPTION
## 🤔 Background

Measuring what `sync` actually emits, one `tools: [Read, Bash]` agent spec produces **five different outcomes**:

```
claude / copilot / factory   tools: [Read, Bash]      passthrough
qoder                        tools: Read, Bash        comma string
kiro                         tools: [read, shell]     translated, widens access
codex / augment / kilo       omitted + coverage note
cursor                       omitted, NO note         ← silent
```

Cursor was the odd one out. Its subagent frontmatter documents only `name`, `description`, `model`, `readonly`, and `is_background` ([verified](https://cursor.com/docs/subagents)) — no `tools` field — so an allowlist cannot restrict a Cursor subagent. Kilo Code, Augment, and Codex are in the identical position and all three warn. Cursor dropped the key silently.

An author writing `tools: [Read]` got an unrestricted subagent with no way to notice. That is the failure mode this project keeps finding in vendors, shipped in our own adapter.

## 🔖 Changes

**`internal/adapters/cursor/`** — `agentMarkdown` reports whether the spec declared `tools`; `Emit` folds that into one `NoteFieldNoOp` per sync, pointing at `readonly: true` as Cursor's coarse equivalent. `tools` also joins the `x-cursor` exclude list so an escape-hatch attempt cannot reintroduce a key Cursor does not read.

**`docs/user/spec-format.md`** — a per-target `tools` table, modeled on the `disabled` one that already works. The field previously had a single line: "Format depends on target CLI." That understates a field with five behaviours, one of which widens access.

The Kiro row is the one worth reading: its categories grant more than the name they came from, so `Edit` alone also permits `delete_file`.

## Verification

- new tests confirmed red first: cursor emitted zero coverage notes where three sibling targets emit one
- confirmed in a real dogfood `sync`, which now prints the cursor note alongside codex and augment
- `make preflight` green, `agnostic-ai sync --check` exit 0

## Note on process

The cursor note appeared to not fire during verification. It was a stale `./agnostic-ai` binary — the exact trap recorded in #569's Phase 7 lessons two hours earlier. Rebuilding fixed it. Leaving this here because the lesson clearly needs the repetition.