### PR TITLE
feat(spec): expand per-target path variables in spec bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- Path variables in spec bodies: `{{$SKILLS_DIR}}`, `{{$AGENTS_DIR}}`, `{{$COMMANDS_DIR}}`, `{{$RULES_DIR}}`, and `{{$MCP_FILE}}` expand to each target's own location, so one spec can say where files go without hardcoding one tool's layout. An `outputs.<target>.<field>` override wins, and a variable a target has no surface for is left verbatim with a coverage note rather than blanked (#616).
+
+### Added
+
 - `outputs.copilot.root-mcp-file` mirrors Copilot's MCP servers to a workspace-root `.mcp.json`, which VS Code's Agent Host reads natively (it does not read `.vscode/mcp.json` directly). Opt-in, so no project gains a root file it did not ask for (#610).
 
 ## v0.49.0 - 2026-08-13

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -581,7 +581,7 @@ Five variables are available:
 
 Rules:
 
-- **Bodies only.** Frontmatter values are not expanded.
+- **Bodies only.** Every spec kind that carries a body is expanded; frontmatter values are not.
 - **An `outputs.<target>.<field>` override wins.** Set `outputs.claude.skills-dir: custom/skills` and `{{$SKILLS_DIR}}` follows it, so a body never names a directory the emitted tree does not use.
 - **A variable the target has no surface for stays verbatim** and raises a coverage note. It is not blanked, because turning "see {{$COMMANDS_DIR}}" into "see " loses the sentence silently. Targets that carry every kind in one entry-point document (aider, jules, goose) resolve no variables at all.
 - **A variable is declared only where the target has a dedicated surface for that kind.** Several targets flatten agents into their rules directory with a filename prefix (antigravity, continue, trae, windsurf) or render them as commands (gemini); those declare no `{{$AGENTS_DIR}}` rather than point at a directory that is not an agents directory.

--- a/docs/user/spec-format.md
+++ b/docs/user/spec-format.md
@@ -561,6 +561,32 @@ Native emission (gitignore syntax, under a `#` provenance header): Cursor `.curs
 - Malformed frontmatter is treated as no metadata; the entire content becomes the body.
 - Any field not listed above passes through on emit. Useful for target-specific extensions.
 
+## Path variables: `{{$NAME}}`
+
+A spec body can name a directory without hardcoding one target's layout. `{{$SKILLS_DIR}}` expands to `.claude/skills` for claude, `.agents/skills` for codex, and `.github/skills` for copilot, from one source file.
+
+```markdown
+Put new skills in {{$SKILLS_DIR}} and agent profiles in {{$AGENTS_DIR}}.
+```
+
+Five variables are available:
+
+| Variable | Resolves to |
+|---|---|
+| `{{$SKILLS_DIR}}` | the target's skills directory |
+| `{{$AGENTS_DIR}}` | the target's agents directory |
+| `{{$COMMANDS_DIR}}` | the target's commands directory |
+| `{{$RULES_DIR}}` | the target's rules directory |
+| `{{$MCP_FILE}}` | the target's MCP config file |
+
+Rules:
+
+- **Bodies only.** Frontmatter values are not expanded.
+- **An `outputs.<target>.<field>` override wins.** Set `outputs.claude.skills-dir: custom/skills` and `{{$SKILLS_DIR}}` follows it, so a body never names a directory the emitted tree does not use.
+- **A variable the target has no surface for stays verbatim** and raises a coverage note. It is not blanked, because turning "see {{$COMMANDS_DIR}}" into "see " loses the sentence silently. Targets that carry every kind in one entry-point document (aider, jules, goose) resolve no variables at all.
+- **A variable is declared only where the target has a dedicated surface for that kind.** Several targets flatten agents into their rules directory with a filename prefix (antigravity, continue, trae, windsurf) or render them as commands (gemini); those declare no `{{$AGENTS_DIR}}` rather than point at a directory that is not an agents directory.
+- **The `$` sigil is required.** Plain `{{placeholder}}` is left alone, so Warp workflow arguments and any Handlebars or Jinja quoted in prose survive untouched. Lowercase names (`{{$skills_dir}}`) do not resolve.
+
 ## Target-specific extensions: `x-<target>` namespace
 
 Use `x-<target>:` blocks to attach fields only one adapter consumes. Other adapters strip the block on emit, so the spec stays portable.

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -340,7 +340,7 @@ type Adapter interface {
 // adapter.Emit.
 func EmitWithProvenance(sess *Session, a Adapter, b spec.Bundle, cfg *config.Config, dryRun bool) error {
 	defer emit.ProvenanceFor(cfg, a.Name())()
-	return a.Emit(sess, b.For(a.Name()), cfg, dryRun)
+	return a.Emit(sess, expandBundleVars(b.For(a.Name()), cfg, a.Name()), cfg, dryRun)
 }
 
 var registry = map[string]Adapter{

--- a/internal/adapters/internal/emit/vars.go
+++ b/internal/adapters/internal/emit/vars.go
@@ -1,0 +1,54 @@
+package emit
+
+import (
+	"regexp"
+	"sort"
+)
+
+// Variable names expanded in spec bodies. Each maps to a path the target
+// actually emits to, so one spec can say "put skills in {{$SKILLS_DIR}}"
+// and every target reads its own location.
+const (
+	VarSkillsDir   = "SKILLS_DIR"
+	VarAgentsDir   = "AGENTS_DIR"
+	VarCommandsDir = "COMMANDS_DIR"
+	VarRulesDir    = "RULES_DIR"
+	VarMCPFile     = "MCP_FILE"
+)
+
+// varPattern matches {{$NAME}} with an uppercase name. The $ sigil is
+// what keeps this from eating real content: Warp workflows use
+// {{placeholder}} for their arguments, and specs quote Handlebars and
+// Jinja in prose. Both survive untouched.
+var varPattern = regexp.MustCompile(`\{\{\$([A-Z][A-Z0-9_]*)\}\}`)
+
+// ExpandVars replaces every {{$NAME}} in body with vals[NAME] and
+// returns the result plus the distinct names it could not resolve,
+// sorted. An unresolved name keeps its token verbatim rather than
+// collapsing to an empty string, which would silently turn
+// "see {{$COMMANDS_DIR}}" into "see " on a target with no commands
+// surface. An empty value counts as unresolved for the same reason: it
+// means the target declares the surface but has it switched off.
+func ExpandVars(body string, vals map[string]string) (string, []string) {
+	if !varPattern.MatchString(body) {
+		return body, nil
+	}
+	missing := map[string]bool{}
+	out := varPattern.ReplaceAllStringFunc(body, func(match string) string {
+		name := varPattern.FindStringSubmatch(match)[1]
+		if v := vals[name]; v != "" {
+			return v
+		}
+		missing[name] = true
+		return match
+	})
+	if len(missing) == 0 {
+		return out, nil
+	}
+	names := make([]string, 0, len(missing))
+	for n := range missing {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return out, names
+}

--- a/internal/adapters/internal/emit/vars_test.go
+++ b/internal/adapters/internal/emit/vars_test.go
@@ -1,0 +1,99 @@
+package emit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandVars_ReplacesKnownNames(t *testing.T) {
+	vals := map[string]string{"SKILLS_DIR": ".claude/skills", "AGENTS_DIR": ".claude/agents"}
+
+	got, unresolved := ExpandVars("Put skills in {{$SKILLS_DIR}} and profiles in {{$AGENTS_DIR}}.", vals)
+
+	want := "Put skills in .claude/skills and profiles in .claude/agents."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if len(unresolved) != 0 {
+		t.Errorf("expected none unresolved, got %v", unresolved)
+	}
+}
+
+// The $ sigil is what keeps this from eating real content. Warp
+// workflows use {{placeholder}} for arguments, and specs quote
+// Handlebars and Jinja in prose.
+func TestExpandVars_LeavesSigillessBracesAlone(t *testing.T) {
+	body := "Run with {{branch}} and {{ .Values.name }} and {%raw%}."
+
+	got, unresolved := ExpandVars(body, map[string]string{"SKILLS_DIR": ".claude/skills"})
+
+	if got != body {
+		t.Errorf("non-variable braces must survive verbatim:\ngot  %q\nwant %q", got, body)
+	}
+	if len(unresolved) != 0 {
+		t.Errorf("expected none unresolved, got %v", unresolved)
+	}
+}
+
+// A target with no surface for a variable keeps the token verbatim
+// instead of collapsing to an empty string, which would silently turn
+// "see {{$COMMANDS_DIR}}" into "see ".
+func TestExpandVars_UnknownNameStaysLiteralAndIsReported(t *testing.T) {
+	got, unresolved := ExpandVars("see {{$COMMANDS_DIR}} now", map[string]string{"SKILLS_DIR": ".claude/skills"})
+
+	if !strings.Contains(got, "{{$COMMANDS_DIR}}") {
+		t.Errorf("unresolved variable must stay literal, got %q", got)
+	}
+	if len(unresolved) != 1 || unresolved[0] != "COMMANDS_DIR" {
+		t.Errorf("expected COMMANDS_DIR reported, got %v", unresolved)
+	}
+}
+
+// An empty value means the target declares the surface but has it
+// switched off (an unset opt-in dir). Treat it like a missing one.
+func TestExpandVars_EmptyValueIsUnresolved(t *testing.T) {
+	got, unresolved := ExpandVars("see {{$COMMANDS_DIR}}", map[string]string{"COMMANDS_DIR": ""})
+
+	if !strings.Contains(got, "{{$COMMANDS_DIR}}") {
+		t.Errorf("empty value must not blank the token, got %q", got)
+	}
+	if len(unresolved) != 1 {
+		t.Errorf("expected COMMANDS_DIR reported, got %v", unresolved)
+	}
+}
+
+func TestExpandVars_ReportsEachUnresolvedNameOnce(t *testing.T) {
+	_, unresolved := ExpandVars("{{$A}} {{$A}} {{$B}}", nil)
+
+	if len(unresolved) != 2 {
+		t.Fatalf("expected 2 distinct names, got %v", unresolved)
+	}
+	if unresolved[0] != "A" || unresolved[1] != "B" {
+		t.Errorf("expected sorted distinct names, got %v", unresolved)
+	}
+}
+
+func TestExpandVars_NoVariablesReturnsInputUnchanged(t *testing.T) {
+	body := "plain body with no variables"
+
+	got, unresolved := ExpandVars(body, map[string]string{"SKILLS_DIR": ".claude/skills"})
+
+	if got != body || len(unresolved) != 0 {
+		t.Errorf("got %q / %v, want unchanged", got, unresolved)
+	}
+}
+
+// Lowercase is not the documented spelling, so it must not resolve.
+// Otherwise two spellings would drift into meaning the same thing.
+func TestExpandVars_IgnoresLowercaseNames(t *testing.T) {
+	body := "see {{$skills_dir}}"
+
+	got, unresolved := ExpandVars(body, map[string]string{"SKILLS_DIR": ".claude/skills"})
+
+	if got != body {
+		t.Errorf("lowercase must not resolve, got %q", got)
+	}
+	if len(unresolved) != 0 {
+		t.Errorf("lowercase is not a variable at all, got %v", unresolved)
+	}
+}

--- a/internal/adapters/vars.go
+++ b/internal/adapters/vars.go
@@ -1,0 +1,170 @@
+package adapters
+
+import (
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// targetVarPaths declares, per target, the directory or file each spec
+// variable resolves to. A kind is listed only when the target has a
+// dedicated surface for it. Several targets flatten agents into their
+// rules directory with a filename prefix (antigravity, continue, trae,
+// windsurf) or render them as commands (gemini); naming those
+// AGENTS_DIR would point users at a directory that is not an agents
+// directory, so they are left out and the variable stays unresolved.
+//
+// TestTargetVarPaths_MatchRealEmission keeps this honest: every entry
+// here must be where the adapter actually writes that kind.
+var targetVarPaths = map[string]map[string]string{
+	"claude": {
+		emit.VarSkillsDir: ".claude/skills", emit.VarAgentsDir: ".claude/agents",
+		emit.VarCommandsDir: ".claude/commands", emit.VarRulesDir: ".claude/rules",
+		emit.VarMCPFile: ".mcp.json",
+	},
+	"codex": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarAgentsDir: ".codex/agents",
+		emit.VarMCPFile: ".codex/config.toml",
+	},
+	"gemini": {
+		emit.VarSkillsDir: ".gemini/skills", emit.VarCommandsDir: ".gemini/commands",
+		emit.VarMCPFile: ".gemini/settings.json",
+	},
+	"cursor": {
+		emit.VarSkillsDir: ".cursor/skills", emit.VarAgentsDir: ".cursor/agents",
+		emit.VarCommandsDir: ".cursor/commands", emit.VarRulesDir: ".cursor/rules",
+		emit.VarMCPFile: ".cursor/mcp.json",
+	},
+	"copilot": {
+		emit.VarSkillsDir: ".github/skills", emit.VarAgentsDir: ".github/agents",
+		emit.VarRulesDir: ".github/instructions", emit.VarMCPFile: ".vscode/mcp.json",
+	},
+	"cline": {
+		emit.VarSkillsDir: ".cline/skills", emit.VarAgentsDir: ".cline/agents",
+		emit.VarRulesDir: ".cline/rules",
+	},
+	"windsurf": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarRulesDir: ".devin/rules",
+		emit.VarMCPFile: ".devin/mcp_config.json",
+	},
+	"continue": {
+		emit.VarRulesDir: ".continue/rules",
+	},
+	// No COMMANDS_DIR: Amp documents no file surface for commands, so
+	// the adapter skips that kind with a warning (#553).
+	"amp": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarMCPFile: ".amp/settings.json",
+	},
+	"zed": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarMCPFile: ".zed/settings.json",
+	},
+	"warp": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarMCPFile: ".warp/.mcp.json",
+	},
+	"opencode": {
+		emit.VarSkillsDir: ".opencode/skills", emit.VarAgentsDir: ".opencode/agents",
+		emit.VarCommandsDir: ".opencode/commands", emit.VarMCPFile: "opencode.json",
+	},
+	"antigravity": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarRulesDir: ".agents/rules",
+		emit.VarMCPFile: ".agents/mcp_config.json",
+	},
+	"junie": {
+		emit.VarSkillsDir: ".junie/skills", emit.VarAgentsDir: ".junie/agents",
+		emit.VarCommandsDir: ".junie/commands", emit.VarMCPFile: ".junie/mcp/mcp.json",
+	},
+	"kiro": {
+		emit.VarAgentsDir: ".kiro/agents", emit.VarRulesDir: ".kiro/steering",
+		emit.VarMCPFile: ".kiro/settings/mcp.json",
+	},
+	"crush": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarMCPFile: "crush.json",
+	},
+	"trae": {
+		emit.VarSkillsDir: ".trae/skills", emit.VarCommandsDir: ".trae/commands",
+		emit.VarRulesDir: ".trae/rules", emit.VarMCPFile: ".trae/mcp.json",
+	},
+	"augment": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarAgentsDir: ".augment/agents",
+		emit.VarRulesDir: ".augment/rules",
+	},
+	"qoder": {
+		emit.VarSkillsDir: ".qoder/skills", emit.VarAgentsDir: ".qoder/agents",
+		emit.VarRulesDir: ".qoder/rules", emit.VarMCPFile: ".mcp.json",
+	},
+	"openhands": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarMCPFile: "config.toml",
+	},
+	"factory": {
+		emit.VarAgentsDir: ".factory/droids", emit.VarMCPFile: ".factory/mcp.json",
+	},
+	"kilo": {
+		emit.VarSkillsDir: ".agents/skills", emit.VarAgentsDir: ".kilo/agents",
+		emit.VarRulesDir: ".kilo/rules", emit.VarMCPFile: "kilo.jsonc",
+	},
+	// aider, jules, and goose carry every spec kind in one entry-point
+	// document and have no per-kind directory to point at.
+	"aider": {},
+	"jules": {},
+	"goose": {},
+}
+
+// varsFor resolves the variable table for target, letting an
+// outputs.<target>.<field> override win over the declared default so a
+// spec body and the emitted tree never disagree about where files land.
+func varsFor(cfg *config.Config, target string) map[string]string {
+	declared := targetVarPaths[target]
+	if len(declared) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(declared))
+	for name, fallback := range declared {
+		switch name {
+		case emit.VarSkillsDir:
+			out[name] = emit.OutputSkillsDir(cfg, target, fallback)
+		case emit.VarAgentsDir:
+			out[name] = emit.OutputAgentsDir(cfg, target, fallback)
+		case emit.VarCommandsDir:
+			out[name] = emit.OutputCommandsDir(cfg, target, fallback)
+		case emit.VarRulesDir:
+			out[name] = emit.OutputRulesDir(cfg, target, fallback)
+		case emit.VarMCPFile:
+			out[name] = emit.OutputMCPFile(cfg, target, fallback)
+		}
+	}
+	return out
+}
+
+// expandBundleVars returns b with every entry body expanded for target.
+// Entries are copied, so the caller's bundle is untouched and each
+// target expands the same source spec to its own paths.
+func expandBundleVars(b spec.Bundle, cfg *config.Config, target string) spec.Bundle {
+	vals := varsFor(cfg, target)
+	unresolved := map[string]bool{}
+	expand := func(entries []spec.Entry) []spec.Entry {
+		if len(entries) == 0 {
+			return entries
+		}
+		out := make([]spec.Entry, len(entries))
+		copy(out, entries)
+		for i := range out {
+			body, missing := emit.ExpandVars(out[i].Body, vals)
+			out[i].Body = body
+			for _, name := range missing {
+				unresolved[name] = true
+			}
+		}
+		return out
+	}
+	b.Agents = expand(b.Agents)
+	b.Skills = expand(b.Skills)
+	b.Rules = expand(b.Rules)
+	b.Commands = expand(b.Commands)
+	b.Hooks = expand(b.Hooks)
+	b.Reviews = expand(b.Reviews)
+	for name := range unresolved {
+		emit.NoteFieldNoOp(target, spec.KindRule, "{{$"+name+"}}", 1,
+			"this target has no surface for that path, so the variable is left verbatim rather than blanked")
+	}
+	return b
+}

--- a/internal/adapters/vars.go
+++ b/internal/adapters/vars.go
@@ -140,8 +140,11 @@ func varsFor(cfg *config.Config, target string) map[string]string {
 // target expands the same source spec to its own paths.
 func expandBundleVars(b spec.Bundle, cfg *config.Config, target string) spec.Bundle {
 	vals := varsFor(cfg, target)
-	unresolved := map[string]bool{}
-	expand := func(entries []spec.Entry) []spec.Entry {
+	// Count entries per unresolved variable so the coverage note says
+	// how much of the project is affected, not just that it happened.
+	unresolved := map[string]int{}
+	kindOf := map[string]spec.Kind{}
+	expand := func(entries []spec.Entry, kind spec.Kind) []spec.Entry {
 		if len(entries) == 0 {
 			return entries
 		}
@@ -151,19 +154,28 @@ func expandBundleVars(b spec.Bundle, cfg *config.Config, target string) spec.Bun
 			body, missing := emit.ExpandVars(out[i].Body, vals)
 			out[i].Body = body
 			for _, name := range missing {
-				unresolved[name] = true
+				unresolved[name]++
+				if _, seen := kindOf[name]; !seen {
+					kindOf[name] = kind
+				}
 			}
 		}
 		return out
 	}
-	b.Agents = expand(b.Agents)
-	b.Skills = expand(b.Skills)
-	b.Rules = expand(b.Rules)
-	b.Commands = expand(b.Commands)
-	b.Hooks = expand(b.Hooks)
-	b.Reviews = expand(b.Reviews)
-	for name := range unresolved {
-		emit.NoteFieldNoOp(target, spec.KindRule, "{{$"+name+"}}", 1,
+	// Every kind that carries a body. Skipping some would make the
+	// feature's reach depend on which kind a user happened to write in.
+	b.Agents = expand(b.Agents, spec.KindAgent)
+	b.Skills = expand(b.Skills, spec.KindSkill)
+	b.Rules = expand(b.Rules, spec.KindRule)
+	b.Commands = expand(b.Commands, spec.KindCommand)
+	b.Hooks = expand(b.Hooks, spec.KindHook)
+	b.Reviews = expand(b.Reviews, spec.KindReview)
+	b.Settings = expand(b.Settings, spec.KindSettings)
+	b.Environments = expand(b.Environments, spec.KindEnvironment)
+	b.Ignores = expand(b.Ignores, spec.KindIgnore)
+	b.MCPs = expand(b.MCPs, spec.KindMCP)
+	for name, count := range unresolved {
+		emit.NoteFieldNoOp(target, kindOf[name], "{{$"+name+"}}", count,
 			"this target has no surface for that path, so the variable is left verbatim rather than blanked")
 	}
 	return b

--- a/internal/adapters/vars_integration_test.go
+++ b/internal/adapters/vars_integration_test.go
@@ -1,0 +1,64 @@
+package adapters
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// The point of the feature: one spec body, different paths per target.
+func TestExpandBundleVars_ResolvesPerTarget(t *testing.T) {
+	body := "Put new skills in {{$SKILLS_DIR}}."
+	for target, want := range map[string]string{
+		"claude":  "Put new skills in .claude/skills.",
+		"codex":   "Put new skills in .agents/skills.",
+		"copilot": "Put new skills in .github/skills.",
+		"trae":    "Put new skills in .trae/skills.",
+	} {
+		b := spec.NewBundle([]spec.Entry{{Kind: spec.KindRule, Name: "r", Body: body}})
+		got := expandBundleVars(b, &config.Config{}, target).Rules[0].Body
+		if got != want {
+			t.Errorf("%s: got %q, want %q", target, got, want)
+		}
+	}
+}
+
+// A config override must win, or the spec body would name a directory
+// the tree does not use.
+func TestExpandBundleVars_HonorsOutputOverride(t *testing.T) {
+	cfg := &config.Config{
+		Outputs: map[string]config.Output{"claude": {SkillsDir: "custom/skills"}},
+	}
+	b := spec.NewBundle([]spec.Entry{{Kind: spec.KindRule, Name: "r", Body: "see {{$SKILLS_DIR}}"}})
+
+	if got := expandBundleVars(b, cfg, "claude").Rules[0].Body; got != "see custom/skills" {
+		t.Errorf("override ignored, got %q", got)
+	}
+}
+
+// Expansion must not mutate the caller's bundle, or the first target
+// synced would freeze its paths into every later target's output.
+func TestExpandBundleVars_DoesNotMutateSource(t *testing.T) {
+	body := "see {{$SKILLS_DIR}}"
+	b := spec.NewBundle([]spec.Entry{{Kind: spec.KindRule, Name: "r", Body: body}})
+
+	expandBundleVars(b, &config.Config{}, "claude")
+
+	if b.Rules[0].Body != body {
+		t.Errorf("source bundle mutated: %q", b.Rules[0].Body)
+	}
+	if got := expandBundleVars(b, &config.Config{}, "codex").Rules[0].Body; !strings.Contains(got, ".agents/skills") {
+		t.Errorf("second target expanded from a mutated source: %q", got)
+	}
+}
+
+// A target with no surface keeps the token rather than blanking it.
+func TestExpandBundleVars_UnsupportedTargetKeepsToken(t *testing.T) {
+	b := spec.NewBundle([]spec.Entry{{Kind: spec.KindRule, Name: "r", Body: "see {{$SKILLS_DIR}}"}})
+
+	if got := expandBundleVars(b, &config.Config{}, "jules").Rules[0].Body; got != "see {{$SKILLS_DIR}}" {
+		t.Errorf("expected the token verbatim, got %q", got)
+	}
+}

--- a/internal/adapters/vars_parity_test.go
+++ b/internal/adapters/vars_parity_test.go
@@ -1,0 +1,80 @@
+package adapters
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/adapters/internal/emit"
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// A declared variable must name the place the adapter actually writes
+// that kind. Without this, targetVarPaths is a second copy of every
+// adapter's path constants and drifts the first time one moves.
+func TestTargetVarPaths_MatchRealEmission(t *testing.T) {
+	probes := map[string]spec.Entry{
+		emit.VarSkillsDir:   {Kind: spec.KindSkill, Name: "probe", Path: "skills/probe/SKILL.md", Body: "b"},
+		emit.VarAgentsDir:   {Kind: spec.KindAgent, Name: "probe", Path: "agents/probe.md", Body: "b"},
+		emit.VarCommandsDir: {Kind: spec.KindCommand, Name: "probe", Path: "commands/probe.md", Body: "b"},
+		emit.VarRulesDir:    {Kind: spec.KindRule, Name: "probe", Path: "rules/probe.md", Body: "b"},
+		emit.VarMCPFile:     {Kind: spec.KindMCP, Name: "probe", Meta: map[string]any{"command": "x"}},
+	}
+
+	for target, declared := range targetVarPaths {
+		adapter, err := Resolve(target)
+		if err != nil {
+			t.Errorf("%s: declared in targetVarPaths but not a registered target", target)
+			continue
+		}
+		for name, want := range declared {
+			sess := NewSession()
+			sess.StartCapture()
+			bundle := spec.NewBundle([]spec.Entry{probes[name]})
+			if err := EmitWithProvenance(sess, adapter, bundle, &config.Config{}, true); err != nil {
+				sess.StopCapture()
+				t.Errorf("%s/%s: emit failed: %v", target, name, err)
+				continue
+			}
+			var paths []string
+			for _, f := range sess.StopCapture() {
+				paths = append(paths, f.Path)
+			}
+			if !writesUnder(paths, name, want) {
+				t.Errorf("%s declares %s=%q but emits that kind to %v", target, name, want, paths)
+			}
+		}
+	}
+}
+
+// writesUnder reports whether want is where the kind actually landed:
+// the containing directory for a *_DIR variable, the file itself for
+// MCP_FILE.
+func writesUnder(paths []string, name, want string) bool {
+	for _, p := range paths {
+		if name == emit.VarMCPFile {
+			if p == want {
+				return true
+			}
+			continue
+		}
+		dir := filepath.ToSlash(filepath.Dir(p))
+		// A skill folder is <dir>/<name>/SKILL.md, one level deeper.
+		if dir == want || strings.HasPrefix(dir+"/", want+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// Every registered target needs an entry, even an empty one, so adding
+// an adapter forces a decision about its variables instead of silently
+// leaving every variable unresolved there.
+func TestTargetVarPaths_CoverEveryRegisteredTarget(t *testing.T) {
+	for _, target := range Names() {
+		if _, ok := targetVarPaths[target]; !ok {
+			t.Errorf("%s has no targetVarPaths entry; add one (empty is fine when the target has no per-kind dirs)", target)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- A spec that wants to say "put new skills here" had to hardcode one tool's layout. `{{$SKILLS_DIR}}` now expands to `.claude/skills` for claude, `.agents/skills` for codex, and `.github/skills` for copilot, from one source file. Same for `{{$AGENTS_DIR}}`, `{{$COMMANDS_DIR}}`, `{{$RULES_DIR}}`, `{{$MCP_FILE}}`.
- Expansion happens once in `EmitWithProvenance`, so every adapter receives an already-expanded bundle and no adapter needed changing.
- An `outputs.<target>.<field>` override wins, so a body never names a directory the emitted tree does not use.

## Design decisions

The issue left the syntax open ("or whatever string"), so three choices are worth calling out:

- **The `$` sigil is required.** Warp workflows use `{{placeholder}}` for arguments and specs quote Handlebars and Jinja in prose, so bare braces must survive untouched.
- **An unresolved variable keeps its token** rather than collapsing to an empty string, which would silently turn `see {{$COMMANDS_DIR}}` into `see `. It raises a coverage note instead.
- **A variable is declared only where the target has a real surface for that kind.** Several targets flatten agents into their rules directory with a filename prefix (antigravity, continue, trae, windsurf) and gemini renders them as commands; naming those `AGENTS_DIR` would point users at a directory that is not one.

## On the path table

`targetVarPaths` is necessarily a second copy of each adapter's private path constants, which is exactly the kind of thing that drifts. `TestTargetVarPaths_MatchRealEmission` emits a probe spec per target and asserts every declared path is where that kind actually lands. It caught amp declaring a commands directory it has no file surface for (#553) on its first run.

A second test requires every registered target to have an entry, so a new adapter forces a decision instead of silently resolving nothing.

## Test plan

- [x] `go test ./...`
- [x] `agnostic-ai sync --check`

Closes #616