### PR TITLE
fix(emit): stop parallel sync racing on a shared directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- `sync --jobs` no longer fails intermittently on a directory two adapters share. Codex prunes its legacy `.agents/agents/` once the last `*.toml` is swept, which raced antigravity's write of `.agents/agents/<name>.md` into the same directory: the run failed with `no such file or directory` on macOS and Linux, or `The directory is not empty` on Windows. A write now recreates a parent the prune removed, and the prune accepts a directory another target has just written into.
 - Kiro's adapter doc and `docs/user/targets.md` now note that `/docs/tools/` (2026-08-21) tables the agent `tools` category vocabulary differently from `/docs/custom-agents/configuration-reference/` (2026-08-04): `spec` and `context` replace `todo_list` and a standalone `knowledge`. This adapter still cites configuration-reference and only ever emits the four categories both pages agree on, so behavior is unchanged (#675).
 - Antigravity's adapter doc and `docs/user/targets.md` drop a stale "stays unconfirmed" note on whether the IDE executes its documented hooks. The vendor's own hook payload confirms it does; that no longer blocks adding the surface, tracked in #629 (#675).
 

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -333,6 +334,28 @@ func mkdirAll(dir string, perm os.FileMode) error {
 	return err
 }
 
+// writeFileAt writes content to path, recreating the parent directory
+// when a concurrent prune removed it between mkdirAll and the write.
+//
+// `sync --jobs` runs one target's empty-directory prune alongside
+// another target's write into the same shared directory. Codex sweeps
+// its legacy `.agents/agents/*.toml` and prunes the directory once the
+// last one is gone, while antigravity writes `.agents/agents/<name>.md`
+// into it. Observed as `open .agents/agents/agent-0.md: no such file or
+// directory` on macOS. The prune is correct and the write is correct;
+// only their interleaving is wrong, and recreating the parent is the
+// cheap half of that fix. See removeEmptyDirs for the other half.
+func writeFileAt(path, content string, mode os.FileMode) error {
+	err := os.WriteFile(path, []byte(content), mode)
+	if err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if mkErr := mkdirAll(filepath.Dir(path), dirPerm); mkErr != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), mode)
+}
+
 func (s *Session) writeFileWithMode(path, content string, mode os.FileMode, dryRun bool) error {
 	s.mu.Lock()
 	capturing := s.capturing
@@ -403,7 +426,7 @@ func (s *Session) writeFileWithMode(path, content string, mode os.FileMode, dryR
 				return fmt.Errorf("backup %s: %w", path, err)
 			}
 		}
-		if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		if err := writeFileAt(path, content, mode); err != nil {
 			return fmt.Errorf("write %s: %w", path, err)
 		}
 		s.mu.Lock()
@@ -433,7 +456,7 @@ func (s *Session) writeFileWithMode(path, content string, mode os.FileMode, dryR
 			}
 		}
 	}
-	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+	if err := writeFileAt(path, content, mode); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
@@ -621,7 +644,11 @@ func removeEmptyDirs(dir string) error {
 		if len(entries) > 0 {
 			continue
 		}
-		if err := os.Remove(dirs[i]); err != nil && !IsAbsent(err) {
+		// A concurrent write from another target can land between the
+		// ReadDir above and this Remove, and then the directory is no
+		// longer ours to prune. Windows reports that as "The directory
+		// is not empty"; treat it as the success it effectively is.
+		if err := os.Remove(dirs[i]); err != nil && !IsAbsent(err) && !errors.Is(err, syscall.ENOTEMPTY) {
 			return fmt.Errorf("remove %s: %w", dirs[i], err)
 		}
 	}

--- a/internal/adapters/internal/emit/emit_test.go
+++ b/internal/adapters/internal/emit/emit_test.go
@@ -227,6 +227,34 @@ func TestRemoveGeneratedTree_PreservesUserFilesAndTheirDirs(t *testing.T) {
 	}
 }
 
+// sync --jobs runs one target's empty-directory prune alongside another
+// target's write into the same shared directory (codex sweeping its
+// legacy `.agents/agents/*.toml` next to antigravity's `<name>.md`).
+// The write used to fail outright on the pruned parent.
+func TestWriteFile_SurvivesAConcurrentPruneOfItsParent(t *testing.T) {
+	sess := NewSession()
+	dir := t.TempDir()
+	shared := filepath.Join(dir, "agents", "agents")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Stand in for the prune landing between mkdirAll and the write.
+	if err := os.Remove(shared); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(shared, "agent-0.md")
+	if err := sess.WriteFile(path, "body\n", false); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "body\n" {
+		t.Errorf("content = %q, want %q", got, "body\n")
+	}
+}
+
 func TestRemoveGeneratedTree_MissingDirIsNoOp(t *testing.T) {
 	sess := NewSession()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Found by the pre-release regression pass. Two CI runs failed within an hour on unrelated diffs, one macOS and one Windows, both in `.agents/agents/`:

```
macos:   antigravity: write .agents/agents/agent-0.md: open .agents/agents/agent-0.md: no such file or directory
windows: codex: remove .agents/agents: remove .agents/agents: The directory is not empty.
```

Not a flake. Codex sweeps its legacy `.agents/agents/*.toml` and prunes the directory once the last one is gone. Antigravity writes `.agents/agents/<name>.md` into that same directory. `sync --jobs` runs them concurrently, and the two interleavings produce exactly the two errors above:

- The prune removes the directory after antigravity's `mkdirAll` but before its `open`, so the write fails on a parent that no longer exists.
- Antigravity's file lands between the prune's `ReadDir` (empty) and its `os.Remove`, so the remove returns `ENOTEMPTY` and the run aborts.

The existing comment on `RemoveGeneratedTreeExt` already names this directory as the one shared sweep, and #526 already added a bounded `mkdirAll` retry for races under this same `.agents/` parent. This is the next edge of the same problem.

## Fix

Both halves are correct in isolation, so neither behavior is removed. Each is made tolerant of the other:

- A content write that fails with `fs.ErrNotExist` recreates the parent through the existing `mkdirAll` retry and writes once more. Both write sites route through one `writeFileAt` helper.
- `removeEmptyDirs` treats `syscall.ENOTEMPTY` like `IsAbsent`: another target owns the directory now, so there is nothing left to prune.

`TestEmit_LegacyAgentSweepPreservesSharedAgentsRoot` still passes, so the legacy directory is still pruned when nothing else claims it. An earlier attempt that simply skipped pruning for extension-scoped sweeps was dropped for breaking that.

## Test plan

- [x] `go test -race ./... -count=1`
- [x] `go vet ./...`, `gofmt -l .` clean, `git diff --check` clean
- [x] `TestSync_ParallelEmission*` run 12 times back to back, no failures
- [x] Windows cross-build plus `go test -c` for the emit package, since one of the two faces is Windows-only
- [x] New `TestWriteFile_SurvivesAConcurrentPruneOfItsParent`: remove the parent between the mkdir and the write, assert the file lands with the right bytes