### PR TITLE
feat(sync): add global Claude and Cursor configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
+- `agnostic-ai sync --global` emits shared user-level instructions, hooks, and skills as native Claude Code and Cursor configuration from `~/.agnostic-ai/global/`, while preserving unrelated native configuration and keeping project sync isolated (#680).
+
 - Codex MCP servers emit the vendor's per-tool sub-tables from a `tools` map: `[mcp_servers.<name>.tools.<tool>]`, keys passed through verbatim, covering `output_token_limit` (shipped in Codex v0.153.0) and the per-tool approval override. The block was dropped in silence before, with no warning and no coverage note (#678).
 - `outputs.claude.settings.bashOutputMaxChars` and `.taskOutputMaxChars` raise how much command and background-task output Claude Code takes inline before spilling it to a file, up to 128K characters. Both shipped in Claude Code v2.1.261 and previously had no declarative path, only the captured overlay (#679).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
-- `agnostic-ai sync --global` emits shared user-level instructions, hooks, and skills as native Claude Code and Cursor configuration from `~/.agnostic-ai/global/`, while preserving unrelated native configuration and keeping project sync isolated (#680).
+- `agnostic-ai sync --global` emits shared user-level instructions, hooks, and skills as native Claude Code and Cursor configuration directly from `~/.agnostic-ai/`, while preserving unrelated native configuration and keeping project sync isolated (#680).
 
 - Codex MCP servers emit the vendor's per-tool sub-tables from a `tools` map: `[mcp_servers.<name>.tools.<tool>]`, keys passed through verbatim, covering `output_token_limit` (shipped in Codex v0.153.0) and the per-tool approval override. The block was dropped in silence before, with no warning and no coverage note (#678).
 - `outputs.claude.settings.bashOutputMaxChars` and `.taskOutputMaxChars` raise how much command and background-task output Claude Code takes inline before spilling it to a file, up to 128K characters. Both shipped in Claude Code v2.1.261 and previously had no declarative path, only the captured overlay (#679).
 
 ### Changed
+
+- Ordinary project sync no longer loads `~/.agnostic-ai/` as a low-precedence spec layer. The directory is now the explicit native-global source for `sync --global`; keep project-only defaults in each project or a pack (#680).
 
 - Crush docs now record that `crush.json` is the vendor's deprecated legacy format, frozen from new fields, and that Crush merges it with `crushrc` (with a startup warning when a project has both). No emission changes; MCP servers still write to `crush.json` (#674).
 
@@ -851,7 +853,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 - `agnostic-ai validate --fix`: rewrite specs for autofixable issues (backfills missing `name:` from filename / parent dir). Plain `validate` flags fixable issues with `*`.
 - Plugin protocol v1 for external adapters (`agnostic-ai-adapter-<target>` on PATH; JSON over stdin/stdout). Docs at `docs/internal/plugin-protocol.md`.
 - `adapters.Resolve(name)`: lookup site with built-in → external fallback.
-- `agnostic-ai packs add|remove|update|list`: shareable spec packs from Git URLs. Pinned in `agnostic.packs.lock`. Load as a layer between user-global and project.
+- `agnostic-ai packs add|remove|update|list`: shareable spec packs from Git URLs. Pinned in `agnostic.packs.lock`. Load as a layer before project specs.
 - `docs/user/ci.md`: dedicated CI page + `chemaclass/agnostic-ai-action@v1`.
 - `completion bash|zsh|fish|powershell`.
 - JSON schemas at `docs/schemas/config.schema.json` (generated) and `spec.schema.json` (hand-authored).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Changed
 
-- Ordinary project sync no longer loads `~/.agnostic-ai/` as a low-precedence spec layer. The directory is now the explicit native-global source for `sync --global`; keep project-only defaults in each project or a pack (#680).
+- Ordinary project sync no longer loads `~/.agnostic-ai/` as a low-precedence spec layer. The directory is now the explicit global source for `sync --global`; keep project-only defaults in each project or a pack (#680).
 
 - Crush docs now record that `crush.json` is the vendor's deprecated legacy format, frozen from new fields, and that Crush merges it with `crushrc` (with a startup warning when a project has both). No emission changes; MCP servers still write to `crush.json` (#674).
 

--- a/README.md
+++ b/README.md
@@ -158,3 +158,13 @@ Five kinds here. `command`, `settings`, `review`, `environment`, and `ignore` ar
 **Write the rule once. Every AI tool obeys it. Outlive the tool.**
 
 </div>
+
+### Share user configuration across Claude Code and Cursor
+
+Put user-wide instructions in `~/.agnostic-ai/global/AGNOSTIC_AI.md`, with optional `rules/`, `hooks/`, and `skills/` folders beside it. Then run this from any directory:
+
+```bash
+agnostic-ai sync --global
+```
+
+This mode is opt-in and separate from project sync. It writes native user configuration for Claude Code and Cursor. See [global configuration](docs/user/configuration.md#global-configuration).

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Five kinds here. `command`, `settings`, `review`, `environment`, and `ignore` ar
 
 ### Share user configuration across Claude Code and Cursor
 
-Put user-wide instructions in `~/.agnostic-ai/global/AGNOSTIC_AI.md`, with optional `rules/`, `hooks/`, and `skills/` folders beside it. Then run this from any directory:
+Put user-wide instructions in `~/.agnostic-ai/AGNOSTIC_AI.md`, with optional `rules/`, `hooks/`, and `skills/` folders beside it. Then run this from any directory:
 
 ```bash
 agnostic-ai sync --global

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -81,7 +81,7 @@ type Entry struct {
     Name  string            // identifier
     Path  string            // source file path (for errors and provenance)
     Scope string            // implicit per-dir scope from layout
-    Layer string            // source layer: user-global | project | project-user
+    Layer string            // project source: pack:<name> | project | project-user
     Meta  map[string]any    // frontmatter or YAML fields
     Body  string            // markdown body (empty for hooks/mcps)
 }

--- a/docs/internal/roadmap.md
+++ b/docs/internal/roadmap.md
@@ -6,7 +6,7 @@ High-level directions. Concrete work in [issues](https://github.com/Chemaclass/a
 
 Three layers, low to high precedence:
 
-- **user-global** (`$AGNOSTIC_AI_HOME` or `~/.agnostic-ai/`): cross-project source of truth.
+- **native global** (`$AGNOSTIC_AI_HOME` or `~/.agnostic-ai/`): explicit source for `sync --global`, separate from project sync.
 - **project** (`agnostic-ai.yaml` `sources`): checked-in specs.
 - **project-user** (`<project>/.agnostic-ai.local/`, gitignored): per-developer overrides.
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -256,6 +256,7 @@ agnostic-ai sync [flags]
 
 | Flag | Description |
 |------|-------------|
+| `--global` | Install user-level instructions, unconditional rules, hooks, and skills directly from `$AGNOSTIC_AI_HOME` (default `~/.agnostic-ai/`) into native Claude Code and Cursor config. Works outside a project and never loads project config or packs. |
 | `-t, --target <list>` | Comma-separated targets (default: all in config) |
 | `--only <list>` | Emit only these targets (comma-separated). Mutually exclusive with `--except`. Errors on unknown names. |
 | `--except <list>` | Emit all configured targets except these (comma-separated). Mutually exclusive with `--only`. Errors on unknown names. |
@@ -595,7 +596,7 @@ agnostic-ai lsp
 
 | Var | Default | Description |
 |-----|---------|-------------|
-| `AGNOSTIC_AI_HOME` | `~/.agnostic-ai` | Root of the user-global spec layer. See [configuration: layered specs](configuration.md#layered-specs). |
+| `AGNOSTIC_AI_HOME` | `~/.agnostic-ai` | Source root for `sync --global`. Ordinary project sync does not load it. See [global configuration](configuration.md#global-configuration). |
 
 ## Config precedence
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -4,10 +4,10 @@
 
 `agnostic-ai sync --global` syncs user-level instructions, rules, hooks, and skills to Claude Code and Cursor. It works from any directory and does not load `agnostic-ai.yaml`, packs, local overrides, or project specs.
 
-The source root is `$AGNOSTIC_AI_HOME/global/`, or `~/.agnostic-ai/global/` when `AGNOSTIC_AI_HOME` is unset:
+The source root is `$AGNOSTIC_AI_HOME`, or `~/.agnostic-ai/` when `AGNOSTIC_AI_HOME` is unset:
 
 ```text
-global/
+~/.agnostic-ai/
 ├── AGNOSTIC_AI.md
 ├── rules/*.md
 ├── hooks/*.yaml
@@ -19,6 +19,10 @@ Run `agnostic-ai sync --global`. Both targets are enabled by default. `--target`
 Global rules must be unconditional. A nested rule or a rule with scope, path, glob, or target conditions is rejected rather than flattened. Global mode does not support agents, commands, MCP servers, settings, inheritance, or merging with project specs.
 
 Generated files are real files, never symlinks. Managed instruction blocks, hook entries, and skill assets are recorded under `$AGNOSTIC_AI_HOME/state/global.json`. Sync preserves unrelated text, JSON keys, hooks, and skills. It removes only artifacts recorded as managed. An unmanaged skill collision, damaged managed marker, invalid native JSON file, or corrupt ownership state stops the whole operation before writes. Native tool precedence still applies when both global and project configuration exist.
+
+Migration: ordinary `agnostic-ai sync` no longer loads specs from `~/.agnostic-ai/`. Rules, hooks, and skills already stored there become native global inputs when you run `sync --global`. Move defaults intended only for project output into each project's `.agnostic-ai/` tree or a shared pack. Move unsupported old global kinds such as agents, MCP servers, commands, settings, reviews, environments, and ignore specs into projects or packs because global mode does not load them.
+
+A repository's `.agnostic-ai/` directory remains project-specific, even though the default user root has the same basename. Keep organization or team defaults in committed project specs or a pinned pack. `.agnostic-ai.local/` remains the uncommitted personal override for one project.
 
 `agnostic-ai.yaml` lives at the project root. It is read from the current working directory at command time. Every section is optional. Defaults are listed below.
 
@@ -648,7 +652,7 @@ Any setting not declared here round-trips through the overlay captured during `a
 
 ## Codex config
 
-The `outputs.codex.config` block declares first-class `.codex/config.toml` global keys, written into the project-tier config on each sync. Keys not listed here belong in the user-global `~/.codex/config.toml`, which Codex merges last.
+The `outputs.codex.config` block declares first-class `.codex/config.toml` global keys, written into the project-tier config on each sync. Keys not listed here belong in the user-level `~/.codex/config.toml`, which Codex merges last.
 
 ```yaml
 outputs:
@@ -751,17 +755,17 @@ Last wins:
 
 ## Layered specs
 
-Specs load from up to three layers, low- to high-precedence:
+Project specs load from up to three sources, low- to high-precedence:
 
 | Layer | Root | Loaded when |
 |-------|------|-------------|
-| `user-global` | `$AGNOSTIC_AI_HOME` if set, else `~/.agnostic-ai` | directory exists |
+| packs | `.agnostic-ai/packs/` from `agnostic.packs.lock` | packs are installed |
 | `project` | `agnostic-ai.yaml` `sources` paths | always |
 | `project-user` | `<project>/.agnostic-ai.local` | directory exists |
 
 Higher layers override by spec name (per kind). New names append.
 
-`user-global` and `project-user` use a fixed source layout: `agents/`, `skills/`, `rules/`, `hooks/`, `mcps/` under the layer root. Only the `project` layer honors custom `sources` paths.
+`project-user` uses the fixed kind directories under its root. Only the `project` layer honors custom `sources` paths. `$AGNOSTIC_AI_HOME` is not a project layer; `sync --global` reads it through the separate global workflow above.
 
 Add `.agnostic-ai.local/` to your `.gitignore` so personal overrides stay local.
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -755,7 +755,7 @@ Last wins:
 
 ## Layered specs
 
-Project specs load from up to three sources, low- to high-precedence:
+Project specs load from three tiers, low- to high-precedence:
 
 | Layer | Root | Loaded when |
 |-------|------|-------------|

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -1,5 +1,25 @@
 # Configuration
 
+## Global configuration
+
+`agnostic-ai sync --global` syncs user-level instructions, rules, hooks, and skills to Claude Code and Cursor. It works from any directory and does not load `agnostic-ai.yaml`, packs, local overrides, or project specs.
+
+The source root is `$AGNOSTIC_AI_HOME/global/`, or `~/.agnostic-ai/global/` when `AGNOSTIC_AI_HOME` is unset:
+
+```text
+global/
+├── AGNOSTIC_AI.md
+├── rules/*.md
+├── hooks/*.yaml
+└── skills/<name>/SKILL.md
+```
+
+Run `agnostic-ai sync --global`. Both targets are enabled by default. `--target`, `--only`, and `--except` can narrow the set to `claude` or `cursor`. `--dry-run`, `--check`, and `--backup` retain their normal meaning. Project-only flags such as `--watch`, `--plan`, `--json`, `--gitignore`, and `--jobs` are rejected before any write.
+
+Global rules must be unconditional. A nested rule or a rule with scope, path, glob, or target conditions is rejected rather than flattened. Global mode does not support agents, commands, MCP servers, settings, inheritance, or merging with project specs.
+
+Generated files are real files, never symlinks. Managed instruction blocks, hook entries, and skill assets are recorded under `$AGNOSTIC_AI_HOME/state/global.json`. Sync preserves unrelated text, JSON keys, hooks, and skills. It removes only artifacts recorded as managed. An unmanaged skill collision, damaged managed marker, invalid native JSON file, or corrupt ownership state stops the whole operation before writes. Native tool precedence still applies when both global and project configuration exist.
+
 `agnostic-ai.yaml` lives at the project root. It is read from the current working directory at command time. Every section is optional. Defaults are listed below.
 
 Legacy filename: `agnostic.config.yaml` still loads, with a deprecation warning. Rename to `agnostic-ai.yaml` when convenient.

--- a/docs/user/packs.md
+++ b/docs/user/packs.md
@@ -64,10 +64,10 @@ Commit it so peers and CI install the same revisions. The file is sorted by name
 
 ## Layer precedence
 
-Packs slot between the user-global layer and the project layer:
+Packs load before the project and personal project layers:
 
 ```
-user-global  →  packs  →  project  →  project-user
+packs  →  project  →  project-user
 ```
 
 Higher layers override by `(kind, name)`. A project rule named `conventional-commits` masks the pack version with the same name. This is the escape hatch when a pack convention needs project-specific tweaks.

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -9,7 +9,7 @@
 | Claude Code | `~/.claude/CLAUDE.md` | `~/.claude/settings.json` | `~/.claude/skills/<name>/` |
 | Cursor | `~/.cursor/AGENTS.md` | `~/.cursor/hooks.json` | `~/.cursor/skills/<name>/` |
 
-Cursor does not automatically load the home-level `AGENTS.md`. Global sync therefore installs a managed `sessionStart` hook and a self-contained shell bridge under `~/.cursor/hooks/`. The bridge returns the rendered instructions as valid `additional_context` JSON without calling agnostic-ai, Python, or jq. Cursor session-start hooks are fire-and-forget context injection, not enforced policy. Existing `sessionStart` entries remain in place.
+Cursor does not automatically load the home-level `AGENTS.md`. Global sync therefore installs a managed `sessionStart` hook and a self-contained script bridge under `~/.cursor/hooks/` (POSIX shell on macOS and Linux, PowerShell on Windows). The bridge returns the rendered instructions as valid `additional_context` JSON without calling agnostic-ai, Python, or jq. Cursor session-start hooks are fire-and-forget context injection, not enforced policy. Existing `sessionStart` entries remain in place.
 
 Each adapter emits in its tool's native format: separate files where the tool supports them, a merged document otherwise. Unsupported features (e.g. hooks for a non-hook-aware target) skip with a warning by default. Override via `on-unsupported` in [configuration](configuration.md).
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -1,5 +1,16 @@
 # Targets
 
+## Global output
+
+`sync --global` supports Claude Code and Cursor only. These paths are user-level and are independent of the project outputs documented below.
+
+| Target | Instructions | Hooks | Skills |
+|--------|--------------|-------|--------|
+| Claude Code | `~/.claude/CLAUDE.md` | `~/.claude/settings.json` | `~/.claude/skills/<name>/` |
+| Cursor | `~/.cursor/AGENTS.md` | `~/.cursor/hooks.json` | `~/.cursor/skills/<name>/` |
+
+Cursor does not automatically load the home-level `AGENTS.md`. Global sync therefore installs a managed `sessionStart` hook and a self-contained shell bridge under `~/.cursor/hooks/`. The bridge returns the rendered instructions as valid `additional_context` JSON without calling agnostic-ai, Python, or jq. Cursor session-start hooks are fire-and-forget context injection, not enforced policy. Existing `sessionStart` entries remain in place.
+
 Each adapter emits in its tool's native format: separate files where the tool supports them, a merged document otherwise. Unsupported features (e.g. hooks for a non-hook-aware target) skip with a warning by default. Override via `on-unsupported` in [configuration](configuration.md).
 
 ## Entry-point files

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -107,7 +107,6 @@ func BenchmarkSyncFull(b *testing.B) {
 				root := benchProject(b, n)
 				benchQuiet(b)
 				benchChdir(b, root)
-				benchIsolateGlobalLayer(b)
 				// Prime once so timed iterations measure the re-sync path.
 				if err := runSyncOnce(".", nil, false, false, "off", jc.jobs); err != nil {
 					b.Fatal(err)
@@ -135,7 +134,6 @@ func BenchmarkSyncCheck(b *testing.B) {
 			root := benchProject(b, n)
 			benchQuiet(b)
 			benchChdir(b, root)
-			benchIsolateGlobalLayer(b)
 			// Prime disk via the check path's own writers so the timed
 			// compare finds every file in sync.
 			reports, err := collectDrift(nil)
@@ -259,9 +257,8 @@ func benchProject(b *testing.B, n int) string {
 }
 
 // benchLoad loads the fixture config and a project-only bundle. It skips
-// resolveLayers on purpose so the user-global and project-user layers
-// never leak host state into the numbers; benchIsolateGlobalLayer covers
-// the paths that load through the CLI instead.
+// resolveLayers so the project-user layer cannot leak host state into the
+// numbers.
 func benchLoad(b *testing.B, root string) (*config.Config, spec.Bundle) {
 	b.Helper()
 	cfg, err := config.Load(root)
@@ -414,15 +411,6 @@ func benchQuiet(b *testing.B) {
 		logOut = prevOut
 		adapters.SetWarner(os.Stderr)
 	})
-}
-
-// benchIsolateGlobalLayer points the user-global layer at an empty temp
-// dir so host state under ~/.agnostic-ai cannot leak into a benchmark
-// that loads through the CLI (resolveLayers). The dir exists but has no
-// spec subdirs, so the layer contributes nothing.
-func benchIsolateGlobalLayer(b *testing.B) {
-	b.Helper()
-	b.Setenv(envUserGlobalRoot, b.TempDir())
 }
 
 // resetBenchBuffers clears the process-global capability-warning and

--- a/internal/cli/layers.go
+++ b/internal/cli/layers.go
@@ -15,8 +15,6 @@ const (
 	layerNameProject     = "project"
 	layerNameProjectUser = "project-user"
 
-	envUserGlobalRoot  = "AGNOSTIC_AI_HOME"
-	defaultUserGlobal  = ".agnostic-ai"
 	defaultProjectUser = ".agnostic-ai.local"
 )
 

--- a/internal/cli/layers.go
+++ b/internal/cli/layers.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	layerNameUserGlobal  = "user-global"
 	layerNameProject     = "project"
 	layerNameProjectUser = "project-user"
 
@@ -21,8 +20,8 @@ const (
 	defaultProjectUser = ".agnostic-ai.local"
 )
 
-// defaultLayerSources is the fixed source layout used by user-global
-// and project-user layers. The project layer keeps its configurable
+// defaultLayerSources is the fixed source layout used by the project-user
+// layer. The project layer keeps its configurable
 // `cfg.Sources` paths.
 func defaultLayerSources() config.Sources {
 	return config.Sources{
@@ -44,29 +43,12 @@ func defaultLayerSources() config.Sources {
 // not exist.
 func resolveLayers(projectRoot string, cfg *config.Config) []spec.Layer {
 	var layers []spec.Layer
-	if l, ok := resolveUserGlobalLayer(); ok {
-		layers = append(layers, l)
-	}
 	layers = append(layers, resolvePacksLayers(projectRoot)...)
 	layers = append(layers, resolveProjectLayer(projectRoot, cfg))
 	if l, ok := resolveProjectUserLayer(projectRoot); ok {
 		layers = append(layers, l)
 	}
 	return layers
-}
-
-// resolveUserGlobalLayer returns the user-global layer when
-// AGNOSTIC_AI_HOME or ~/.agnostic-ai resolves to an existing directory.
-func resolveUserGlobalLayer() (spec.Layer, bool) {
-	root, ok := userGlobalRoot()
-	if !ok {
-		return spec.Layer{}, false
-	}
-	return spec.Layer{
-		Name:    layerNameUserGlobal,
-		Root:    root,
-		Sources: defaultLayerSources(),
-	}, true
 }
 
 // resolveProjectLayer returns the always-present project layer using
@@ -91,29 +73,6 @@ func resolveProjectUserLayer(projectRoot string) (spec.Layer, bool) {
 		Root:    pu,
 		Sources: defaultLayerSources(),
 	}, true
-}
-
-// userGlobalRoot resolves the user-global layer root. AGNOSTIC_AI_HOME
-// wins if set and the dir exists; otherwise ~/.agnostic-ai when present.
-// A set-but-unusable AGNOSTIC_AI_HOME is reported on stderr so typos
-// don't silently disable the user-global layer.
-func userGlobalRoot() (string, bool) {
-	if env := os.Getenv(envUserGlobalRoot); env != "" {
-		if dirExists(env) {
-			return env, true
-		}
-		fmt.Fprintf(os.Stderr, "! %s=%s: not a directory; user-global layer skipped\n", envUserGlobalRoot, env)
-		return "", false
-	}
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return "", false
-	}
-	root := filepath.Join(home, defaultUserGlobal)
-	if dirExists(root) {
-		return root, true
-	}
-	return "", false
 }
 
 func dirExists(path string) bool {

--- a/internal/cli/layers_test.go
+++ b/internal/cli/layers_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestResolveLayers_ProjectOnlyByDefault(t *testing.T) {
-	t.Setenv(envUserGlobalRoot, "/nonexistent-agnostic-ai-test-path")
-	t.Setenv("HOME", t.TempDir()) // empty home, no ~/.agnostic-ai
-
 	root := t.TempDir()
 	cfg := &config.Config{Sources: defaultLayerSources()}
 
@@ -24,30 +21,21 @@ func TestResolveLayers_ProjectOnlyByDefault(t *testing.T) {
 	}
 }
 
-func TestResolveLayers_UserGlobalDetectedViaEnv(t *testing.T) {
-	ug := t.TempDir()
-	t.Setenv(envUserGlobalRoot, ug)
-	t.Setenv("HOME", t.TempDir())
+func TestResolveLayers_DoesNotLoadGlobalHome(t *testing.T) {
+	globalHome := t.TempDir()
+	t.Setenv(envUserGlobalRoot, globalHome)
+	if err := os.MkdirAll(filepath.Join(globalHome, "rules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	root := t.TempDir()
-	cfg := &config.Config{Sources: defaultLayerSources()}
-
-	layers := resolveLayers(root, cfg)
-	if len(layers) != 2 {
-		t.Fatalf("expected 2 layers, got %d", len(layers))
-	}
-	if layers[0].Name != layerNameUserGlobal || layers[0].Root != ug {
-		t.Errorf("layer[0]=%+v", layers[0])
-	}
-	if layers[1].Name != layerNameProject {
-		t.Errorf("layer[1]=%+v", layers[1])
+	layers := resolveLayers(root, &config.Config{Sources: defaultLayerSources()})
+	if len(layers) != 1 || layers[0].Name != layerNameProject {
+		t.Fatalf("global home joined project layers: %+v", layers)
 	}
 }
 
 func TestResolveLayers_ProjectUserDetected(t *testing.T) {
-	t.Setenv(envUserGlobalRoot, "/nonexistent-agnostic-ai-test-path")
-	t.Setenv("HOME", t.TempDir())
-
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, defaultProjectUser), 0o755); err != nil {
 		t.Fatal(err)
@@ -66,11 +54,7 @@ func TestResolveLayers_ProjectUserDetected(t *testing.T) {
 	}
 }
 
-func TestResolveLayers_AllThreePrecedenceOrder(t *testing.T) {
-	ug := t.TempDir()
-	t.Setenv(envUserGlobalRoot, ug)
-	t.Setenv("HOME", t.TempDir())
-
+func TestResolveLayers_ProjectAndProjectUserPrecedenceOrder(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, defaultProjectUser), 0o755); err != nil {
 		t.Fatal(err)
@@ -78,10 +62,10 @@ func TestResolveLayers_AllThreePrecedenceOrder(t *testing.T) {
 	cfg := &config.Config{Sources: defaultLayerSources()}
 
 	layers := resolveLayers(root, cfg)
-	if len(layers) != 3 {
-		t.Fatalf("expected 3 layers, got %d", len(layers))
+	if len(layers) != 2 {
+		t.Fatalf("expected 2 layers, got %d", len(layers))
 	}
-	want := []string{layerNameUserGlobal, layerNameProject, layerNameProjectUser}
+	want := []string{layerNameProject, layerNameProjectUser}
 	for i, n := range want {
 		if layers[i].Name != n {
 			t.Errorf("layers[%d]=%q, want %q", i, layers[i].Name, n)

--- a/internal/cli/packs_test.go
+++ b/internal/cli/packs_test.go
@@ -138,10 +138,7 @@ func TestPacksUpdate_LocalSource(t *testing.T) {
 	}
 }
 
-func TestResolveLayers_PacksLayerInsertedBetweenUserGlobalAndProject(t *testing.T) {
-	t.Setenv(envUserGlobalRoot, "/nonexistent-agnostic-ai-test-path")
-	t.Setenv("HOME", t.TempDir())
-
+func TestResolveLayers_PacksLayerInsertedBeforeProject(t *testing.T) {
 	root := t.TempDir()
 	src := filepath.Join(t.TempDir(), "p1")
 	mustWrite(t, filepath.Join(src, "rules", "r.md"), "---\nname: r\n---\nb")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -107,11 +107,9 @@ func NewRootCmd(version string) *cobra.Command {
 	return root
 }
 
-// loadProject loads config and a layered bundle from root. Layer
-// precedence (low to high): user-global (~/.agnostic-ai or
-// $AGNOSTIC_AI_HOME) → project (cfg.Sources) → project-user
-// (.agnostic-ai.local). Optional layers load only when their root
-// exists.
+// loadProject loads config and project-scoped specs. Packs have lower
+// precedence than project specs, while .agnostic-ai.local has higher
+// precedence. User-level specs are installed only by sync --global.
 func loadProject(root string) (*config.Config, spec.Bundle, error) {
 	cfg, sources, err := config.LoadWithSources(root)
 	if err != nil {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -15,7 +15,7 @@ import (
 
 func newSyncCmd() *cobra.Command {
 	var targets, only, except []string
-	var dryRun, check, plan, backup, watch, watchPoll, jsonOut, allTargets, diff bool
+	var dryRun, check, plan, backup, watch, watchPoll, jsonOut, allTargets, diff, global bool
 	var gitignoreFlag, format string
 	var jobs int
 
@@ -52,6 +52,9 @@ func newSyncCmd() *cobra.Command {
   # Machine-readable output for CI dashboards and editor extensions
   agnostic-ai sync --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if global {
+				return runGlobalSync(cmd, globalSyncOptions{targets: targets, only: only, except: except, dryRun: dryRun, check: check, backup: backup, plan: plan, watch: watch, watchPoll: watchPoll, jsonOut: jsonOut, allTargets: allTargets, diff: diff, format: format, gitignore: gitignoreFlag, jobs: jobs})
+			}
 			if err := validateGitignoreFlag(gitignoreFlag); err != nil {
 				return err
 			}
@@ -136,6 +139,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON for machine consumption")
 	cmd.Flags().BoolVar(&allTargets, "all", false, "Sync every configured target without prompting (skip the first-sync target picker)")
 	cmd.Flags().IntVar(&jobs, "jobs", 0, "Number of targets to emit in parallel (0 = one per CPU; 1 = serial). Output is identical regardless.")
+	cmd.Flags().BoolVar(&global, "global", false, "Sync user-level Claude Code and Cursor configuration")
 	registerTargetCompletion(cmd)
 	return cmd
 }

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -79,7 +79,7 @@ func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
 	if sourceHome == "" {
 		sourceHome = filepath.Join(home, ".agnostic-ai")
 	}
-	source := filepath.Join(sourceHome, "global")
+	source := sourceHome
 	cfg := &config.Config{Sources: config.Sources{Rules: "rules", Hooks: "hooks", Skills: "skills"}}
 	bundle, err := spec.LoadBundle(source, cfg)
 	if err != nil {

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -122,7 +122,9 @@ func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
 	}
 	if o.dryRun {
 		for _, w := range writes {
-			fmt.Fprintf(cmd.OutOrStdout(), "dry-run: write %s\n", w.path)
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run: write %s\n", w.path); err != nil {
+				return fmt.Errorf("write dry-run output: %w", err)
+			}
 		}
 		return nil
 	}
@@ -130,7 +132,9 @@ func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
 	if err := applyGlobalChanges(writes, removals, o.backup); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Synced global configuration to %d target(s).\n", len(targets))
+	if _, err = fmt.Fprintf(cmd.OutOrStdout(), "Synced global configuration to %d target(s).\n", len(targets)); err != nil {
+		return fmt.Errorf("write sync summary: %w", err)
+	}
 	return nil
 }
 
@@ -469,7 +473,7 @@ func applyGlobalChanges(writes []globalWrite, removals []string, backup bool) er
 		}
 		tmpName := tmp.Name()
 		writeErr := func() error {
-			defer os.Remove(tmpName)
+			defer func() { _ = os.Remove(tmpName) }()
 			if _, err := tmp.Write(w.data); err != nil {
 				return err
 			}

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -49,6 +49,12 @@ func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
 	if len(o.only) > 0 && len(o.except) > 0 {
 		return errs.Coded(errs.CodeFlagConflict, "--only and --except are mutually exclusive")
 	}
+	if err := validateCheckFormat(o.format); err != nil {
+		return err
+	}
+	if o.format != checkFormatHuman && !o.check {
+		return errs.Coded(errs.CodeFlagConflict, "--format requires --check with --global")
+	}
 	targets := o.targets
 	if len(targets) == 0 {
 		targets = []string{"claude", "cursor"}
@@ -120,13 +126,9 @@ func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
 		}
 		return nil
 	}
-	if err := applyGlobalWrites(writes, o.backup); err != nil {
+	removals := removedGlobalFiles(old.Files, next.Files)
+	if err := applyGlobalChanges(writes, removals, o.backup); err != nil {
 		return err
-	}
-	for _, path := range removedGlobalFiles(old.Files, next.Files) {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove managed %s: %w", path, err)
-		}
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Synced global configuration to %d target(s).\n", len(targets))
 	return nil
@@ -417,7 +419,7 @@ func removedGlobalFiles(old, next []string) []string {
 	return out
 }
 
-func applyGlobalWrites(writes []globalWrite, backup bool) error {
+func applyGlobalChanges(writes []globalWrite, removals []string, backup bool) error {
 	type prior struct {
 		path   string
 		data   []byte
@@ -483,6 +485,26 @@ func applyGlobalWrites(writes []globalWrite, backup bool) error {
 			_ = tmp.Close()
 			rollback()
 			return fmt.Errorf("write %s: %w", w.path, writeErr)
+		}
+	}
+	for _, path := range removals {
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			rollback()
+			return fmt.Errorf("read managed %s: %w", path, err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			rollback()
+			return fmt.Errorf("stat managed %s: %w", path, err)
+		}
+		done = append(done, prior{path: path, data: data, mode: info.Mode()})
+		if err := os.Remove(path); err != nil {
+			rollback()
+			return fmt.Errorf("remove managed %s: %w", path, err)
 		}
 	}
 	return nil

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -1,0 +1,489 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chemaclass/agnostic-ai/internal/config"
+	"github.com/chemaclass/agnostic-ai/internal/errs"
+	"github.com/chemaclass/agnostic-ai/internal/spec"
+)
+
+const (
+	globalStart = "<!-- agnostic-ai:global:start -->"
+	globalEnd   = "<!-- agnostic-ai:global:end -->"
+)
+
+type globalSyncOptions struct {
+	targets, only, except                                                    []string
+	dryRun, check, backup, plan, watch, watchPoll, jsonOut, allTargets, diff bool
+	format, gitignore                                                        string
+	jobs                                                                     int
+}
+
+type globalState struct {
+	Version     int              `json:"version"`
+	Files       []string         `json:"files"`
+	ClaudeHooks map[string][]any `json:"claudeHooks,omitempty"`
+	CursorHooks map[string][]any `json:"cursorHooks,omitempty"`
+}
+
+type globalWrite struct {
+	path string
+	data []byte
+	mode fs.FileMode
+}
+
+func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
+	if o.watch || o.watchPoll || o.plan || o.jsonOut || o.allTargets || o.diff || o.gitignore != "" || o.jobs != 0 {
+		return errs.Coded(errs.CodeFlagConflict, "--global does not support --watch, --watch-poll, --plan, --json, --all, --diff, --gitignore, or --jobs")
+	}
+	if len(o.only) > 0 && len(o.except) > 0 {
+		return errs.Coded(errs.CodeFlagConflict, "--only and --except are mutually exclusive")
+	}
+	targets := o.targets
+	if len(targets) == 0 {
+		targets = []string{"claude", "cursor"}
+	}
+	var err error
+	targets, err = filterTargets(targets, o.only, o.except)
+	if err != nil {
+		return err
+	}
+	for _, target := range targets {
+		if target != "claude" && target != "cursor" {
+			return fmt.Errorf("--global: unsupported target %q (supported: claude, cursor)", target)
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	sourceHome := os.Getenv("AGNOSTIC_AI_HOME")
+	if sourceHome == "" {
+		sourceHome = filepath.Join(home, ".agnostic-ai")
+	}
+	source := filepath.Join(sourceHome, "global")
+	cfg := &config.Config{Sources: config.Sources{Rules: "rules", Hooks: "hooks", Skills: "skills"}}
+	bundle, err := spec.LoadBundle(source, cfg)
+	if err != nil {
+		return err
+	}
+	for _, rule := range bundle.Rules {
+		if rule.Scope != "" || hasGlobalRuleCondition(rule.Meta) {
+			return fmt.Errorf("global rule %q is scoped or conditional; global rules must apply unconditionally", rule.Name)
+		}
+	}
+	instructions, err := os.ReadFile(filepath.Join(source, "AGNOSTIC_AI.md"))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", filepath.Join(source, "AGNOSTIC_AI.md"), err)
+	}
+
+	statePath := filepath.Join(sourceHome, "state", "global.json")
+	old, err := loadGlobalState(statePath)
+	if err != nil {
+		return err
+	}
+	writes, next, err := buildGlobalWrites(home, source, targets, instructions, bundle, old)
+	if err != nil {
+		return err
+	}
+	stateData, err := json.MarshalIndent(next, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", statePath, err)
+	}
+	writes = append(writes, globalWrite{statePath, append(stateData, '\n'), 0o644})
+	if err := preflightGlobalWrites(writes, old, next); err != nil {
+		return err
+	}
+	if o.check {
+		for _, w := range writes {
+			data, err := os.ReadFile(w.path)
+			if err != nil || !reflect.DeepEqual(data, w.data) {
+				return fmt.Errorf("global configuration drift: %s", w.path)
+			}
+		}
+		return nil
+	}
+	if o.dryRun {
+		for _, w := range writes {
+			fmt.Fprintf(cmd.OutOrStdout(), "dry-run: write %s\n", w.path)
+		}
+		return nil
+	}
+	if err := applyGlobalWrites(writes, o.backup); err != nil {
+		return err
+	}
+	for _, path := range removedGlobalFiles(old.Files, next.Files) {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove managed %s: %w", path, err)
+		}
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Synced global configuration to %d target(s).\n", len(targets))
+	return nil
+}
+
+func hasGlobalRuleCondition(meta map[string]any) bool {
+	for _, key := range []string{"scope", "globs", "paths", "target", "targets", "target-exclude", "targets-exclude"} {
+		if _, ok := meta[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func loadGlobalState(path string) (globalState, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return globalState{Version: 1}, nil
+	}
+	if err != nil {
+		return globalState{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var state globalState
+	if err := json.Unmarshal(data, &state); err != nil || state.Version != 1 {
+		return globalState{}, fmt.Errorf("parse %s: corrupt global ownership state", path)
+	}
+	return state, nil
+}
+
+func buildGlobalWrites(home, source string, targets []string, intro []byte, b spec.Bundle, old globalState) ([]globalWrite, globalState, error) {
+	next := globalState{Version: 1, Files: append([]string(nil), old.Files...), ClaudeHooks: cloneHookState(old.ClaudeHooks), CursorHooks: cloneHookState(old.CursorHooks)}
+	var writes []globalWrite
+	body := strings.TrimSpace(string(intro))
+	for _, rule := range b.Rules {
+		if body != "" {
+			body += "\n\n"
+		}
+		body += "## " + rule.Name + "\n\n" + strings.TrimSpace(rule.Body)
+	}
+	managed := globalStart + "\n" + body + "\n" + globalEnd
+	for _, target := range targets {
+		base := filepath.Join(home, "."+target)
+		next.Files = removePathPrefix(next.Files, base+string(filepath.Separator))
+		instructionsPath := filepath.Join(base, map[string]string{"claude": "CLAUDE.md", "cursor": "AGENTS.md"}[target])
+		merged, err := mergeGlobalBlock(instructionsPath, managed)
+		if err != nil {
+			return nil, next, err
+		}
+		writes = append(writes, globalWrite{instructionsPath, []byte(merged), 0o644})
+		next.Files = append(next.Files, instructionsPath)
+		for _, skill := range b.Skills {
+			dst := filepath.Join(base, "skills", skill.Name)
+			if err := filepath.WalkDir(filepath.Dir(skill.Path), func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() {
+					return nil
+				}
+				rel, err := filepath.Rel(filepath.Dir(skill.Path), path)
+				if err != nil {
+					return err
+				}
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("read %s: %w", path, err)
+				}
+				out := filepath.Join(dst, rel)
+				info, err := d.Info()
+				if err != nil {
+					return fmt.Errorf("stat %s: %w", path, err)
+				}
+				writes = append(writes, globalWrite{out, data, info.Mode().Perm()})
+				next.Files = append(next.Files, out)
+				return nil
+			}); err != nil {
+				return nil, next, err
+			}
+		}
+		if target == "claude" {
+			next.ClaudeHooks = map[string][]any{}
+			path := filepath.Join(base, "settings.json")
+			doc, err := mergeGlobalHooks(path, "claude", b.Hooks, old.ClaudeHooks, next.ClaudeHooks)
+			if err != nil {
+				return nil, next, err
+			}
+			if doc != nil {
+				writes = append(writes, globalWrite{path, doc, 0o644})
+				next.Files = append(next.Files, path)
+			}
+		} else {
+			next.CursorHooks = map[string][]any{}
+			bridge := filepath.Join(base, "hooks", "agnostic-ai-global-context.sh")
+			script := "#!/bin/sh\nprintf '%s\\n' " + shellQuote(`{"additional_context":`+jsonString(body)+`}`) + "\n"
+			writes = append(writes, globalWrite{bridge, []byte(script), 0o755})
+			next.Files = append(next.Files, bridge)
+			path := filepath.Join(base, "hooks.json")
+			hooks := append([]spec.Entry{}, b.Hooks...)
+			hooks = append(hooks, spec.Entry{Meta: map[string]any{"event": "sessionStart", "command": bridge}})
+			doc, err := mergeGlobalHooks(path, "cursor", hooks, old.CursorHooks, next.CursorHooks)
+			if err != nil {
+				return nil, next, err
+			}
+			writes = append(writes, globalWrite{path, doc, 0o644})
+			next.Files = append(next.Files, path)
+		}
+	}
+	sort.Strings(next.Files)
+	return writes, next, nil
+}
+
+func mergeGlobalBlock(path, managed string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	body := string(data)
+	start, end := strings.Index(body, globalStart), strings.Index(body, globalEnd)
+	if (start >= 0) != (end >= 0) || (start >= 0 && end < start) {
+		return "", fmt.Errorf("%s: corrupt agnostic-ai managed block", path)
+	}
+	if start >= 0 {
+		end += len(globalEnd)
+		body = strings.TrimSpace(body[:start] + body[end:])
+	}
+	body = strings.TrimSpace(body)
+	if strings.TrimSpace(managed) == globalStart+"\n\n"+globalEnd {
+		return body, nil
+	}
+	if body != "" {
+		body += "\n\n"
+	}
+	return body + managed + "\n", nil
+}
+
+func mergeGlobalHooks(path, target string, entries []spec.Entry, previous map[string][]any, next map[string][]any) ([]byte, error) {
+	doc := map[string]any{}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &doc); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	for event, oldEntries := range previous {
+		current, _ := hooks[event].([]any)
+		for _, oldEntry := range oldEntries {
+			var found bool
+			current, found = removeEqual(current, oldEntry)
+			if !found {
+				return nil, fmt.Errorf("%s: managed hook ownership is corrupt for %s", path, event)
+			}
+		}
+		if len(current) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = current
+		}
+	}
+	for _, entry := range entries {
+		event, _ := entry.Meta["event"].(string)
+		if event == "" {
+			continue
+		}
+		for _, command := range globalHookCommands(entry.Meta["command"]) {
+			var item any
+			if target == "claude" {
+				commandHook := map[string]any{"type": "command", "command": command}
+				for _, key := range []string{"timeout", "statusMessage", "async", "asyncRewake", "shell", "if", "once"} {
+					if value, ok := entry.Meta[key]; ok {
+						commandHook[key] = value
+					}
+				}
+				matcher, _ := entry.Meta["matcher"].(string)
+				item = map[string]any{"matcher": matcher, "hooks": []any{commandHook}}
+			} else {
+				cursorHook := map[string]any{"command": command}
+				for _, key := range []string{"matcher", "timeout", "loop_limit", "failClosed"} {
+					if value, ok := entry.Meta[key]; ok {
+						cursorHook[key] = value
+					}
+				}
+				item = cursorHook
+			}
+			current, _ := hooks[event].([]any)
+			hooks[event] = append(current, item)
+			next[event] = append(next[event], item)
+		}
+	}
+	doc["hooks"] = hooks
+	if target == "cursor" {
+		doc["version"] = float64(1)
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s: %w", path, err)
+	}
+	return append(out, '\n'), nil
+}
+
+func removeEqual(items []any, want any) ([]any, bool) {
+	for i, item := range items {
+		if reflect.DeepEqual(item, want) {
+			return append(items[:i], items[i+1:]...), true
+		}
+	}
+	return items, false
+}
+
+func globalHookCommands(raw any) []string {
+	switch value := raw.(type) {
+	case string:
+		if value != "" {
+			return []string{value}
+		}
+	case []any:
+		var out []string
+		for _, item := range value {
+			if command, ok := item.(string); ok && command != "" {
+				out = append(out, command)
+			}
+		}
+		return out
+	case []string:
+		return value
+	}
+	return nil
+}
+func jsonString(s string) string { raw, _ := json.Marshal(s); return string(raw) }
+func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'" }
+
+func preflightGlobalWrites(writes []globalWrite, old, next globalState) error {
+	owned := map[string]bool{}
+	for _, p := range old.Files {
+		owned[p] = true
+	}
+	for _, w := range writes {
+		if strings.Contains(w.path, string(filepath.Separator)+"skills"+string(filepath.Separator)) && !owned[w.path] {
+			if filepath.Base(w.path) == "SKILL.md" {
+				if _, err := os.Stat(filepath.Dir(w.path)); err == nil {
+					return fmt.Errorf("%s: unmanaged global skill collision", filepath.Dir(w.path))
+				}
+			}
+			if _, err := os.Stat(w.path); err == nil {
+				return fmt.Errorf("%s: unmanaged global skill collision", w.path)
+			}
+		}
+		if info, err := os.Lstat(w.path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s: refusing to replace symlink", w.path)
+		}
+	}
+	return nil
+}
+
+func cloneHookState(in map[string][]any) map[string][]any {
+	out := map[string][]any{}
+	for k, v := range in {
+		out[k] = append([]any(nil), v...)
+	}
+	return out
+}
+func removePathPrefix(paths []string, prefix string) []string {
+	out := paths[:0]
+	for _, p := range paths {
+		if !strings.HasPrefix(p, prefix) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func removedGlobalFiles(old, next []string) []string {
+	keep := map[string]bool{}
+	for _, p := range next {
+		keep[p] = true
+	}
+	var out []string
+	for _, p := range old {
+		if !keep[p] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func applyGlobalWrites(writes []globalWrite, backup bool) error {
+	type prior struct {
+		path   string
+		data   []byte
+		mode   fs.FileMode
+		absent bool
+	}
+	var done []prior
+	rollback := func() {
+		for i := len(done) - 1; i >= 0; i-- {
+			p := done[i]
+			if p.absent {
+				_ = os.Remove(p.path)
+			} else {
+				_ = os.WriteFile(p.path, p.data, p.mode)
+			}
+		}
+	}
+	for _, w := range writes {
+		old, err := os.ReadFile(w.path)
+		absent := os.IsNotExist(err)
+		if err != nil && !absent {
+			rollback()
+			return fmt.Errorf("read %s: %w", w.path, err)
+		}
+		if !absent && reflect.DeepEqual(old, w.data) {
+			continue
+		}
+		mode := fs.FileMode(0o644)
+		if info, statErr := os.Stat(w.path); statErr == nil {
+			mode = info.Mode()
+		}
+		done = append(done, prior{w.path, old, mode, absent})
+		if err := os.MkdirAll(filepath.Dir(w.path), 0o755); err != nil {
+			rollback()
+			return fmt.Errorf("create directory for %s: %w", w.path, err)
+		}
+		if backup && !absent {
+			if err := os.WriteFile(w.path+".bak", old, mode); err != nil {
+				rollback()
+				return fmt.Errorf("backup %s: %w", w.path, err)
+			}
+		}
+		tmp, err := os.CreateTemp(filepath.Dir(w.path), ".agnostic-ai-global-*")
+		if err != nil {
+			rollback()
+			return fmt.Errorf("create temporary file for %s: %w", w.path, err)
+		}
+		tmpName := tmp.Name()
+		writeErr := func() error {
+			defer os.Remove(tmpName)
+			if _, err := tmp.Write(w.data); err != nil {
+				return err
+			}
+			if err := tmp.Chmod(w.mode); err != nil {
+				return err
+			}
+			if err := tmp.Close(); err != nil {
+				return err
+			}
+			return os.Rename(tmpName, w.path)
+		}()
+		if writeErr != nil {
+			_ = tmp.Close()
+			rollback()
+			return fmt.Errorf("write %s: %w", w.path, writeErr)
+		}
+	}
+	return nil
+}

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -19,8 +19,10 @@ import (
 )
 
 const (
-	globalStart = "<!-- agnostic-ai:global:start -->"
-	globalEnd   = "<!-- agnostic-ai:global:end -->"
+	globalStart       = "<!-- agnostic-ai:global:start -->"
+	globalEnd         = "<!-- agnostic-ai:global:end -->"
+	envUserGlobalRoot = "AGNOSTIC_AI_HOME"
+	defaultUserGlobal = ".agnostic-ai"
 )
 
 type globalSyncOptions struct {

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -70,9 +71,9 @@ func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
 		}
 	}
 
-	home, err := os.UserHomeDir()
+	home, err := globalUserHome()
 	if err != nil {
-		return fmt.Errorf("resolve home directory: %w", err)
+		return err
 	}
 	sourceHome := os.Getenv("AGNOSTIC_AI_HOME")
 	if sourceHome == "" {
@@ -225,13 +226,12 @@ func buildGlobalWrites(home, source string, targets []string, intro []byte, b sp
 			}
 		} else {
 			next.CursorHooks = map[string][]any{}
-			bridge := filepath.Join(base, "hooks", "agnostic-ai-global-context.sh")
-			script := "#!/bin/sh\nprintf '%s\\n' " + shellQuote(`{"additional_context":`+jsonString(body)+`}`) + "\n"
-			writes = append(writes, globalWrite{bridge, []byte(script), 0o755})
+			bridge, command, script, mode := cursorGlobalBridge(base, body)
+			writes = append(writes, globalWrite{bridge, []byte(script), mode})
 			next.Files = append(next.Files, bridge)
 			path := filepath.Join(base, "hooks.json")
 			hooks := append([]spec.Entry{}, b.Hooks...)
-			hooks = append(hooks, spec.Entry{Meta: map[string]any{"event": "sessionStart", "command": bridge}})
+			hooks = append(hooks, spec.Entry{Meta: map[string]any{"event": "sessionStart", "command": command}})
 			doc, err := mergeGlobalHooks(path, "cursor", hooks, old.CursorHooks, next.CursorHooks)
 			if err != nil {
 				return nil, next, err
@@ -368,6 +368,29 @@ func globalHookCommands(raw any) []string {
 }
 func jsonString(s string) string { raw, _ := json.Marshal(s); return string(raw) }
 func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'" }
+
+func globalUserHome() (string, error) {
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return home, nil
+}
+
+func cursorGlobalBridge(base, body string) (path, command, script string, mode fs.FileMode) {
+	payload := `{"additional_context":` + jsonString(body) + `}`
+	if runtime.GOOS == "windows" {
+		path = filepath.Join(base, "hooks", "agnostic-ai-global-context.ps1")
+		command = `powershell -NoProfile -ExecutionPolicy Bypass -File "` + strings.ReplaceAll(path, `"`, `\"`) + `"`
+		script = "$payload = '" + strings.ReplaceAll(payload, "'", "''") + "'\r\n[Console]::Out.WriteLine($payload)\r\n"
+		return path, command, script, 0o644
+	}
+	path = filepath.Join(base, "hooks", "agnostic-ai-global-context.sh")
+	return path, path, "#!/bin/sh\nprintf '%s\\n' " + shellQuote(payload) + "\n", 0o755
+}
 
 func preflightGlobalWrites(writes []globalWrite, old, next globalState) error {
 	owned := map[string]bool{}

--- a/internal/cli/sync_global_test.go
+++ b/internal/cli/sync_global_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSyncGlobal_WorksOutsideProjectAndPreservesNativeText(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	source := filepath.Join(home, "source", "global")
+	mustWriteGlobalTest(t, filepath.Join(source, "AGNOSTIC_AI.md"), "Shared instructions\n")
+	mustWriteGlobalTest(t, filepath.Join(source, "rules", "safe.md"), "---\nname: safe\n---\nBe safe.\n")
+	mustWriteGlobalTest(t, filepath.Join(source, "skills", "review", "SKILL.md"), "---\nname: review\ndescription: Review code\n---\nReview it.\n")
+	mustWriteGlobalTest(t, filepath.Join(home, ".claude", "CLAUDE.md"), "Personal text.\n")
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync --global: %v", err)
+	}
+	for _, path := range []string{filepath.Join(home, ".claude", "CLAUDE.md"), filepath.Join(home, ".cursor", "AGENTS.md")} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		got := string(data)
+		if !strings.Contains(got, "Shared instructions") || !strings.Contains(got, "Be safe") {
+			t.Errorf("%s missing managed instructions:\n%s", path, got)
+		}
+	}
+	claude, _ := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	if !strings.Contains(string(claude), "Personal text.") {
+		t.Error("sync replaced unrelated Claude instructions")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "review", "SKILL.md")); err != nil {
+		t.Error(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".cursor", "skills", "review", "SKILL.md")); err != nil {
+		t.Error(err)
+	}
+	bridge := filepath.Join(home, ".cursor", "hooks", "agnostic-ai-global-context.sh")
+	out, err := exec.Command(bridge).Output()
+	if err != nil {
+		t.Fatalf("run Cursor bridge: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(out, &payload); err != nil || !strings.Contains(payload["additional_context"], "Shared instructions") {
+		t.Fatalf("invalid Cursor bridge payload %q: %v", out, err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--check"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("second check: %v", err)
+	}
+}
+
+func TestSyncGlobal_PreflightRejectsUnmanagedSkillBeforeWrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "AGNOSTIC_AI.md"), "new\n")
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "skills", "review", "SKILL.md"), "---\nname: review\n---\nmanaged\n")
+	mustWriteGlobalTest(t, filepath.Join(home, ".cursor", "skills", "review", "SKILL.md"), "unmanaged\n")
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unmanaged") {
+		t.Fatalf("want unmanaged collision, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".claude", "CLAUDE.md")); !os.IsNotExist(statErr) {
+		t.Error("preflight wrote Claude output before detecting Cursor collision")
+	}
+}
+
+func TestSyncGlobal_RejectsScopedRuleAndUnsupportedFlags(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "rules", "backend", "safe.md"), "---\nname: safe\n---\nSafe.\n")
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "scoped") {
+		t.Fatalf("want scoped rule error, got %v", err)
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--watch"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "--watch") {
+		t.Fatalf("want flag error, got %v", err)
+	}
+}
+
+func TestSyncGlobal_PreservesAndRemovesOnlyManagedHooks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	sourceHook := filepath.Join(home, "source", "global", "hooks", "notify.yaml")
+	mustWriteGlobalTest(t, sourceHook, "name: notify\nevent: sessionStart\ncommand: managed-command\n")
+	mustWriteGlobalTest(t, filepath.Join(home, ".cursor", "hooks.json"), "{\n  \"version\": 1,\n  \"theme\": \"dark\",\n  \"hooks\": {\"sessionStart\": [{\"command\": \"user-command\"}]}\n}\n")
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--only", "cursor"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(sourceHook); err != nil {
+		t.Fatal(err)
+	}
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--only", "cursor"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".cursor", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "user-command") || !strings.Contains(got, `"theme": "dark"`) {
+		t.Fatalf("unrelated Cursor configuration was lost:\n%s", got)
+	}
+	if strings.Contains(got, "managed-command") {
+		t.Fatalf("removed managed hook remains:\n%s", got)
+	}
+}
+
+func mustWriteGlobalTest(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/sync_global_test.go
+++ b/internal/cli/sync_global_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -12,6 +13,7 @@ import (
 func TestSyncGlobal_WorksOutsideProjectAndPreservesNativeText(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
 	source := filepath.Join(home, "source", "global")
 	mustWriteGlobalTest(t, filepath.Join(source, "AGNOSTIC_AI.md"), "Shared instructions\n")
@@ -44,14 +46,16 @@ func TestSyncGlobal_WorksOutsideProjectAndPreservesNativeText(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, ".cursor", "skills", "review", "SKILL.md")); err != nil {
 		t.Error(err)
 	}
-	bridge := filepath.Join(home, ".cursor", "hooks", "agnostic-ai-global-context.sh")
-	out, err := exec.Command(bridge).Output()
-	if err != nil {
-		t.Fatalf("run Cursor bridge: %v", err)
-	}
-	var payload map[string]string
-	if err := json.Unmarshal(out, &payload); err != nil || !strings.Contains(payload["additional_context"], "Shared instructions") {
-		t.Fatalf("invalid Cursor bridge payload %q: %v", out, err)
+	if runtime.GOOS != "windows" {
+		bridge := filepath.Join(home, ".cursor", "hooks", "agnostic-ai-global-context.sh")
+		out, err := exec.Command(bridge).Output()
+		if err != nil {
+			t.Fatalf("run Cursor bridge: %v", err)
+		}
+		var payload map[string]string
+		if err := json.Unmarshal(out, &payload); err != nil || !strings.Contains(payload["additional_context"], "Shared instructions") {
+			t.Fatalf("invalid Cursor bridge payload %q: %v", out, err)
+		}
 	}
 
 	root = NewRootCmd("test")
@@ -64,6 +68,7 @@ func TestSyncGlobal_WorksOutsideProjectAndPreservesNativeText(t *testing.T) {
 func TestSyncGlobal_PreflightRejectsUnmanagedSkillBeforeWrites(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
 	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "AGNOSTIC_AI.md"), "new\n")
 	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "skills", "review", "SKILL.md"), "---\nname: review\n---\nmanaged\n")
@@ -83,6 +88,7 @@ func TestSyncGlobal_PreflightRejectsUnmanagedSkillBeforeWrites(t *testing.T) {
 func TestSyncGlobal_RejectsScopedRuleAndUnsupportedFlags(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
 	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "rules", "backend", "safe.md"), "---\nname: safe\n---\nSafe.\n")
 	root := NewRootCmd("test")
@@ -101,6 +107,7 @@ func TestSyncGlobal_RejectsScopedRuleAndUnsupportedFlags(t *testing.T) {
 func TestSyncGlobal_PreservesAndRemovesOnlyManagedHooks(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
 	sourceHook := filepath.Join(home, "source", "global", "hooks", "notify.yaml")
 	mustWriteGlobalTest(t, sourceHook, "name: notify\nevent: sessionStart\ncommand: managed-command\n")

--- a/internal/cli/sync_global_test.go
+++ b/internal/cli/sync_global_test.go
@@ -15,7 +15,7 @@ func TestSyncGlobal_WorksOutsideProjectAndPreservesNativeText(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
-	source := filepath.Join(home, "source", "global")
+	source := filepath.Join(home, "source")
 	mustWriteGlobalTest(t, filepath.Join(source, "AGNOSTIC_AI.md"), "Shared instructions\n")
 	mustWriteGlobalTest(t, filepath.Join(source, "rules", "safe.md"), "---\nname: safe\n---\nBe safe.\n")
 	mustWriteGlobalTest(t, filepath.Join(source, "skills", "review", "SKILL.md"), "---\nname: review\ndescription: Review code\n---\nReview it.\n")
@@ -70,8 +70,8 @@ func TestSyncGlobal_PreflightRejectsUnmanagedSkillBeforeWrites(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
-	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "AGNOSTIC_AI.md"), "new\n")
-	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "skills", "review", "SKILL.md"), "---\nname: review\n---\nmanaged\n")
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "AGNOSTIC_AI.md"), "new\n")
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "skills", "review", "SKILL.md"), "---\nname: review\n---\nmanaged\n")
 	mustWriteGlobalTest(t, filepath.Join(home, ".cursor", "skills", "review", "SKILL.md"), "unmanaged\n")
 
 	root := NewRootCmd("test")
@@ -90,7 +90,7 @@ func TestSyncGlobal_RejectsScopedRuleAndUnsupportedFlags(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
-	mustWriteGlobalTest(t, filepath.Join(home, "source", "global", "rules", "backend", "safe.md"), "---\nname: safe\n---\nSafe.\n")
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "rules", "backend", "safe.md"), "---\nname: safe\n---\nSafe.\n")
 	root := NewRootCmd("test")
 	root.SetArgs([]string{"sync", "--global"})
 	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "scoped") {
@@ -109,7 +109,7 @@ func TestSyncGlobal_PreservesAndRemovesOnlyManagedHooks(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
-	sourceHook := filepath.Join(home, "source", "global", "hooks", "notify.yaml")
+	sourceHook := filepath.Join(home, "source", "hooks", "notify.yaml")
 	mustWriteGlobalTest(t, sourceHook, "name: notify\nevent: sessionStart\ncommand: managed-command\n")
 	mustWriteGlobalTest(t, filepath.Join(home, ".cursor", "hooks.json"), "{\n  \"version\": 1,\n  \"theme\": \"dark\",\n  \"hooks\": {\"sessionStart\": [{\"command\": \"user-command\"}]}\n}\n")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -278,7 +278,7 @@ type ClaudePermissions struct {
 //
 // These fields are written into the project-tier `.codex/config.toml` on each
 // sync. Keys not listed here (e.g. user-specific overrides) belong in the
-// user-global `~/.codex/config.toml` which Codex merges last.
+// user-level `~/.codex/config.toml` which Codex merges last.
 type CodexConfig struct {
 	Sandbox               string                        `yaml:"sandbox,omitempty"                 json:"sandbox,omitempty"`
 	ApprovalPolicy        string                        `yaml:"approval-policy,omitempty"         json:"approval-policy,omitempty"`

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -56,7 +56,7 @@ type Entry struct {
 	// (Claude CLAUDE.md, Gemini, Aider, Copilot) merge regardless.
 	Scope string
 	// Layer names the source layer this entry came from
-	// ("user-global", "project", "project-user"). Empty when loaded
+	// ("pack:<name>", "project", "project-user"). Empty when loaded
 	// outside the layered loader (legacy path).
 	Layer string
 	Meta  map[string]any


### PR DESCRIPTION
## Summary

- add opt-in `agnostic-ai sync --global`, reading instructions, unconditional rules, hooks, and skills directly from `$AGNOSTIC_AI_HOME` (default `~/.agnostic-ai/`)
- emit native Claude Code and Cursor user configuration with managed ownership, preservation, atomic preflight, and a self-contained Cursor session context bridge
- make ordinary `agnostic-ai sync` project-only by removing the former automatic user-global layer
- document the single-root mental model, native paths, precedence, limitations, and migration from old project-default global specs

## Acceptance scenario

From any directory, place shared sources directly under `~/.agnostic-ai/`:

```text
~/.agnostic-ai/
├── AGNOSTIC_AI.md
├── rules/
├── hooks/
└── skills/
```

Run `agnostic-ai sync --global`. Claude Code and Cursor receive working native user configuration. A later ordinary project sync loads only packs, project specs, and `.agnostic-ai.local/`; it cannot emit the same global sources into project outputs.

## Migration

Existing project-default specs under `~/.agnostic-ai/` no longer join ordinary project sync. Rules, hooks, and skills there become native global inputs when `sync --global` runs. Move synced-project-only defaults and unsupported global kinds into each project's `.agnostic-ai/` tree or a pinned pack.

## Non-goals

Other targets, cross-scope inheritance, project config or packs in global mode, agents, commands, MCP servers, settings, reviews, environments, ignore specs, scoped global rules, authoring or migration automation, watch mode, UI automation, symlinks, and remote agents.

## Test plan

- [x] targeted global, layer, and pack tests
- [x] `go test ./internal/cli -count=1`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `make build`
- [x] Windows CLI-test cross-compile
- [x] `git diff --check`
- [x] final KISS-model validation
- [x] CI rerun

The earlier project `./agnostic-ai sync --check` reports pre-existing generated target drift unrelated to this branch. No config schema or spec-format field changed.

Closes #680

