### PR TITLE
feat(sync): extend global sync to every documented target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Added
 
-- `agnostic-ai sync --global` emits shared user-level instructions, hooks, and skills as native Claude Code and Cursor configuration directly from `~/.agnostic-ai/`, while preserving unrelated native configuration and keeping project sync isolated (#680).
+- `agnostic-ai sync --global` emits shared user-level instructions, hooks, and skills as native configuration directly from `~/.agnostic-ai/`, while preserving unrelated native configuration and keeping project sync isolated (#680).
+- `sync --global` now covers 22 of the 25 targets instead of Claude Code and Cursor alone, each at its own documented user-level path. Rules inline into the instructions file, or land in `~/.augment/rules/` for the one target that documents no user-level instructions file. Hooks reach Codex, Gemini, and Qoder, which share Claude Code's documented schema at user scope. Aider, Continue, and Jules are excluded: no vendor documents an auto-loaded user-level surface for them (#680).
 
 - Codex MCP servers emit the vendor's per-tool sub-tables from a `tools` map: `[mcp_servers.<name>.tools.<tool>]`, keys passed through verbatim, covering `output_token_limit` (shipped in Codex v0.153.0) and the per-tool approval override. The block was dropped in silence before, with no warning and no coverage note (#678).
 - `outputs.claude.settings.bashOutputMaxChars` and `.taskOutputMaxChars` raise how much command and background-task output Claude Code takes inline before spilling it to a file, up to 128K characters. Both shipped in Claude Code v2.1.261 and previously had no declarative path, only the captured overlay (#679).

--- a/README.md
+++ b/README.md
@@ -167,4 +167,4 @@ Put user-wide instructions in `~/.agnostic-ai/AGNOSTIC_AI.md`, with optional `ru
 agnostic-ai sync --global
 ```
 
-This mode is opt-in and separate from project sync. It writes native user configuration for Claude Code and Cursor. See [global configuration](docs/user/configuration.md#global-configuration).
+This mode is opt-in and separate from project sync. It writes native user configuration for 22 of the 25 targets. See [global configuration](docs/user/configuration.md#global-configuration).

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -256,7 +256,7 @@ agnostic-ai sync [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--global` | Install user-level instructions, unconditional rules, hooks, and skills directly from `$AGNOSTIC_AI_HOME` (default `~/.agnostic-ai/`) into native Claude Code and Cursor config. Works outside a project and never loads project config or packs. |
+| `--global` | Install user-level instructions, unconditional rules, hooks, and skills directly from `$AGNOSTIC_AI_HOME` (default `~/.agnostic-ai/`) into each tool's native user config. Covers 22 targets; see [global output](targets.md#global-output). Works outside a project and never loads project config or packs. |
 | `-t, --target <list>` | Comma-separated targets (default: all in config) |
 | `--only <list>` | Emit only these targets (comma-separated). Mutually exclusive with `--except`. Errors on unknown names. |
 | `--except <list>` | Emit all configured targets except these (comma-separated). Mutually exclusive with `--only`. Errors on unknown names. |

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -2,7 +2,7 @@
 
 ## Global configuration
 
-`agnostic-ai sync --global` syncs user-level instructions, rules, hooks, and skills to Claude Code and Cursor. It works from any directory and does not load `agnostic-ai.yaml`, packs, local overrides, or project specs.
+`agnostic-ai sync --global` syncs user-level instructions, rules, hooks, and skills to 22 of the 25 targets. It works from any directory and does not load `agnostic-ai.yaml`, packs, local overrides, or project specs. See [global output](targets.md#global-output) for the per-target paths and for the three targets that document no user-level surface.
 
 The source root is `$AGNOSTIC_AI_HOME`, or `~/.agnostic-ai/` when `AGNOSTIC_AI_HOME` is unset:
 
@@ -14,11 +14,13 @@ The source root is `$AGNOSTIC_AI_HOME`, or `~/.agnostic-ai/` when `AGNOSTIC_AI_H
 └── skills/<name>/SKILL.md
 ```
 
-Run `agnostic-ai sync --global`. Both targets are enabled by default. `--target`, `--only`, and `--except` can narrow the set to `claude` or `cursor`. `--dry-run`, `--check`, and `--backup` retain their normal meaning. Project-only flags such as `--watch`, `--plan`, `--json`, `--gitignore`, and `--jobs` are rejected before any write.
+Run `agnostic-ai sync --global`. Every supported target is enabled by default. `--target`, `--only`, and `--except` narrow the set; naming a target with no user-level surface fails with the supported list. `--dry-run`, `--check`, and `--backup` retain their normal meaning. Project-only flags such as `--watch`, `--plan`, `--json`, `--gitignore`, and `--jobs` are rejected before any write.
 
 Global rules must be unconditional. A nested rule or a rule with scope, path, glob, or target conditions is rejected rather than flattened. Global mode does not support agents, commands, MCP servers, settings, inheritance, or merging with project specs.
 
-Generated files are real files, never symlinks. Managed instruction blocks, hook entries, and skill assets are recorded under `$AGNOSTIC_AI_HOME/state/global.json`. Sync preserves unrelated text, JSON keys, hooks, and skills. It removes only artifacts recorded as managed. An unmanaged skill collision, damaged managed marker, invalid native JSON file, or corrupt ownership state stops the whole operation before writes. Native tool precedence still applies when both global and project configuration exist.
+Generated files are real files, never symlinks. Managed instruction blocks, hook entries, and skill assets are recorded per target under `$AGNOSTIC_AI_HOME/state/global.json`. Sync preserves unrelated text, JSON keys, hooks, and skills. It removes only artifacts recorded as managed, and only for the targets in the current run, so `--only` never sweeps another target's output. An unmanaged skill or rule collision, damaged managed marker, invalid native JSON file, or corrupt ownership state stops the whole operation before writes. Native tool precedence still applies when both global and project configuration exist.
+
+Nothing is created for a surface with no content. A target whose instructions body and rules are both empty gets no instructions file, and one already recorded is removed rather than left empty. A target with no hooks gets no hooks file seeded into its config directory.
 
 Migration: ordinary `agnostic-ai sync` no longer loads specs from `~/.agnostic-ai/`. Rules, hooks, and skills already stored there become native global inputs when you run `sync --global`. Move defaults intended only for project output into each project's `.agnostic-ai/` tree or a shared pack. Move unsupported old global kinds such as agents, MCP servers, commands, settings, reviews, environments, and ignore specs into projects or packs because global mode does not load them.
 

--- a/docs/user/targets.md
+++ b/docs/user/targets.md
@@ -2,14 +2,44 @@
 
 ## Global output
 
-`sync --global` supports Claude Code and Cursor only. These paths are user-level and are independent of the project outputs documented below.
+`sync --global` writes user-level configuration for 22 of the 25 targets. These paths are independent of the project outputs documented below. A dash means the vendor documents no user-level surface of that kind, so nothing is written rather than a path being guessed (target-audit 2026-09-07).
 
-| Target | Instructions | Hooks | Skills |
-|--------|--------------|-------|--------|
-| Claude Code | `~/.claude/CLAUDE.md` | `~/.claude/settings.json` | `~/.claude/skills/<name>/` |
-| Cursor | `~/.cursor/AGENTS.md` | `~/.cursor/hooks.json` | `~/.cursor/skills/<name>/` |
+| Target | Instructions | Rules | Hooks | Skills |
+|--------|--------------|-------|-------|--------|
+| **claude** | `~/.claude/CLAUDE.md` | inlined | `~/.claude/settings.json` | `~/.claude/skills/<name>/` |
+| **cursor** | `~/.cursor/AGENTS.md` (bridged) | inlined | `~/.cursor/hooks.json` | `~/.cursor/skills/<name>/` |
+| **codex** | `~/.codex/AGENTS.md` | inlined | `~/.codex/hooks.json` | `~/.agents/skills/<name>/` |
+| **gemini** | `~/.gemini/GEMINI.md` | inlined | `~/.gemini/settings.json` | `~/.gemini/skills/<name>/` |
+| **qoder** | `~/.qoder/AGENTS.md` | inlined | `~/.qoder/settings.json` | `~/.qoder/skills/<name>/` |
+| **copilot** | `~/.copilot/copilot-instructions.md` | inlined | - | `~/.copilot/skills/<name>/` |
+| **cline** | `~/.agents/AGENTS.md` | inlined | - | `~/.cline/skills/<name>/` |
+| **windsurf** | `~/.config/devin/AGENTS.md` | inlined | - | `~/.agents/skills/<name>/` |
+| **amp** | `~/.config/amp/AGENTS.md` | inlined | - | `~/.agents/skills/<name>/` |
+| **zed** | `~/.config/zed/AGENTS.md` | inlined | - | `~/.agents/skills/<name>/` |
+| **warp** | `~/.agents/AGENTS.md` | inlined | - | `~/.agents/skills/<name>/` |
+| **opencode** | `~/.config/opencode/AGENTS.md` | inlined | - | `~/.config/opencode/skills/<name>/` |
+| **antigravity** | `~/.gemini/GEMINI.md` | inlined | - | `~/.gemini/antigravity/skills/<name>/` |
+| **junie** | `~/.junie/AGENTS.md` | inlined | - | `~/.junie/skills/<name>/` |
+| **kiro** | `~/.kiro/steering/AGENTS.md` | inlined | - | `~/.kiro/skills/<name>/` |
+| **crush** | `~/.config/crush/CRUSH.md` | inlined | - | `~/.config/crush/skills/<name>/` |
+| **factory** | `~/.factory/AGENTS.md` | inlined | - | `~/.factory/skills/<name>/` |
+| **kilo** | `~/.config/kilo/AGENTS.md` | inlined | - | `~/.kilo/skills/<name>/` |
+| **goose** | `~/.config/goose/.goosehints` | inlined | - | `~/.agents/skills/<name>/` |
+| **openhands** | - | - | - | `~/.agents/skills/<name>/` |
+| **trae** | - | - | - | `~/.trae/skills/<name>/` |
+| **augment** | - | `~/.augment/rules/<name>.md` | - | `~/.augment/skills/<name>/` |
 
-Cursor does not automatically load the home-level `AGENTS.md`. Global sync therefore installs a managed `sessionStart` hook and a self-contained script bridge under `~/.cursor/hooks/` (POSIX shell on macOS and Linux, PowerShell on Windows). The bridge returns the rendered instructions as valid `additional_context` JSON without calling agnostic-ai, Python, or jq. Cursor session-start hooks are fire-and-forget context injection, not enforced policy. Existing `sessionStart` entries remain in place.
+Rules inline into the instructions file, under the same sentinel-marked managed block as the shared instructions body. Augment is the one exception: the vendor documents no user-level instructions file for the CLI (`~/.augment/user-guidelines.md` is VS Code only), and its `~/.augment/rules/` entries are "always treated as `always_apply`", which is exactly what a global rule is. Every path marked `~/.config/` follows `XDG_CONFIG_HOME` when that variable is set.
+
+Three targets are absent by verdict. Aider reaches a home instructions file only through a `read:` entry in `~/.aider.conf.yml`, never automatically. Continue's one documented home surface is the `rules:` list inside the `config.yaml` that Continue itself rewrites. Jules documents nothing at user scope at all: its CLI reference has no config file and no home path.
+
+Several targets share a path on purpose, and the shared write happens once. `~/.agents/skills/` is read by codex, windsurf, amp, zed, warp, goose, and openhands; `~/.agents/AGENTS.md` by cline and warp; `~/.gemini/GEMINI.md` by gemini and antigravity. Two targets resolving to one path with different bytes is a hard error naming the path, not a last-writer-wins race.
+
+Hooks reach five targets. Claude Code, Codex, Gemini, and Qoder all document the Claude-style `{"hooks": {"<Event>": [{"matcher", "hooks": [...]}]}}` shape at user scope, so one renderer serves them; Cursor keeps its own. The other seventeen are declined for a stated reason, not for lack of a surface: Factory keys `hooks.json` directly by event with no wrapper, Augment measures `timeout` in milliseconds and requires a script extension, Copilot uses `version: 1` with camelCase events and `timeoutSec`, Cascade uses snake_case events with no matcher, Antigravity nests events under a named hook object, Crush supports `PreToolUse` alone, Goose needs a wrapping plugin directory plus a manifest, Junie's are Early Access, Kiro uses a `{"version": "v1", "hooks": [...]}` array, and Amp, OpenCode, and Cline expose hooks only as TypeScript plugin modules. Adding those shapes is tracked in #629, which covers the same schemas at project tier.
+
+Cursor does not automatically load the home-level `AGENTS.md`. Global sync therefore installs a managed `sessionStart` hook and a self-contained script bridge under `~/.cursor/hooks/` (POSIX shell on macOS and Linux, PowerShell on Windows). The bridge returns the rendered instructions as valid `additional_context` JSON without calling agnostic-ai, Python, or jq. Cursor session-start hooks are fire-and-forget context injection, not enforced policy. Existing `sessionStart` entries remain in place. Every other instructions path in the table above auto-loads, so Cursor is the only target that needs the bridge.
+
+Two interactions to know before enabling everything at once. OpenCode reads `~/.claude/CLAUDE.md` only when `~/.config/opencode/AGENTS.md` does not exist, so syncing both targets moves OpenCode onto its own file and any user text that lived only in the Claude file stops reaching it. Devin CLI and VS Code Copilot read `~/.claude/` surfaces by default, so a user syncing claude plus windsurf or copilot gets the same instructions body through two paths.
 
 Each adapter emits in its tool's native format: separate files where the tool supports them, a merged document otherwise. Unsupported features (e.g. hooks for a non-hook-aware target) skip with a warning by default. Override via `on-unsupported` in [configuration](configuration.md).
 

--- a/internal/cli/global_targets.go
+++ b/internal/cli/global_targets.go
@@ -4,28 +4,34 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
-// globalTarget describes where one tool keeps its user-level
-// configuration. Every path is relative to the target's own config
-// directory, which is itself resolved against the user home (or
-// XDG_CONFIG_HOME when xdg is set).
+// Path prefixes used in the globalTargets table. A path carries its own
+// root because several tools split surfaces across two roots: Kilo Code
+// reads instructions from ~/.config/kilo/ but skills from ~/.kilo/, and
+// Goose reads hints from ~/.config/goose/ but skills from ~/.agents/.
+const (
+	globalPathHome = "home:"
+	globalPathXDG  = "xdg:"
+)
+
+// globalTarget describes one tool's user-level surfaces. Every field is
+// a table path (see globalPathHome / globalPathXDG).
 //
-// A field left empty means the vendor documents no user-level surface
-// of that kind; sync --global then emits nothing for it rather than
-// guessing a path.
+// An empty field means the vendor documents no user-level surface of
+// that kind, so sync --global emits nothing for it rather than guessing
+// a path.
 type globalTarget struct {
-	// dir is the config directory relative to the user home. Ignored
-	// when xdg is set.
-	dir string
-	// xdg is the config directory relative to XDG_CONFIG_HOME
-	// (default ~/.config) for tools that follow the base-dir spec.
-	xdg string
-	// instructions is the always-on context file inside the config dir.
+	// instructions is the always-on context file the tool loads with no
+	// wiring. Global rules inline into it.
 	instructions string
-	// skills is the skills directory inside the config dir.
+	// rules is a per-rule directory, used only for a target whose
+	// vendor documents no user-level instructions file at all.
+	rules string
+	// skills is the skills directory.
 	skills string
-	// hooks is the hooks file inside the config dir.
+	// hooks is the hooks file.
 	hooks string
 	// hooksFormat selects the native hooks schema: "claude" or "cursor".
 	hooksFormat string
@@ -41,11 +47,115 @@ type globalTarget struct {
 	bridgeKey string
 }
 
-// globalTargets maps target name to its user-level surfaces. Only
-// targets listed here are accepted by sync --global.
+// globalTargets maps target name to its user-level surfaces, as
+// documented by each vendor (target-audit 2026-09-07). Only targets
+// listed here are accepted by sync --global.
+//
+// Absent by verdict: aider (a home instructions file reaches it only
+// through a `read:` entry in ~/.aider.conf.yml, never automatically),
+// continue (its one home surface is the `rules:` list inside the
+// config.yaml Continue itself rewrites), and jules (nothing documented
+// at user scope at all).
 var globalTargets = map[string]globalTarget{
-	"claude": {dir: ".claude", instructions: "CLAUDE.md", skills: "skills", hooks: "settings.json", hooksFormat: "claude"},
-	"cursor": {dir: ".cursor", instructions: "AGENTS.md", skills: "skills", hooks: "hooks.json", hooksFormat: "cursor", bridge: true, bridgeEvent: "sessionStart", bridgeKey: "additional_context"},
+	"claude": {
+		instructions: globalPathHome + ".claude/CLAUDE.md",
+		skills:       globalPathHome + ".claude/skills",
+		hooks:        globalPathHome + ".claude/settings.json",
+		hooksFormat:  "claude",
+	},
+	"cursor": {
+		instructions: globalPathHome + ".cursor/AGENTS.md",
+		skills:       globalPathHome + ".cursor/skills",
+		hooks:        globalPathHome + ".cursor/hooks.json",
+		hooksFormat:  "cursor",
+		bridge:       true,
+		bridgeEvent:  "sessionStart",
+		bridgeKey:    "additional_context",
+	},
+	"codex": {
+		instructions: globalPathHome + ".codex/AGENTS.md",
+		skills:       globalPathHome + ".agents/skills",
+		hooks:        globalPathHome + ".codex/hooks.json",
+		hooksFormat:  "claude",
+	},
+	"gemini": {
+		instructions: globalPathHome + ".gemini/GEMINI.md",
+		skills:       globalPathHome + ".gemini/skills",
+		hooks:        globalPathHome + ".gemini/settings.json",
+		hooksFormat:  "claude",
+	},
+	"qoder": {
+		instructions: globalPathHome + ".qoder/AGENTS.md",
+		skills:       globalPathHome + ".qoder/skills",
+		hooks:        globalPathHome + ".qoder/settings.json",
+		hooksFormat:  "claude",
+	},
+	"copilot": {
+		instructions: globalPathHome + ".copilot/copilot-instructions.md",
+		skills:       globalPathHome + ".copilot/skills",
+	},
+	"cline": {
+		instructions: globalPathHome + ".agents/AGENTS.md",
+		skills:       globalPathHome + ".cline/skills",
+	},
+	"windsurf": {
+		instructions: globalPathXDG + "devin/AGENTS.md",
+		skills:       globalPathHome + ".agents/skills",
+	},
+	"amp": {
+		instructions: globalPathXDG + "amp/AGENTS.md",
+		skills:       globalPathHome + ".agents/skills",
+	},
+	"zed": {
+		instructions: globalPathXDG + "zed/AGENTS.md",
+		skills:       globalPathHome + ".agents/skills",
+	},
+	"warp": {
+		instructions: globalPathHome + ".agents/AGENTS.md",
+		skills:       globalPathHome + ".agents/skills",
+	},
+	"opencode": {
+		instructions: globalPathXDG + "opencode/AGENTS.md",
+		skills:       globalPathXDG + "opencode/skills",
+	},
+	"antigravity": {
+		instructions: globalPathHome + ".gemini/GEMINI.md",
+		skills:       globalPathHome + ".gemini/antigravity/skills",
+	},
+	"junie": {
+		instructions: globalPathHome + ".junie/AGENTS.md",
+		skills:       globalPathHome + ".junie/skills",
+	},
+	"kiro": {
+		instructions: globalPathHome + ".kiro/steering/AGENTS.md",
+		skills:       globalPathHome + ".kiro/skills",
+	},
+	"crush": {
+		instructions: globalPathXDG + "crush/CRUSH.md",
+		skills:       globalPathXDG + "crush/skills",
+	},
+	"factory": {
+		instructions: globalPathHome + ".factory/AGENTS.md",
+		skills:       globalPathHome + ".factory/skills",
+	},
+	"kilo": {
+		instructions: globalPathXDG + "kilo/AGENTS.md",
+		skills:       globalPathHome + ".kilo/skills",
+	},
+	"goose": {
+		instructions: globalPathXDG + "goose/.goosehints",
+		skills:       globalPathHome + ".agents/skills",
+	},
+	"openhands": {
+		skills: globalPathHome + ".agents/skills",
+	},
+	"trae": {
+		skills: globalPathHome + ".trae/skills",
+	},
+	"augment": {
+		rules:  globalPathHome + ".augment/rules",
+		skills: globalPathHome + ".augment/skills",
+	},
 }
 
 // globalTargetNames returns every target sync --global supports, sorted.
@@ -58,14 +168,44 @@ func globalTargetNames() []string {
 	return out
 }
 
-// base returns the absolute config directory for the target.
-func (g globalTarget) base(home string) string {
-	if g.xdg != "" {
+// globalPath resolves one table path against the user home.
+func globalPath(home, p string) string {
+	if rest, ok := strings.CutPrefix(p, globalPathXDG); ok {
 		root := os.Getenv("XDG_CONFIG_HOME")
 		if root == "" {
 			root = filepath.Join(home, ".config")
 		}
-		return filepath.Join(root, g.xdg)
+		return filepath.Join(root, filepath.FromSlash(rest))
 	}
-	return filepath.Join(home, g.dir)
+	return filepath.Join(home, filepath.FromSlash(strings.TrimPrefix(p, globalPathHome)))
+}
+
+// trees returns the target's managed directory surfaces, resolved.
+// Everything under one is owned by sync --global and swept when the
+// source spec goes away.
+func (g globalTarget) trees(home string) []string {
+	var out []string
+	for _, p := range []string{g.skills, g.rules} {
+		if p != "" {
+			out = append(out, globalPath(home, p))
+		}
+	}
+	return out
+}
+
+// files returns the target's single-file surfaces, resolved, including
+// the bridge script when it has one. Ownership of these is by exact
+// path, since each sits in a directory the tool also uses for its own
+// unmanaged configuration.
+func (g globalTarget) files(home string) []string {
+	var out []string
+	for _, p := range []string{g.instructions, g.hooks} {
+		if p != "" {
+			out = append(out, globalPath(home, p))
+		}
+	}
+	if g.bridge {
+		out = append(out, globalBridgePath(filepath.Dir(globalPath(home, g.hooks))))
+	}
+	return out
 }

--- a/internal/cli/global_targets_test.go
+++ b/internal/cli/global_targets_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -58,15 +59,16 @@ func TestGlobalTargets_TableInvariants(t *testing.T) {
 }
 
 func TestGlobalPath_ResolvesBothRoots(t *testing.T) {
+	home, cfg := t.TempDir(), t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", "")
-	if got, want := globalPath("/h", globalPathHome+".claude/CLAUDE.md"), "/h/.claude/CLAUDE.md"; got != want {
+	if got, want := globalPath(home, globalPathHome+".claude/CLAUDE.md"), filepath.Join(home, ".claude", "CLAUDE.md"); got != want {
 		t.Errorf("home path: got %q want %q", got, want)
 	}
-	if got, want := globalPath("/h", globalPathXDG+"zed/AGENTS.md"), "/h/.config/zed/AGENTS.md"; got != want {
+	if got, want := globalPath(home, globalPathXDG+"zed/AGENTS.md"), filepath.Join(home, ".config", "zed", "AGENTS.md"); got != want {
 		t.Errorf("xdg fallback: got %q want %q", got, want)
 	}
-	t.Setenv("XDG_CONFIG_HOME", "/cfg")
-	if got, want := globalPath("/h", globalPathXDG+"zed/AGENTS.md"), "/cfg/zed/AGENTS.md"; got != want {
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	if got, want := globalPath(home, globalPathXDG+"zed/AGENTS.md"), filepath.Join(cfg, "zed", "AGENTS.md"); got != want {
 		t.Errorf("xdg override: got %q want %q", got, want)
 	}
 }

--- a/internal/cli/global_targets_test.go
+++ b/internal/cli/global_targets_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/chemaclass/agnostic-ai/internal/adapters"
@@ -15,14 +16,25 @@ func TestGlobalTargets_TableInvariants(t *testing.T) {
 		if !known[name] {
 			t.Errorf("%s: global target is not a known adapter", name)
 		}
-		if g.dir == "" && g.xdg == "" {
-			t.Errorf("%s: no config directory", name)
+		surfaces := map[string]string{"instructions": g.instructions, "rules": g.rules, "skills": g.skills, "hooks": g.hooks}
+		var declared int
+		for kind, path := range surfaces {
+			if path == "" {
+				continue
+			}
+			declared++
+			if !strings.HasPrefix(path, globalPathHome) && !strings.HasPrefix(path, globalPathXDG) {
+				t.Errorf("%s: %s path %q has no root prefix", name, kind, path)
+			}
+			if strings.Contains(path, "\\") {
+				t.Errorf("%s: %s path %q must use forward slashes", name, kind, path)
+			}
 		}
-		if g.dir != "" && g.xdg != "" {
-			t.Errorf("%s: dir and xdg are mutually exclusive", name)
-		}
-		if g.instructions == "" && g.skills == "" && g.hooks == "" {
+		if declared == 0 {
 			t.Errorf("%s: listed with no user-level surface at all", name)
+		}
+		if g.instructions != "" && g.rules != "" {
+			t.Errorf("%s: rules dir is only for a target with no instructions file", name)
 		}
 		if g.hooks != "" && g.hooksFormat != "claude" && g.hooksFormat != "cursor" {
 			t.Errorf("%s: hooks file %q has no native schema", name, g.hooks)
@@ -42,5 +54,19 @@ func TestGlobalTargets_TableInvariants(t *testing.T) {
 		if g.hooks == "" || g.bridgeEvent == "" || g.bridgeKey == "" {
 			t.Errorf("%s: bridge needs a hooks file, a session-start event, and a context key", name)
 		}
+	}
+}
+
+func TestGlobalPath_ResolvesBothRoots(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if got, want := globalPath("/h", globalPathHome+".claude/CLAUDE.md"), "/h/.claude/CLAUDE.md"; got != want {
+		t.Errorf("home path: got %q want %q", got, want)
+	}
+	if got, want := globalPath("/h", globalPathXDG+"zed/AGENTS.md"), "/h/.config/zed/AGENTS.md"; got != want {
+		t.Errorf("xdg fallback: got %q want %q", got, want)
+	}
+	t.Setenv("XDG_CONFIG_HOME", "/cfg")
+	if got, want := globalPath("/h", globalPathXDG+"zed/AGENTS.md"), "/cfg/zed/AGENTS.md"; got != want {
+		t.Errorf("xdg override: got %q want %q", got, want)
 	}
 }

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -121,7 +121,11 @@ func runGlobalSync(cmd *cobra.Command, o globalSyncOptions) error {
 		return fmt.Errorf("marshal %s: %w", statePath, err)
 	}
 	writes = append(writes, globalWrite{statePath, append(stateData, '\n'), 0o644})
-	if err := preflightGlobalWrites(writes, old, next); err != nil {
+	var trees []string
+	for _, target := range targets {
+		trees = append(trees, globalTargets[target].trees(home)...)
+	}
+	if err := preflightGlobalWrites(writes, trees, old); err != nil {
 		return err
 	}
 	if o.check {
@@ -190,12 +194,17 @@ func buildGlobalWrites(home, source string, targets []string, intro []byte, b sp
 	for target, hooks := range old.Hooks {
 		next.Hooks[target] = cloneHookState(hooks)
 	}
-	// Strip every synced target's tree before emitting any of them: two
-	// targets can share one config directory, and stripping inside the
-	// loop would drop the earlier target's fresh entries.
+	// Drop every surface the synced targets own before emitting any of
+	// them, so a file the sources no longer produce is swept rather
+	// than kept alive by its own prior record. Targets left out of this
+	// run keep theirs. This runs before the emit loop because several
+	// targets share one skills directory.
 	for _, target := range targets {
-		base := globalTargets[target].base(home)
-		next.Files = removePathPrefix(next.Files, base+string(filepath.Separator))
+		g := globalTargets[target]
+		for _, tree := range g.trees(home) {
+			next.Files = removePathPrefix(next.Files, tree+string(filepath.Separator))
+		}
+		next.Files = removePaths(next.Files, g.files(home))
 	}
 	var writes []globalWrite
 	seen := map[string]int{}
@@ -221,24 +230,35 @@ func buildGlobalWrites(home, source string, targets []string, intro []byte, b sp
 	managed := globalStart + "\n" + body + "\n" + globalEnd
 	for _, target := range targets {
 		g := globalTargets[target]
-		base := g.base(home)
 		if g.instructions != "" {
-			path := filepath.Join(base, g.instructions)
+			path := globalPath(home, g.instructions)
 			merged, err := mergeGlobalBlock(path, managed)
 			if err != nil {
 				return nil, next, err
 			}
-			// Never create an empty instructions file for a user who
-			// authored no global instructions and no global rules.
-			if merged != "" || fileExists(path) {
+			// An empty merge means no global instructions, no global
+			// rules, and no user text left around the managed block.
+			// Emit nothing so the file is never seeded, and so one
+			// already recorded is swept instead of left empty.
+			if merged != "" {
 				if err := add(path, []byte(merged), 0o644); err != nil {
 					return nil, next, err
 				}
 			}
 		}
+		if g.rules != "" {
+			dir := globalPath(home, g.rules)
+			for _, rule := range b.Rules {
+				out := filepath.Join(dir, rule.Name+".md")
+				if err := add(out, []byte(strings.TrimSpace(rule.Body)+"\n"), 0o644); err != nil {
+					return nil, next, err
+				}
+			}
+		}
 		if g.skills != "" {
+			dir := globalPath(home, g.skills)
 			for _, skill := range b.Skills {
-				if err := addGlobalSkill(filepath.Join(base, g.skills, skill.Name), skill.Path, add); err != nil {
+				if err := addGlobalSkill(filepath.Join(dir, skill.Name), skill.Path, add); err != nil {
 					return nil, next, err
 				}
 			}
@@ -247,15 +267,15 @@ func buildGlobalWrites(home, source string, targets []string, intro []byte, b sp
 			continue
 		}
 		next.Hooks[target] = map[string][]any{}
+		path := globalPath(home, g.hooks)
 		hooks := b.Hooks
 		if g.bridge && body != "" {
-			bridge, command, script, mode := globalContextBridge(base, body, g.bridgeKey)
+			bridge, command, script, mode := globalContextBridge(filepath.Dir(path), body, g.bridgeKey)
 			if err := add(bridge, []byte(script), mode); err != nil {
 				return nil, next, err
 			}
 			hooks = append(append([]spec.Entry{}, hooks...), spec.Entry{Meta: map[string]any{"event": g.bridgeEvent, "command": command}})
 		}
-		path := filepath.Join(base, g.hooks)
 		doc, err := mergeGlobalHooks(path, g.hooksFormat, hooks, old.Hooks[target], next.Hooks[target])
 		if err != nil {
 			return nil, next, err
@@ -439,32 +459,40 @@ func globalUserHome() (string, error) {
 	return home, nil
 }
 
+// globalBridgePath returns the managed context-bridge script path for a
+// target whose hooks file lives in base.
+func globalBridgePath(base string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(base, "hooks", "agnostic-ai-global-context.ps1")
+	}
+	return filepath.Join(base, "hooks", "agnostic-ai-global-context.sh")
+}
+
 func globalContextBridge(base, body, key string) (path, command, script string, mode fs.FileMode) {
 	payload := `{` + jsonString(key) + `:` + jsonString(body) + `}`
+	path = globalBridgePath(base)
 	if runtime.GOOS == "windows" {
-		path = filepath.Join(base, "hooks", "agnostic-ai-global-context.ps1")
 		command = `powershell -NoProfile -ExecutionPolicy Bypass -File "` + strings.ReplaceAll(path, `"`, `\"`) + `"`
 		script = "$payload = '" + strings.ReplaceAll(payload, "'", "''") + "'\r\n[Console]::Out.WriteLine($payload)\r\n"
 		return path, command, script, 0o644
 	}
-	path = filepath.Join(base, "hooks", "agnostic-ai-global-context.sh")
 	return path, path, "#!/bin/sh\nprintf '%s\\n' " + shellQuote(payload) + "\n", 0o755
 }
 
-func preflightGlobalWrites(writes []globalWrite, old, next globalState) error {
+func preflightGlobalWrites(writes []globalWrite, trees []string, old globalState) error {
 	owned := map[string]bool{}
 	for _, p := range old.Files {
 		owned[p] = true
 	}
 	for _, w := range writes {
-		if strings.Contains(w.path, string(filepath.Separator)+"skills"+string(filepath.Separator)) && !owned[w.path] {
+		if inManagedTree(w.path, trees) && !owned[w.path] {
 			if filepath.Base(w.path) == "SKILL.md" {
 				if _, err := os.Stat(filepath.Dir(w.path)); err == nil {
 					return fmt.Errorf("%s: unmanaged global skill collision", filepath.Dir(w.path))
 				}
 			}
 			if _, err := os.Stat(w.path); err == nil {
-				return fmt.Errorf("%s: unmanaged global skill collision", w.path)
+				return fmt.Errorf("%s: unmanaged global spec collision", w.path)
 			}
 		}
 		if info, err := os.Lstat(w.path); err == nil && info.Mode()&os.ModeSymlink != 0 {
@@ -474,6 +502,17 @@ func preflightGlobalWrites(writes []globalWrite, old, next globalState) error {
 	return nil
 }
 
+// inManagedTree reports whether path sits under one of the directory
+// surfaces sync --global owns for the targets in this run.
+func inManagedTree(path string, trees []string) bool {
+	for _, tree := range trees {
+		if strings.HasPrefix(path, tree+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 func cloneHookState(in map[string][]any) map[string][]any {
 	out := map[string][]any{}
 	for k, v := range in {
@@ -481,6 +520,20 @@ func cloneHookState(in map[string][]any) map[string][]any {
 	}
 	return out
 }
+func removePaths(paths, drop []string) []string {
+	unwanted := map[string]bool{}
+	for _, p := range drop {
+		unwanted[p] = true
+	}
+	out := paths[:0]
+	for _, p := range paths {
+		if !unwanted[p] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 func removePathPrefix(paths []string, prefix string) []string {
 	out := paths[:0]
 	for _, p := range paths {

--- a/internal/cli/sync_global_test.go
+++ b/internal/cli/sync_global_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ func TestSyncGlobal_WorksOutsideProjectAndPreservesNativeText(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	source := filepath.Join(home, "source")
 	mustWriteGlobalTest(t, filepath.Join(source, "AGNOSTIC_AI.md"), "Shared instructions\n")
 	mustWriteGlobalTest(t, filepath.Join(source, "rules", "safe.md"), "---\nname: safe\n---\nBe safe.\n")
@@ -70,6 +72,7 @@ func TestSyncGlobal_PreflightRejectsUnmanagedSkillBeforeWrites(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	mustWriteGlobalTest(t, filepath.Join(home, "source", "AGNOSTIC_AI.md"), "new\n")
 	mustWriteGlobalTest(t, filepath.Join(home, "source", "skills", "review", "SKILL.md"), "---\nname: review\n---\nmanaged\n")
 	mustWriteGlobalTest(t, filepath.Join(home, ".cursor", "skills", "review", "SKILL.md"), "unmanaged\n")
@@ -90,6 +93,7 @@ func TestSyncGlobal_RejectsScopedRuleAndUnsupportedFlags(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	mustWriteGlobalTest(t, filepath.Join(home, "source", "rules", "backend", "safe.md"), "---\nname: safe\n---\nSafe.\n")
 	root := NewRootCmd("test")
 	root.SetArgs([]string{"sync", "--global"})
@@ -109,6 +113,7 @@ func TestSyncGlobal_PreservesAndRemovesOnlyManagedHooks(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	sourceHook := filepath.Join(home, "source", "hooks", "notify.yaml")
 	mustWriteGlobalTest(t, sourceHook, "name: notify\nevent: sessionStart\ncommand: managed-command\n")
 	mustWriteGlobalTest(t, filepath.Join(home, ".cursor", "hooks.json"), "{\n  \"version\": 1,\n  \"theme\": \"dark\",\n  \"hooks\": {\"sessionStart\": [{\"command\": \"user-command\"}]}\n}\n")
@@ -147,5 +152,139 @@ func mustWriteGlobalTest(t *testing.T, path, body string) {
 	}
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSyncGlobal_WritesEachTargetsOwnNativePaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	source := filepath.Join(home, "source")
+	mustWriteGlobalTest(t, filepath.Join(source, "AGNOSTIC_AI.md"), "Shared instructions\n")
+	mustWriteGlobalTest(t, filepath.Join(source, "rules", "safe.md"), "---\nname: safe\n---\nBe safe.\n")
+	mustWriteGlobalTest(t, filepath.Join(source, "skills", "review", "SKILL.md"), "---\nname: review\ndescription: Review code\n---\nReview it.\n")
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sync --global: %v", err)
+	}
+
+	// One representative of every shape in the table: a home-rooted
+	// instructions file, an XDG-rooted one, a non-AGENTS.md filename,
+	// the shared cross-tool skills tree, a target-private skills tree,
+	// and the rules directory used where a vendor documents no
+	// user-level instructions file.
+	instructions := map[string]string{
+		"codex": filepath.Join(home, ".codex", "AGENTS.md"),
+		"zed":   filepath.Join(home, ".config", "zed", "AGENTS.md"),
+		"goose": filepath.Join(home, ".config", "goose", ".goosehints"),
+		"kiro":  filepath.Join(home, ".kiro", "steering", "AGENTS.md"),
+	}
+	for target, path := range instructions {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: %v", target, err)
+			continue
+		}
+		if !strings.Contains(string(data), "Shared instructions") || !strings.Contains(string(data), "Be safe") {
+			t.Errorf("%s: %s missing managed instructions:\n%s", target, path, data)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".agents", "skills", "review", "SKILL.md"),
+		filepath.Join(home, ".cline", "skills", "review", "SKILL.md"),
+		filepath.Join(home, ".config", "opencode", "skills", "review", "SKILL.md"),
+		filepath.Join(home, ".augment", "rules", "safe.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Error(err)
+		}
+	}
+	// Augment documents no user-level instructions file, so its rules
+	// must not land as one.
+	if _, err := os.Stat(filepath.Join(home, ".augment", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("wrote an instructions file for a target that documents none")
+	}
+	// A target with no documented user-level hooks surface gets no
+	// hooks file invented for it.
+	if _, err := os.Stat(filepath.Join(home, ".factory", "hooks.json")); !os.IsNotExist(err) {
+		t.Error("invented a hooks file for a target with no documented user-level schema")
+	}
+
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--check"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("check after full sync: %v", err)
+	}
+}
+
+func TestSyncGlobal_SharedPathIsWrittenOnce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "AGNOSTIC_AI.md"), "Shared instructions\n")
+
+	root := NewRootCmd("test")
+	// cline and warp both read ~/.agents/AGENTS.md.
+	root.SetArgs([]string{"sync", "--global", "--only", "cline,warp", "--dry-run"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(home, ".agents", "AGENTS.md")
+	if got := strings.Count(out.String(), "dry-run: write "+shared+"\n"); got != 1 {
+		t.Errorf("shared instructions path written %d times, want 1:\n%s", got, out.String())
+	}
+}
+
+func TestSyncGlobal_RejectsTargetWithNoUserLevelSurface(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	mustWriteGlobalTest(t, filepath.Join(home, "source", "AGNOSTIC_AI.md"), "Shared instructions\n")
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "-t", "jules"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unsupported target \"jules\"") {
+		t.Fatalf("want unsupported-target error, got %v", err)
+	}
+}
+
+func TestSyncGlobal_SweepsAnInstructionsFileAfterItsSourceIsGone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	intro := filepath.Join(home, "source", "AGNOSTIC_AI.md")
+	mustWriteGlobalTest(t, intro, "Shared instructions\n")
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--only", "codex"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); err != nil {
+		t.Fatalf("first sync wrote no instructions file: %v", err)
+	}
+	if err := os.Remove(intro); err != nil {
+		t.Fatal(err)
+	}
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--only", "codex"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Errorf("managed instructions file survived its source: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`sync --global` shipped in #682 covering Claude Code and Cursor. This extends it to every target whose vendor documents a user-level surface: **22 of 25**.

A fresh target audit (2026-09-07) checked all 23 remaining tools against live vendor docs. Twenty document an auto-loaded home instructions file, a home skills tree, or both. Three document nothing usable at user scope.

## Coverage

| | Targets |
|---|---|
| Instructions + skills | codex, gemini, qoder, copilot, cline, windsurf, amp, zed, warp, opencode, antigravity, junie, kiro, crush, factory, kilo, goose |
| Skills only | openhands, trae |
| Rules dir + skills | augment |
| Already covered | claude, cursor |
| Excluded by verdict | aider, continue, jules |

Hooks reach five targets. Claude Code, Codex, Gemini, and Qoder all document the same Claude-style `{"hooks": {"<Event>": [{"matcher", "hooks": [...]}]}}` shape at user scope, so one renderer serves them. Cursor keeps its own.

## Decisions worth reviewing

**Rules inline, except for Augment.** Global rules go into the instructions file under the managed block, matching the project tier. Augment gets `~/.augment/rules/<name>.md` instead, because the vendor documents no user-level instructions file for the CLI (`~/.augment/user-guidelines.md` is VS Code only) and states that rules there are "always treated as `always_apply`", which is what a global rule already is.

**Seventeen targets are declined for hooks with a stated reason, not for lack of a surface.** Factory keys `hooks.json` directly by event with no wrapper. Augment measures `timeout` in milliseconds and requires a script extension. Copilot uses `version: 1`, camelCase events, and `timeoutSec`. Cascade uses snake_case events with no matcher. Antigravity nests events under a named hook object. Crush supports `PreToolUse` alone. Goose needs a wrapping plugin directory plus a manifest. Junie's are Early Access. Kiro uses a `{"version": "v1", "hooks": [...]}` array. Amp, OpenCode, and Cline expose hooks only as TypeScript plugin modules. #629 tracks the same schemas at project tier; doing them there and here together is the right shape, not a rushed second renderer now.

**Three exclusions.** Aider reaches a home instructions file only through a `read:` entry in `~/.aider.conf.yml`, never automatically. Continue's one documented home surface is the `rules:` list inside the `config.yaml` Continue itself rewrites. Jules's CLI reference documents no config file and no home path.

**Two roots per target where the vendor splits them.** Kilo Code reads instructions from `~/.config/kilo/` but skills from `~/.kilo/`. Goose reads hints from `~/.config/goose/` but skills from `~/.agents/`. Table paths therefore carry their own root prefix (`home:` or `xdg:`) instead of hanging off one base directory. `xdg:` honors `XDG_CONFIG_HOME`.

**Shared paths write once.** `~/.agents/skills/` is read by seven targets, `~/.agents/AGENTS.md` by two, `~/.gemini/GEMINI.md` by two. Identical bytes dedupe to one write; differing bytes are a hard error naming the path.

## Also in this PR

Ownership is now swept per surface rather than per config directory. Before, a single file was re-recorded on every run and so could never be swept once its source went away, and `--only` on a target sharing a directory could drop another target's records. A target whose instructions body and rules are both empty now gets no file, and one already recorded is removed rather than left empty.

## Test plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean, `git diff --check` clean
- [x] Real run in a throwaway `HOME`: 22 targets, 36 files, correct native paths, `~/.agents/skills/` written once, no invented hooks files
- [x] `sync --global --check` clean immediately after, so the run is idempotent
- [x] New tests: per-target native paths, shared-path single write, unsupported-target rejection, stale single-file sweep, and `XDG_CONFIG_HOME` resolution

## Docs

`docs/user/targets.md` gains the full 22-row global table plus the exclusions, the shared paths, and the declined hook schemas with their reasons. `docs/user/configuration.md`, `docs/user/cli-reference.md`, `README.md`, and `CHANGELOG.md` follow.

Follow-up to #682 and #683.