### PR TITLE
fix(cli): fail on reported problems instead of exiting 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `lint` flags frontmatter keys that near-miss a key agnostic-ai owns (`allowed_tools`, `allowedTools`, `allowed-tools`, `disallowed_tools`, `max_turns`, `model_name`). Such a key parses, emits, and does nothing, so a tool restriction can look set while the agent runs unrestricted. Warn severity, so `lint --strict` gates it; the message suggests moving a genuinely target-native key under `x-<target>` (#617).
+
+### Changed
+
+- `validate` exits 1 when it reports any issue, and `doctor --check-globs` exits 1 when a rule's globs match no files. Both printed the problem and exited 0 before, so a CI step could not gate on either: one project sat 24 versions behind with 23 invalid specs and a green pipeline for months (#617).
+
+### Added
+
 - Path variables in spec bodies: `{{$SKILLS_DIR}}`, `{{$AGENTS_DIR}}`, `{{$COMMANDS_DIR}}`, `{{$RULES_DIR}}`, and `{{$MCP_FILE}}` expand to each target's own location, so one spec can say where files go without hardcoding one tool's layout. An `outputs.<target>.<field>` override wins, and a variable a target has no surface for is left verbatim with a coverage note rather than blanked (#616).
 
 ### Added

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -231,12 +231,15 @@ func newDoctorCmd() *cobra.Command {
 			hasDrift := printDrift(reports)
 
 			// 4b. Optional: globs that match nothing in the working tree.
+			unloadableRules := 0
 			if checkGlobs {
 				cmd.Println()
 				cmd.Println("Glob coverage:")
-				if err := reportUnmatchedGlobs(cmd, "."); err != nil {
+				n, err := reportUnmatchedGlobs(cmd, ".")
+				if err != nil {
 					return err
 				}
+				unloadableRules = n
 			}
 
 			// 5. MCP resolution
@@ -252,6 +255,12 @@ func newDoctorCmd() *cobra.Command {
 			// 6. Next step
 			doctorNextStep(cmd, hasDrift, true)
 
+			// A rule whose globs match nothing never loads, so it
+			// silently does not exist. Reported before, but exit 0 meant
+			// no CI step could gate on it (#617).
+			if unloadableRules > 0 {
+				return fmt.Errorf("%d rule(s) have a glob matching no files and will never load", unloadableRules)
+			}
 			if hasDrift {
 				if !fix {
 					return fmt.Errorf("drift detected. run `agnostic-ai sync` to reconcile, or `agnostic-ai doctor --fix`")

--- a/internal/cli/check_globs.go
+++ b/internal/cli/check_globs.go
@@ -20,10 +20,10 @@ import (
 // matches anything except `/`. Multiple comma-separated patterns are
 // split and checked independently; a rule passes when ANY pattern
 // matches at least one file in the working tree.
-func reportUnmatchedGlobs(cmd *cobra.Command, root string) error {
+func reportUnmatchedGlobs(cmd *cobra.Command, root string) (int, error) {
 	_, b, err := loadProject(root)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	var unmatched []ruleGlob
 	for _, r := range b.Rules {
@@ -37,7 +37,7 @@ func reportUnmatchedGlobs(cmd *cobra.Command, root string) error {
 		}
 		matched, err := anyGlobMatches(root, patterns)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		if !matched {
 			unmatched = append(unmatched, ruleGlob{name: r.Name, globs: raw})
@@ -45,7 +45,7 @@ func reportUnmatchedGlobs(cmd *cobra.Command, root string) error {
 	}
 	if len(unmatched) == 0 {
 		cmd.Println("  ✓ every rule's `globs:` pattern matches at least one file")
-		return nil
+		return 0, nil
 	}
 	sort.Slice(unmatched, func(i, j int) bool { return unmatched[i].name < unmatched[j].name })
 	cmd.Printf("  ! %d rule(s) with no matching files in repo (rule will never load):\n", len(unmatched))
@@ -53,7 +53,7 @@ func reportUnmatchedGlobs(cmd *cobra.Command, root string) error {
 		cmd.Printf("      %s (globs: %s)\n", u.name, u.globs)
 	}
 	cmd.Println("    fix: update the rule's `globs:` or remove the rule")
-	return nil
+	return len(unmatched), nil
 }
 
 type ruleGlob struct {

--- a/internal/cli/exit_codes_test.go
+++ b/internal/cli/exit_codes_test.go
@@ -39,22 +39,11 @@ func newProject(t *testing.T) string {
 	return dir
 }
 
-func writeSpec(t *testing.T, dir, rel, body string) {
-	t.Helper()
-	path := filepath.Join(dir, rel)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestValidate_ExitsNonZeroWhenIssuesFound(t *testing.T) {
 	dir := newProject(t)
 	// A hook with no event: reported today, and exits 0 today. `name:`
 	// is deliberately optional on markdown specs, so it is not an issue.
-	writeSpec(t, dir, ".agnostic-ai/hooks/broken.yaml", "command: echo hi\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai/hooks/broken.yaml"), "command: echo hi\n")
 
 	out, err := runCLI(t, "validate")
 
@@ -68,7 +57,7 @@ func TestValidate_ExitsNonZeroWhenIssuesFound(t *testing.T) {
 
 func TestValidate_ExitsZeroWhenClean(t *testing.T) {
 	dir := newProject(t)
-	writeSpec(t, dir, ".agnostic-ai/rules/ok.md", "---\ndescription: fine\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai/rules/ok.md"), "---\ndescription: fine\n---\nbody\n")
 
 	if _, err := runCLI(t, "validate"); err != nil {
 		t.Errorf("a clean project must still exit 0: %v", err)
@@ -79,7 +68,7 @@ func TestValidate_ExitsZeroWhenClean(t *testing.T) {
 // something behind is not.
 func TestValidate_FixExitsNonZeroOnlyWhenIssuesRemain(t *testing.T) {
 	dir := newProject(t)
-	writeSpec(t, dir, ".agnostic-ai/rules/ok.md", "---\ndescription: fine\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai/rules/ok.md"), "---\ndescription: fine\n---\nbody\n")
 
 	if _, err := runCLI(t, "validate", "--fix"); err != nil {
 		t.Errorf("nothing to fix must exit 0: %v", err)
@@ -88,7 +77,7 @@ func TestValidate_FixExitsNonZeroOnlyWhenIssuesRemain(t *testing.T) {
 
 func TestDoctorCheckGlobs_ExitsNonZeroOnRuleThatNeverLoads(t *testing.T) {
 	dir := newProject(t)
-	writeSpec(t, dir, ".agnostic-ai/rules/bad.md",
+	writeFile(t, filepath.Join(dir, ".agnostic-ai/rules/bad.md"),
 		"---\ndescription: d\nglobs: does-not-exist/**\n---\nbody\n")
 
 	out, err := runCLI(t, "doctor", "--check-globs")
@@ -109,8 +98,8 @@ func TestDoctorCheckGlobs_ExitsNonZeroOnRuleThatNeverLoads(t *testing.T) {
 // The same run with every glob matching must not fail on globs.
 func TestDoctorCheckGlobs_ExitsZeroWhenEveryGlobMatches(t *testing.T) {
 	dir := newProject(t)
-	writeSpec(t, dir, "README.md", "# readme\n")
-	writeSpec(t, dir, ".agnostic-ai/rules/good.md",
+	writeFile(t, filepath.Join(dir, "README.md"), "# readme\n")
+	writeFile(t, filepath.Join(dir, ".agnostic-ai/rules/good.md"),
 		"---\ndescription: d\nglobs: '*.md'\n---\nbody\n")
 
 	_, err := runCLI(t, "doctor", "--check-globs")

--- a/internal/cli/exit_codes_test.go
+++ b/internal/cli/exit_codes_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/testutil"
+)
+
+// runCLI executes one command against a fresh root and returns its
+// combined output plus the error the process would exit on.
+func runCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(args)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// A reporting command that always exits 0 cannot gate a CI step. These
+// three printed a problem and passed, so a pinned or broken setup sat
+// green for months (#617).
+
+// newProject creates a minimal project with a config file, since every
+// command loads one before it can report anything.
+func newProject(t *testing.T) string {
+	t.Helper()
+	dir := testutil.TempCwd(t)
+	if err := os.WriteFile(filepath.Join(dir, "agnostic-ai.yaml"), []byte("version: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	silence(t)
+	return dir
+}
+
+func writeSpec(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidate_ExitsNonZeroWhenIssuesFound(t *testing.T) {
+	dir := newProject(t)
+	// A hook with no event: reported today, and exits 0 today. `name:`
+	// is deliberately optional on markdown specs, so it is not an issue.
+	writeSpec(t, dir, ".agnostic-ai/hooks/broken.yaml", "command: echo hi\n")
+
+	out, err := runCLI(t, "validate")
+
+	if !strings.Contains(out, "issue(s) found") {
+		t.Fatalf("expected the issue report, got:\n%s", out)
+	}
+	if err == nil {
+		t.Error("validate reported issues and exited 0; CI cannot gate on that")
+	}
+}
+
+func TestValidate_ExitsZeroWhenClean(t *testing.T) {
+	dir := newProject(t)
+	writeSpec(t, dir, ".agnostic-ai/rules/ok.md", "---\ndescription: fine\n---\nbody\n")
+
+	if _, err := runCLI(t, "validate"); err != nil {
+		t.Errorf("a clean project must still exit 0: %v", err)
+	}
+}
+
+// --fix that resolves everything is a success; --fix that leaves
+// something behind is not.
+func TestValidate_FixExitsNonZeroOnlyWhenIssuesRemain(t *testing.T) {
+	dir := newProject(t)
+	writeSpec(t, dir, ".agnostic-ai/rules/ok.md", "---\ndescription: fine\n---\nbody\n")
+
+	if _, err := runCLI(t, "validate", "--fix"); err != nil {
+		t.Errorf("nothing to fix must exit 0: %v", err)
+	}
+}
+
+func TestDoctorCheckGlobs_ExitsNonZeroOnRuleThatNeverLoads(t *testing.T) {
+	dir := newProject(t)
+	writeSpec(t, dir, ".agnostic-ai/rules/bad.md",
+		"---\ndescription: d\nglobs: does-not-exist/**\n---\nbody\n")
+
+	out, err := runCLI(t, "doctor", "--check-globs")
+
+	if !strings.Contains(out, "never load") {
+		t.Fatalf("expected the glob report, got:\n%s", out)
+	}
+	if err == nil {
+		t.Fatal("a rule that can never load reported and exited 0")
+	}
+	// Doctor also fails on sync drift, so pin the reason: without this
+	// the test passes on an unrelated failure.
+	if !strings.Contains(err.Error(), "glob") {
+		t.Errorf("expected the failure to name the glob problem, got: %v", err)
+	}
+}
+
+// The same run with every glob matching must not fail on globs.
+func TestDoctorCheckGlobs_ExitsZeroWhenEveryGlobMatches(t *testing.T) {
+	dir := newProject(t)
+	writeSpec(t, dir, "README.md", "# readme\n")
+	writeSpec(t, dir, ".agnostic-ai/rules/good.md",
+		"---\ndescription: d\nglobs: '*.md'\n---\nbody\n")
+
+	_, err := runCLI(t, "doctor", "--check-globs")
+
+	if err != nil && strings.Contains(err.Error(), "glob") {
+		t.Errorf("every glob matches, so globs must not be the failure: %v", err)
+	}
+}

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -262,28 +262,39 @@ func countSeverity(findings []lintFinding, s lintSeverity) int {
 	return n
 }
 
-// nearMissKeys maps a frontmatter key that looks like one agnostic-ai
-// owns onto the key it was probably meant to be. Passthrough is the
-// right default for genuine extensions, but a near miss of an owned key
-// is not an extension: it parses, emits, and does nothing. Nine
-// phel-lang agents ran with full tool access because `allowed_tools:`
-// passed validate, lint --strict, sync --check and doctor for months
-// (#617).
-var nearMissKeys = map[string]string{
-	"allowed_tools":    "tools",
-	"allowedTools":     "tools",
-	"allowed-tools":    "tools",
-	"disallowed_tools": "tools",
-	"max_turns":        "max-turns",
-	"model_name":       "model",
+// nearMiss describes a frontmatter key that looks like one the tool
+// understands but is read by nothing. Use names the replacement: an
+// agnostic-ai key when one exists, otherwise the x-<target> form that
+// actually reaches the tool.
+type nearMiss struct {
+	Use   string
+	Owned bool
+}
+
+// nearMissKeys is the near-miss set. Passthrough is the right default
+// for genuine extensions, but a near miss of a key the tool owns is not
+// an extension: it parses, emits, and does nothing. Nine phel-lang
+// agents ran with full tool access because `allowed_tools:` passed
+// validate, lint --strict, sync --check and doctor for months (#617).
+//
+// Two of these have no agnostic-ai equivalent at all. `maxTurns` and
+// `disallowedTools` are Junie's own keys, reachable only under
+// `x-junie`, so pointing at a bare agnostic-ai key would send users to
+// one that does not exist.
+var nearMissKeys = map[string]nearMiss{
+	"allowed_tools":    {Use: "tools", Owned: true},
+	"allowedTools":     {Use: "tools", Owned: true},
+	"allowed-tools":    {Use: "tools", Owned: true},
+	"model_name":       {Use: "model", Owned: true},
+	"max_turns":        {Use: "x-junie.maxTurns"},
+	"disallowed_tools": {Use: "x-junie.disallowedTools"},
 }
 
 // lintNearMissKeys flags those keys at the top level of a spec's
 // frontmatter (LINT007, warn). Warn rather than error because a
 // target-native spelling can be legitimate: Junie really does document
-// disallowedTools. The message says to move such a key under
-// x-<target>, which is correct whether the key was a typo or not. Keys
-// already namespaced under x-<target> are deliberate and never flagged.
+// disallowedTools, just not at the top level. Keys already namespaced
+// under x-<target> are deliberate and never flagged.
 func lintNearMissKeys(entries []spec.Entry) []lintFinding {
 	var out []lintFinding
 	for _, e := range entries {
@@ -293,16 +304,20 @@ func lintNearMissKeys(entries []spec.Entry) []lintFinding {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			meant, ok := nearMissKeys[k]
+			miss, ok := nearMissKeys[k]
 			if !ok {
 				continue
+			}
+			advice := fmt.Sprintf("Use `%s:` instead.", miss.Use)
+			if miss.Owned {
+				advice = fmt.Sprintf("Did you mean `%s:`? If it is a target-native key, "+
+					"move it under `x-<target>:` to keep it.", miss.Use)
 			}
 			out = append(out, lintFinding{
 				Code:     "LINT007",
 				Severity: lintWarn,
 				Path:     e.Path,
-				Message: fmt.Sprintf("`%s:` is not a key agnostic-ai reads, so it has no effect. "+
-					"Did you mean `%s:`? If it is a target-native key, move it under `x-<target>:` to keep it.", k, meant),
+				Message:  fmt.Sprintf("`%s:` is not a key agnostic-ai reads, so it has no effect. %s", k, advice),
 			})
 		}
 	}

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -43,7 +44,8 @@ func newLintCmd() *cobra.Command {
 		Short: "Run semantic lint checks on source specs beyond schema validation.",
 		Long: "Checks for empty specs, duplicate names, dead specs (kinds not " +
 			"supported by any enabled target), hooks whose event ignores their " +
-			"matcher, and unterminated frontmatter. Exit code 1 on " +
+			"matcher, unterminated frontmatter, and frontmatter keys that near-miss " +
+			"a key agnostic-ai owns (allowed_tools vs tools). Exit code 1 on " +
 			"error-severity findings, or on warn-severity findings when --strict " +
 			"is set.",
 		Example: `  # Lint all specs
@@ -112,6 +114,7 @@ func collectLintFindings(targets []string, b spec.Bundle) []lintFinding {
 	findings = append(findings, lintDeadSpecs(entries, targets)...)
 	findings = append(findings, lintHookMatcherMisuse(b.Hooks)...)
 	findings = append(findings, lintUnterminatedFrontmatter(entries)...)
+	findings = append(findings, lintNearMissKeys(entries)...)
 	return findings
 }
 
@@ -257,4 +260,51 @@ func countSeverity(findings []lintFinding, s lintSeverity) int {
 		}
 	}
 	return n
+}
+
+// nearMissKeys maps a frontmatter key that looks like one agnostic-ai
+// owns onto the key it was probably meant to be. Passthrough is the
+// right default for genuine extensions, but a near miss of an owned key
+// is not an extension: it parses, emits, and does nothing. Nine
+// phel-lang agents ran with full tool access because `allowed_tools:`
+// passed validate, lint --strict, sync --check and doctor for months
+// (#617).
+var nearMissKeys = map[string]string{
+	"allowed_tools":    "tools",
+	"allowedTools":     "tools",
+	"allowed-tools":    "tools",
+	"disallowed_tools": "tools",
+	"max_turns":        "max-turns",
+	"model_name":       "model",
+}
+
+// lintNearMissKeys flags those keys at the top level of a spec's
+// frontmatter (LINT007, warn). Warn rather than error because a
+// target-native spelling can be legitimate: Junie really does document
+// disallowedTools. The message says to move such a key under
+// x-<target>, which is correct whether the key was a typo or not. Keys
+// already namespaced under x-<target> are deliberate and never flagged.
+func lintNearMissKeys(entries []spec.Entry) []lintFinding {
+	var out []lintFinding
+	for _, e := range entries {
+		keys := make([]string, 0, len(e.Meta))
+		for k := range e.Meta {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			meant, ok := nearMissKeys[k]
+			if !ok {
+				continue
+			}
+			out = append(out, lintFinding{
+				Code:     "LINT007",
+				Severity: lintWarn,
+				Path:     e.Path,
+				Message: fmt.Sprintf("`%s:` is not a key agnostic-ai reads, so it has no effect. "+
+					"Did you mean `%s:`? If it is a target-native key, move it under `x-<target>:` to keep it.", k, meant),
+			})
+		}
+	}
+	return out
 }

--- a/internal/cli/lint_near_miss_test.go
+++ b/internal/cli/lint_near_miss_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+// A near-miss of a key the tool owns is not an extension, it is a typo
+// that silently disarms a setting. Nine phel-lang agents ran with full
+// tool access because `allowed_tools:` parsed, emitted, and did
+// nothing (#617).
+func TestLintNearMissKeys_FlagsAllowedTools(t *testing.T) {
+	entries := []spec.Entry{{
+		Kind: spec.KindAgent, Name: "a", Path: "agents/a.md",
+		Meta: map[string]any{"allowed_tools": []any{"Read"}}, Body: "b",
+	}}
+
+	findings := lintNearMissKeys(entries)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Message, "tools") {
+		t.Errorf("message must name the key it meant: %q", findings[0].Message)
+	}
+	if findings[0].Severity != lintWarn {
+		t.Errorf("expected warn so --strict gates it, got %v", findings[0].Severity)
+	}
+}
+
+func TestLintNearMissKeys_FlagsEveryDocumentedNearMiss(t *testing.T) {
+	for _, key := range []string{"allowed_tools", "allowedTools", "disallowed_tools", "max_turns", "model_name"} {
+		entries := []spec.Entry{{
+			Kind: spec.KindAgent, Name: "a", Path: "agents/a.md",
+			Meta: map[string]any{key: "x"}, Body: "b",
+		}}
+		if got := lintNearMissKeys(entries); len(got) != 1 {
+			t.Errorf("%s: expected a finding, got %v", key, got)
+		}
+	}
+}
+
+// The real key must stay silent, or the rule punishes correct specs.
+func TestLintNearMissKeys_IgnoresCorrectKeys(t *testing.T) {
+	entries := []spec.Entry{{
+		Kind: spec.KindAgent, Name: "a", Path: "agents/a.md",
+		Meta: map[string]any{"tools": []any{"Read"}, "model": "opus", "description": "d"}, Body: "b",
+	}}
+
+	if got := lintNearMissKeys(entries); len(got) != 0 {
+		t.Errorf("correct keys must not be flagged, got %v", got)
+	}
+}
+
+// Passthrough is the right default for genuine extensions. A key under
+// x-<target> is deliberate, including target-native spellings like
+// Junie's real disallowedTools.
+func TestLintNearMissKeys_IgnoresTargetNamespacedKeys(t *testing.T) {
+	entries := []spec.Entry{{
+		Kind: spec.KindAgent, Name: "a", Path: "agents/a.md",
+		Meta: map[string]any{"x-junie": map[string]any{"disallowedTools": []any{"Bash"}}}, Body: "b",
+	}}
+
+	if got := lintNearMissKeys(entries); len(got) != 0 {
+		t.Errorf("x-<target> keys are deliberate, got %v", got)
+	}
+}
+
+// An unrelated custom key is a genuine extension, not a near miss.
+func TestLintNearMissKeys_IgnoresUnrelatedKeys(t *testing.T) {
+	entries := []spec.Entry{{
+		Kind: spec.KindAgent, Name: "a", Path: "agents/a.md",
+		Meta: map[string]any{"owner": "platform-team"}, Body: "b",
+	}}
+
+	if got := lintNearMissKeys(entries); len(got) != 0 {
+		t.Errorf("unknown keys pass through by design, got %v", got)
+	}
+}
+
+// The rule has to be wired in, not merely defined.
+func TestCollectLintFindings_IncludesNearMissKeys(t *testing.T) {
+	b := spec.NewBundle([]spec.Entry{{
+		Kind: spec.KindAgent, Name: "a", Path: "agents/a.md",
+		Meta: map[string]any{"allowed_tools": []any{"Read"}}, Body: "b",
+	}})
+
+	var found bool
+	for _, f := range collectLintFindings([]string{"claude"}, b) {
+		if strings.Contains(f.Message, "allowed_tools") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("lint must report the near-miss key; a rule nobody calls fixes nothing")
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -18,7 +18,9 @@ func newValidateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate agnostic specs.",
-		Example: `  # Parse every spec, list any issues
+		Long: "Parses every spec and reports problems. Exit code 1 when any " +
+			"issue is reported, so a CI step can gate on it.",
+		Example: `  # Parse every spec, list any issues (exit 1 if any)
   agnostic-ai validate
 
   # Reconcile autofixable issues in source spec files
@@ -37,7 +39,7 @@ func newValidateCmd() *cobra.Command {
 			if len(entries) == 0 {
 				reportIssues(cmd, sourceIssues)
 				cmd.PrintErrln(emptySpecsHint)
-				return nil
+				return issuesError(sourceIssues)
 			}
 			issues := lintEntries(entries)
 			issues = append(issues, lintHookEvents(entries, cfg.Targets)...)
@@ -45,7 +47,7 @@ func newValidateCmd() *cobra.Command {
 			issues = append(issues, sourceIssues...)
 			if !fix {
 				reportIssues(cmd, issues)
-				return nil
+				return issuesError(issues)
 			}
 			fixed, remaining, err := applyFixes(issues)
 			if err != nil {
@@ -58,7 +60,7 @@ func newValidateCmd() *cobra.Command {
 					cmd.Printf("    %s: %s\n", i.Path, i.Message)
 				}
 			}
-			return nil
+			return issuesError(remaining)
 		},
 	}
 	cmd.Flags().BoolVar(&fix, "fix", false, "Apply autofixable issues by rewriting source spec files")
@@ -72,6 +74,17 @@ func newValidateCmd() *cobra.Command {
 func lintEntries(entries []spec.Entry) []validationIssue {
 	var out []validationIssue
 	return out
+}
+
+// issuesError turns a non-empty issue list into the command's exit
+// status. A reporting command that always exits 0 cannot gate a CI
+// step: a project pinned 24 versions behind printed 23 invalid specs
+// and stayed green for months (#617).
+func issuesError(issues []validationIssue) error {
+	if len(issues) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d spec issue(s) found", len(issues))
 }
 
 // reportIssues prints the issue list to the command's stdout. An empty

--- a/internal/cli/validate_native_test.go
+++ b/internal/cli/validate_native_test.go
@@ -22,8 +22,10 @@ func TestValidate_FlagsUnknownHookEvent(t *testing.T) {
 	out := &bytes.Buffer{}
 	root.SetOut(out)
 	root.SetErr(&bytes.Buffer{})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("validate: %v", err)
+	// validate exits non-zero once it reports an issue (#617); these
+	// fixtures all carry one on purpose.
+	if err := root.Execute(); err == nil {
+		t.Error("validate reported an issue and exited 0")
 	}
 	got := out.String()
 	if !strings.Contains(got, "unknown hook event") {
@@ -50,6 +52,7 @@ func TestValidate_AcceptsKnownHookEvent(t *testing.T) {
 	out := &bytes.Buffer{}
 	root.SetOut(out)
 	root.SetErr(&bytes.Buffer{})
+	// This fixture is clean, so validate must still exit 0.
 	if err := root.Execute(); err != nil {
 		t.Fatalf("validate: %v", err)
 	}
@@ -75,6 +78,7 @@ func TestValidate_HookEventGeminiSubsetUnknownToClaude(t *testing.T) {
 	out := &bytes.Buffer{}
 	root.SetOut(out)
 	root.SetErr(&bytes.Buffer{})
+	// This fixture is clean, so validate must still exit 0.
 	if err := root.Execute(); err != nil {
 		t.Fatalf("validate: %v", err)
 	}
@@ -160,8 +164,10 @@ func TestValidate_OrphanHookKindWarning(t *testing.T) {
 	out := &bytes.Buffer{}
 	root.SetOut(out)
 	root.SetErr(&bytes.Buffer{})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("validate: %v", err)
+	// validate exits non-zero once it reports an issue (#617); these
+	// fixtures all carry one on purpose.
+	if err := root.Execute(); err == nil {
+		t.Error("validate reported an issue and exited 0")
 	}
 	got := out.String()
 	if !strings.Contains(got, "no enabled target supports hooks") {
@@ -218,8 +224,10 @@ func TestValidate_MissingHookEventField(t *testing.T) {
 	out := &bytes.Buffer{}
 	root.SetOut(out)
 	root.SetErr(&bytes.Buffer{})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("validate: %v", err)
+	// validate exits non-zero once it reports an issue (#617); these
+	// fixtures all carry one on purpose.
+	if err := root.Execute(); err == nil {
+		t.Error("validate reported an issue and exited 0")
 	}
 	got := out.String()
 	if !strings.Contains(got, "missing required 'event:' field") {


### PR DESCRIPTION
## Summary

Three commands printed a problem and passed, so no CI step could gate on any of them.

- **`validate` exits 1** when it reports an issue, including the no-specs-loaded path. That is exactly the pinned-version case from the issue comment: 23 invalid specs reported on every run, pipeline green for months. With `--fix` it exits on what remains unfixed, so a run that resolves everything still succeeds.
- **`doctor --check-globs` exits 1** when a rule's globs match no files. That rule never loads, so it silently does not exist.
- **`lint` gains LINT007** for frontmatter keys that near-miss a key the tool owns. Nine phel-lang agents ran with full tool access because `allowed_tools:` parsed, emitted into `.claude/agents/`, and did nothing. `lint` already exits non-zero on warnings under `--strict`, so this gets the gate for free.

## Why LINT007 is warn, not error

A target-native spelling can be legitimate: Junie really does document `disallowedTools`, just not at the top level. Keys already under `x-<target>` are deliberate and never flagged, so passthrough stays the default for genuine extensions.

The advice distinguishes two cases, because two of the near-misses have no agnostic-ai equivalent at all:

```
`allowed_tools:` is not a key agnostic-ai reads, so it has no effect.
  Did you mean `tools:`? If it is a target-native key, move it under `x-<target>:` to keep it.

`max_turns:` is not a key agnostic-ai reads, so it has no effect.
  Use `x-junie.maxTurns:` instead.
```

## Breaking

This is a deliberate behavior change. A pipeline that was green only because `validate` could not fail will now go red. That is the point of the issue. Five existing tests asserted the old exit-0 contract and were updated; the two that assert a clean project still expect exit 0.

## Test plan

- [x] `go test ./...`
- [x] `agnostic-ai sync --check`
- [x] This repository's own `validate` still exits 0

Closes #617