### PR TITLE
docs(target-audit): file issues by default and make them workable

### DIFF
--- a/.agnostic-ai/skills/target-audit/SKILL.md
+++ b/.agnostic-ai/skills/target-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: target-audit
 description: Audit every agnostic-ai target against its vendor's current docs and report evidence-backed drift. Use for the recurring "are our adapters still true?" check, or when one tool ships a new surface.
-argument-hint: "[target...] [--file-issues]"
+argument-hint: "[target...] [--no-file-issues]"
 disable-model-invocation: false
 ---
 
@@ -17,12 +17,21 @@ skill finds that drift on a schedule instead of via a user bug report.
 
 ## Arguments
 
-- no args: audit every registered target
+- no args: audit every registered target **and file an issue per confirmed
+  finding**. Filing is the default, not an opt-in.
 - `claude zed kilo`: audit only those
-- `--file-issues`: also open one GitHub issue per confirmed finding.
-  Without it, the run stops at the report.
-- `--fix`: implies `--file-issues`, then opens a PR per fix bucket.
-  Never merges.
+- `--no-file-issues`: stop at the report. Use it for a scratch run you do
+  not intend to act on.
+- `--fix`: file issues, then open a PR per fix bucket. Never merges.
+
+**Why filing is the default.** It used to be opt-in, and two consecutive
+runs proved that wrong. The 2026-08-19 run found 52 findings and filed
+none. The 2026-08-27 run found 54 and filed none until a human asked, by
+which point it was re-verifying the previous run's backlog instead of
+auditing. The report lands in gitignored `local/`, so a run that does not
+file leaves **nothing** behind: no tracked work, no dedupe set for the
+next run, and a fresh re-derivation of the same findings a week later.
+A report nobody can act on is not a cheaper audit, it is a wasted one.
 
 ## Phase 1: Scope
 
@@ -123,7 +132,7 @@ is the only file this skill edits without being asked.
 Then print the top findings to the user with a recommended next action
 each. Keep it short. The report file holds the detail.
 
-## Phase 5: File issues (only with `--file-issues`)
+## Phase 5: File issues (skipped only with `--no-file-issues`)
 
 Per confirmed finding, most severe first:
 
@@ -134,6 +143,23 @@ gh issue create \
   --assignee Chemaclass \
   --body "<body>"
 ```
+
+**A collapsed issue still has to be a workable unit.** Phase 3 collapses one
+vendor change that hits several targets into one issue, and that is right for
+evidence: the quote is written once. But an issue titled "nine targets have
+hook files we never declare" cannot be closed by doing one of them, so nobody
+starts it. Give every multi-target issue a per-target task list:
+
+```markdown
+- [ ] copilot: `.github/hooks/*.json`, 13 events (`copilot/copilot.go:52`)
+- [ ] openhands: `.openhands/hooks.json`, claude renderer works verbatim
+- [ ] crush: project `crush.json`, `PreToolUse` only
+```
+
+Then a PR can close part of it, progress is visible, and the cheapest target
+is obvious to whoever picks it up. Say which one is cheapest and why, in the
+issue: on 2026-08-27 that was openhands, because the vendor states its hook
+format is Claude-compatible, so the existing renderer worked with no changes.
 
 Use `--label bug` instead of `enhancement` for `breaking` findings. Create
 the `target-audit` label once if missing:
@@ -148,8 +174,13 @@ must touch:
 - [ ] adapter package doc comment
 - [ ] `docs/user/targets.md`: capability matrix row and per-target section
 - [ ] `references/sources.md`, if a URL moved
-- [ ] tests: `capability_parity_test.go`, `kitsink_golden_test.go`, and
-      the target's round-trip test under `tests/integration/`
+- [ ] tests: `capability_parity_test.go`, `kitsink_golden_test.go`, the
+      target's round-trip test under `tests/integration/` **if it has one**,
+      and its golden tree at `tests/integration/fixtures/golden/<target>/`.
+      Check both: 14 of 25 targets have a golden tree and **no** round-trip
+      test, so for those the golden tree is the only guard. A scope list
+      naming only the adapter's own `testdata/` misses it and goes red in
+      CI (found on 2026-08-27, kiro).
 - [ ] `agnostic-ai sync`, then commit the regenerated per-target files
 
 Never open an issue for an `unconfirmed` finding. Those go in the report

--- a/.github/skills/target-audit/SKILL.md
+++ b/.github/skills/target-audit/SKILL.md
@@ -17,12 +17,21 @@ skill finds that drift on a schedule instead of via a user bug report.
 
 ## Arguments
 
-- no args: audit every registered target
+- no args: audit every registered target **and file an issue per confirmed
+  finding**. Filing is the default, not an opt-in.
 - `claude zed kilo`: audit only those
-- `--file-issues`: also open one GitHub issue per confirmed finding.
-  Without it, the run stops at the report.
-- `--fix`: implies `--file-issues`, then opens a PR per fix bucket.
-  Never merges.
+- `--no-file-issues`: stop at the report. Use it for a scratch run you do
+  not intend to act on.
+- `--fix`: file issues, then open a PR per fix bucket. Never merges.
+
+**Why filing is the default.** It used to be opt-in, and two consecutive
+runs proved that wrong. The 2026-08-19 run found 52 findings and filed
+none. The 2026-08-27 run found 54 and filed none until a human asked, by
+which point it was re-verifying the previous run's backlog instead of
+auditing. The report lands in gitignored `local/`, so a run that does not
+file leaves **nothing** behind: no tracked work, no dedupe set for the
+next run, and a fresh re-derivation of the same findings a week later.
+A report nobody can act on is not a cheaper audit, it is a wasted one.
 
 ## Phase 1: Scope
 
@@ -123,7 +132,7 @@ is the only file this skill edits without being asked.
 Then print the top findings to the user with a recommended next action
 each. Keep it short. The report file holds the detail.
 
-## Phase 5: File issues (only with `--file-issues`)
+## Phase 5: File issues (skipped only with `--no-file-issues`)
 
 Per confirmed finding, most severe first:
 
@@ -134,6 +143,23 @@ gh issue create \
   --assignee Chemaclass \
   --body "<body>"
 ```
