### PR TITLE
fix(gitignore): never ignore the source entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- The first `sync` in a fresh project no longer gitignores `.agnostic-ai/AGNOSTIC_AI.md` (#580). `sync` writes that file on the first run and records it like any emitted path, so `init && sync && git add -A && git commit` silently left the shared instruction body out of the repository, and a teammate cloning it regenerated every target from an empty body. The second sync removed the entry again, which also made the first `.gitignore` differ from every later one.
 - The install docs no longer advertise channels that are not published. `npx agnostic-ai`, `winget install Chemaclass.agnostic-ai`, and `scoop install agnostic-ai` all 404 today, because each is gated on a release secret that is not configured yet, so every copy button for them handed users a failing command. The landing page drops the npx tab and points its Windows tab at the PowerShell install script, which works. `docs/user/getting-started.md` and the plugin install skill mark the three as unpublished instead of "from the next release", which stopped being true once releases shipped without them.
 
 ## v0.47.1 - 2026-08-09

--- a/internal/cli/gitignore.go
+++ b/internal/cli/gitignore.go
@@ -202,9 +202,33 @@ func gitignoreTopSegment(p string) string {
 // ignore above them, letting a project keep a tracked fixture (e.g.
 // `internal/adapters/**/testdata/**`) without hand-editing the block (#388).
 func buildManagedBlock(cfg *config.Config, entries []string) []string {
-	entries = append(fixedManagedEntries(), entries...)
+	entries = append(fixedManagedEntries(), dropSourceEntryPoint(entries)...)
 	block := collapseManagedEntries(normalizeAndSort(entries), protectedSourceTopDirs(cfg))
 	return append(block, normalizeAllowEntries(cfg.Gitignore.Allow)...)
+}
+
+// dropSourceEntryPoint removes AGNOSTIC_AI.md from the recorded emissions.
+//
+// The first sync in a fresh project writes it and records it like any other
+// emission; later syncs read it from disk and skip the write, so it is absent
+// from the second run's entries. That alone made the first .gitignore differ
+// from every later one. The real damage is that it is a source file, the
+// shared instruction body every target's entry point renders from, so
+// `init && sync && git add -A && git commit` silently left it out of the
+// repository (#580).
+//
+// It cannot be handled by protectedSourceTopDirs: that guards against
+// collapsing entries into a directory-wide ignore, and `.agnostic-ai` legitimately
+// holds two managed entries (`.sync-state`, `packs/`) that must stay listed.
+func dropSourceEntryPoint(entries []string) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if normalizeGitignorePath(e) == normalizeGitignorePath(adapters.AgnosticEntryPointPath) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 // normalizeAllowEntries turns the configured allow patterns into `!`-prefixed

--- a/internal/cli/gitignore_test.go
+++ b/internal/cli/gitignore_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chemaclass/agnostic-ai/internal/adapters"
 	"github.com/chemaclass/agnostic-ai/internal/config"
 	"github.com/chemaclass/agnostic-ai/internal/testutil"
 )
@@ -123,6 +124,19 @@ func TestBuildManagedBlock_IncludesFixedEntries(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("managed block missing fixed entry %q, got %v", want, block)
+		}
+	}
+}
+
+func TestBuildManagedBlock_NeverIgnoresTheAgnosticEntryPoint(t *testing.T) {
+	// The first sync in a fresh project writes AGNOSTIC_AI.md and so records
+	// it as an emitted path; later syncs read it from disk and skip the
+	// write. Left alone that makes the first .gitignore differ from every
+	// later one, and worse, ignores a source file (#580).
+	block := buildManagedBlock(&config.Config{}, []string{adapters.AgnosticEntryPointPath})
+	for _, e := range block {
+		if strings.Contains(e, "AGNOSTIC_AI.md") {
+			t.Errorf("managed block ignores the source entry point %q, got %v", e, block)
 		}
 	}
 }

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -37,14 +37,12 @@ function tear_down() {
 
 # tree_digest hashes emitted output so two runs can be compared.
 #
-# .agnostic-ai/.sync-state is excluded: it records which warnings have already
-# been shown, so it is expected to differ between runs. .gitignore is excluded
-# because the first sync in a fresh project lists a path the second one drops
-# (see the emit-then-ignore bug filed alongside this suite); tighten this back
-# to the whole tree once that is fixed.
+# .agnostic-ai/.sync-state is the one exclusion: it records which warnings have
+# already been shown, so it is expected to differ between runs. Everything else
+# including .gitignore is covered, which is what guards #580.
 function tree_digest() {
   find . -path ./.git -prune -o -type f -print \
-    | grep -vE '(^\./\.gitignore$|/\.sync-state$)' \
+    | grep -vE '/\.sync-state$' \
     | sort | xargs shasum 2>/dev/null | shasum | cut -d' ' -f1
 }
 
@@ -89,6 +87,15 @@ function test_dry_run_leaves_the_tree_untouched() {
   "$BIN" sync --dry-run >/dev/null 2>&1
   after="$(tree_digest)"
   assert_same "$before" "$after"
+}
+
+function test_first_sync_leaves_the_source_entry_point_committable() {
+  # sync writes AGNOSTIC_AI.md on the first run only, which used to get it
+  # recorded as generated output and ignored. It is a source file: the shared
+  # instruction body every target renders from (#580).
+  "$BIN" sync >/dev/null 2>&1
+  git add -A >/dev/null 2>&1
+  assert_contains "AGNOSTIC_AI.md" "$(git status --porcelain)"
 }
 
 # ---- import round-trip -------------------------------------------------------


### PR DESCRIPTION
## Repro

```bash
mkdir p && cd p && git init -q .
agnostic-ai init
agnostic-ai sync
grep -c AGNOSTIC_AI.md .gitignore    # was 1, now 0
agnostic-ai sync
grep -c AGNOSTIC_AI.md .gitignore    # 0
```

## Cause

`.agnostic-ai/AGNOSTIC_AI.md` does not exist after `init`. The first `sync` creates it, and `mainSess.StopRecording()` returns it alongside every genuinely emitted path, so it went into the managed block. Later syncs read it from disk and skip the write (`sync_run.go:422` documents that path), so it was absent from the second run's entries and the block dropped it.

## Impact

It is a **source** file: the shared instruction body every target's entry point renders from. The obvious first-run sequence

```bash
agnostic-ai init && agnostic-ai sync && git add -A && git commit
```

silently excluded it. A teammate cloning that repo regenerated every target from an empty body. `sync --check` returned 0 the whole time, so nothing surfaced it.

Secondary effect: the first `.gitignore` differed from every later one.

## Fix

Filter the path in `buildManagedBlock`, the single choke point shared by all four writers (`runSyncOnce`, `runSyncJSON`, `init_scaffold`, `ensureManagedGitignore`). Fixing it there rather than at the two `sync_run.go` accumulation sites keeps the behaviour identical across every entry path.

`protectedSourceTopDirs` cannot express this. It guards against *collapsing* entries into a directory-wide ignore, and `.agnostic-ai` legitimately contributes two managed entries (`.sync-state`, `packs/`) that must stay listed, so a blanket exclusion by top-level directory would drop those too.

## Verification

- Unit test written first, confirmed red (`managed block ignores the source entry point "/.agnostic-ai/AGNOSTIC_AI.md"`), then green.
- Two e2e guards in `scripts/e2e_test.sh`: `tree_digest` now covers `.gitignore` (previously excluded with a comment pointing at #580), plus an explicit assertion that `git add -A` stages `AGNOSTIC_AI.md` after one sync.
- **Both e2e guards confirmed to fail with the fix reverted and pass with it**, so they genuinely guard the regression rather than passing either way.
- Verified on both `init` and `init --demo`: `.gitignore` now byte-identical between sync 1 and 2, and `git add -A` stages the file.
- `make preflight` ok, `go test -race ./...` exit 0, `make test-shell` 82 passed, `sync --check` clean, `shellcheck -S warning` clean.

Closes #580