### PR TITLE
fix: copilot: Agent Host reads a workspace .mcp.json natively; we emit only .vscode/mcp.json

### DIFF
--- a/.agnostic-ai/rules/adapter-pattern.md
+++ b/.agnostic-ai/rules/adapter-pattern.md
@@ -40,5 +40,6 @@ Conventions:
 - Stateless. No fields on `Adapter`. Construct via `New()` only.
 - One concern per file. If you need shared logic between two adapters, lift it into `internal/adapters/internal/emit/` first.
 - Resolve every output path through an `emit.Output*` helper so the user can override via `outputs.<target>.<field>` in the config.
+- MCP server files: emit only the target-native path (for example VS Code's `.vscode/mcp.json`). Some hosts such as the VS Code Agent Host read a workspace `.mcp.json` at the project root natively, but VS Code forwards non-interactive MCP servers there, so mirroring the same servers to a root `.mcp.json` by default would be a surprise file. If a portable root file is wanted, make it opt-in via `outputs.<target>.root-mcp-file`.
 - Skip silently (return nil) when an output is opt-in and unconfigured. Never write a surprise file.
 - Register the adapter in `internal/adapters/adapter.go` and add it to `config.DefaultTargets()`.


### PR DESCRIPTION
Closes #610