### PR TITLE
fix(sync): keep the trailing newline of preserved user text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 ### Fixed
 
 - `sync --global` no longer seeds an empty hooks or instructions file into a home directory that had none, and now fails with a named path when two targets resolve to the same global file with different content (#680).
+- `sync --global` keeps the trailing newline of user text it preserves. Stripping the managed block from an instructions file used to hand the file back without its final newline (#680).
 - Kiro's adapter doc and `docs/user/targets.md` now note that `/docs/tools/` (2026-08-21) tables the agent `tools` category vocabulary differently from `/docs/custom-agents/configuration-reference/` (2026-08-04): `spec` and `context` replace `todo_list` and a standalone `knowledge`. This adapter still cites configuration-reference and only ever emits the four categories both pages agree on, so behavior is unchanged (#675).
 - Antigravity's adapter doc and `docs/user/targets.md` drop a stale "stays unconfirmed" note on whether the IDE executes its documented hooks. The vendor's own hook payload confirms it does; that no longer blocks adding the surface, tracked in #629 (#675).
 

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -333,7 +333,12 @@ func mergeGlobalBlock(path, managed string) (string, error) {
 	}
 	body = strings.TrimSpace(body)
 	if strings.TrimSpace(managed) == globalStart+"\n\n"+globalEnd {
-		return body, nil
+		if body == "" {
+			return "", nil
+		}
+		// The file is now the user's text alone. Keep it a well-formed
+		// text file rather than handing it back without its newline.
+		return body + "\n", nil
 	}
 	if body != "" {
 		body += "\n\n"

--- a/internal/cli/sync_global_test.go
+++ b/internal/cli/sync_global_test.go
@@ -288,3 +288,36 @@ func TestSyncGlobal_SweepsAnInstructionsFileAfterItsSourceIsGone(t *testing.T) {
 		t.Errorf("managed instructions file survived its source: %v", err)
 	}
 }
+
+func TestSyncGlobal_KeepsTheTrailingNewlineOfPreservedUserText(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	intro := filepath.Join(home, "source", "AGNOSTIC_AI.md")
+	mustWriteGlobalTest(t, intro, "Shared instructions\n")
+	mustWriteGlobalTest(t, filepath.Join(home, ".claude", "CLAUDE.md"), "Personal notes.\n")
+
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--only", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(intro); err != nil {
+		t.Fatal(err)
+	}
+	root = NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--only", "claude"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != "Personal notes.\n" {
+		t.Errorf("preserved user text = %q, want %q", got, "Personal notes.\n")
+	}
+}


### PR DESCRIPTION
## Summary

Found during the pre-release regression pass on `sync --global`.

When the managed block is stripped from a global instructions file (every global source removed, or the target dropped from the run), the user's remaining text was returned trimmed. So a file agnostic-ai does not own the content of came back without its final newline.

Reproduced in a throwaway `HOME`: `~/.claude/CLAUDE.md` holding `Personal notes.\n` became `Personal notes.` with no newline.

An empty result still returns empty, so a file with nothing left in it is swept rather than written as a lone newline.

## Test plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`, `gofmt -l .` clean, `git diff --check` clean
- [x] New `TestSyncGlobal_KeepsTheTrailingNewlineOfPreservedUserText`: sync, remove the source, sync again, assert the file is byte-identical to what the user wrote

Follow-up to #684.