+
+**A collapsed issue still has to be a workable unit.** Phase 3 collapses one
+vendor change that hits several targets into one issue, and that is right for
+evidence: the quote is written once. But an issue titled "nine targets have
+hook files we never declare" cannot be closed by doing one of them, so nobody
+starts it. Give every multi-target issue a per-target task list:
+
+```markdown
+- [ ] copilot: `.github/hooks/*.json`, 13 events (`copilot/copilot.go:52`)
+- [ ] openhands: `.openhands/hooks.json`, claude renderer works verbatim
+- [ ] crush: project `crush.json`, `PreToolUse` only
+```
+
+Then a PR can close part of it, progress is visible, and the cheapest target
+is obvious to whoever picks it up. Say which one is cheapest and why, in the
+issue: on 2026-08-27 that was openhands, because the vendor states its hook
+format is Claude-compatible, so the existing renderer worked with no changes.
 
 Use `--label bug` instead of `enhancement` for `breaking` findings. Create
 the `target-audit` label once if missing:
@@ -148,8 +174,13 @@ must touch:
 - [ ] adapter package doc comment
 - [ ] `docs/user/targets.md`: capability matrix row and per-target section
 - [ ] `references/sources.md`, if a URL moved
-- [ ] tests: `capability_parity_test.go`, `kitsink_golden_test.go`, and
-      the target's round-trip test under `tests/integration/`
+- [ ] tests: `capability_parity_test.go`, `kitsink_golden_test.go`, the
+      target's round-trip test under `tests/integration/` **if it has one**,
+      and its golden tree at `tests/integration/fixtures/golden/<target>/`.
+      Check both: 14 of 25 targets have a golden tree and **no** round-trip
+      test, so for those the golden tree is the only guard. A scope list
+      naming only the adapter's own `testdata/` misses it and goes red in
+      CI (found on 2026-08-27, kiro).
 - [ ] `agnostic-ai sync`, then commit the regenerated per-target files
 
 Never open an issue for an `unconfirmed` finding. Those go in the report


### PR DESCRIPTION
Three changes to the `target-audit` skill, all from what the 2026-08-27 run cost.

## Filing becomes the default

`--file-issues` was opt-in. Two runs in a row showed that is the wrong default:

| Run | Findings | Issues filed |
|---|---|---|
| 2026-08-19 | 52 | 0 |
| 2026-08-27 | 54 | 0, until a human asked |

The report is written to gitignored `local/`. So a run that does not file leaves **nothing** behind: no tracked work, no dedupe set for the next run, and a full re-derivation of the same findings a week later.

That is what happened. The 2026-08-27 run spent most of its budget re-verifying the 2026-08-19 backlog instead of auditing the window, because that backlog existed only in a file git never saw.

The flag inverts to `--no-file-issues` for a scratch run you do not intend to act on.

## A collapsed issue still has to be workable

Phase 3 collapses one vendor change across several targets into one issue. That is right for evidence: the quote gets written once. But "nine targets have hook files we never declare" cannot be closed by doing one of them, so nobody starts it.

Multi-target issues now need a per-target task list, so a PR can close part of one and progress is visible. And the issue should say which target is cheapest and why. On 2026-08-27 that was openhands, because the vendor states its hook format is Claude-compatible, so the existing renderer needed no changes at all.

## The fix checklist pointed at a file most targets do not have

It said "the target's round-trip test under `tests/integration/`". **14 of 25 targets have no round-trip test.** For those the golden tree at `tests/integration/fixtures/golden/<target>/` is the only guard.

This was not theoretical. The kiro fix scope listed three goldens under the adapter's own `testdata/`, and a fourth lived in the golden tree. CI caught it. The checklist now names both and says to check both.