### PR TITLE
test(emit): pin every target's entry point to its vendor read path

### DIFF
--- a/internal/adapters/internal/emit/entrypoint_paths_test.go
+++ b/internal/adapters/internal/emit/entrypoint_paths_test.go
@@ -1,0 +1,45 @@
+package emit
+
+import (
+	"testing"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+)
+
+// Each target's entry point must be a file its own vendor documents as a
+// read path. Getting one wrong is silent in every direction: sync writes
+// the file, `sync --check` stays green, the golden fixtures match, and the
+// tool simply never opens it. Two targets shipped that way and neither was
+// caught by a test: opencode wrote `.opencode/AGENTS.md` (#623) and zed
+// relied on `AGENTS.md` while copilot shadowed it (#624).
+//
+// vendor_lookup_test.go covers the ordered-lookup hazard, where the file we
+// write is real but another emitted file outranks it. This table covers the
+// simpler failure underneath it: writing a path the vendor never names.
+func TestEntryPointPath_MatchesVendorReadPath(t *testing.T) {
+	// Each entry is a path the vendor documents, with the source in the
+	// comment. A target belongs here only once its read path is confirmed.
+	for target, want := range map[string]string{
+		// opencode.ai/docs/rules: an upward walk for files named exactly
+		// AGENTS.md. No .opencode/ variant appears in the docs or in the
+		// vendor's own instruction-context.ts (#623).
+		"opencode": "AGENTS.md",
+		// zed.dev/docs/ai/instructions: first match of an ordered list.
+		// .rules ranks first, ahead of .github/copilot-instructions.md (#624).
+		"zed": ".rules",
+		// code.claude.com/docs/en/memory
+		"claude": "CLAUDE.md",
+		// geminicli.com/docs
+		"gemini": "GEMINI.md",
+		// aider.chat/docs/usage/conventions.html
+		"aider": "CONVENTIONS.md",
+		// docs.github.com/en/copilot: repository custom instructions
+		"copilot": ".github/copilot-instructions.md",
+		// learn.chatgpt.com/docs/agent-configuration/agents-md
+		"codex": "AGENTS.md",
+	} {
+		if got := EntryPointPath(&config.Config{}, target); got != want {
+			t.Errorf("%s entry point = %q, want %q (vendor-documented read path)", target, got, want)
+		}
+	}
+}


### PR DESCRIPTION
A regression guard for the bug class that hit twice this week, and the one thing worth rescuing from an abandoned branch.

## The failure it catches

Writing an entry point the vendor never opens fails silently in every direction available to us. `sync` writes the file. `sync --check` stays green. The golden fixtures match, because they record what we emit, not what anyone reads. The tool opens nothing.

Two targets shipped that way:

- **opencode** wrote `.opencode/AGENTS.md`, a path absent from the vendor docs and from its own `instruction-context.ts` (#623)
- **zed** relied on `AGENTS.md` while `.github/copilot-instructions.md` outranked it (#624)

No test caught either. Both were found by reading vendor docs.

## What this adds

A table pinning each target to a path its vendor documents, with the source in a comment beside it.

`vendor_lookup_test.go`, added with #624, already guards the ordered-lookup hazard: the file we write is real, but another emitted file outranks it. This guards the simpler failure underneath, writing a path no vendor names at all. `opencode` and `zed` now have per-target tests from #652 and #654; `claude`, `gemini`, `aider`, `copilot` and `codex` had nothing.

Verified it fails for the right reason: flipping `opencode` back to `.opencode/AGENTS.md` produces

```
opencode entry point = "AGENTS.md", want ".opencode/AGENTS.md" (vendor-documented read path)
```

## Where it came from

`fix/target-audit-2026-08-19` is a branch the previous audit pushed to origin and never opened a PR for. It carried six of the seven breaking fixes that shipped this week under different PRs, plus the `sources.md` refresh that shipped as #621.

Everything on it is now on `main` by another route, except this test. Diffed file by file to confirm that before proposing the branch be deleted.