### PR TITLE
fix(sync): remove a global hooks file with nothing left in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- `sync --global` removes a hooks file it has nothing left to put in, instead of leaving a `{"hooks": {}}` shell in the tool's config directory. A file holding any other key is kept and only the managed entries come out (#680).
 - `sync --jobs` no longer fails intermittently on a directory two adapters share. Codex prunes its legacy `.agents/agents/` once the last `*.toml` is swept, which raced antigravity's write of `.agents/agents/<name>.md` into the same directory: the run failed with `no such file or directory` on macOS and Linux, or `The directory is not empty` on Windows. A write now recreates a parent the prune removed, and the prune accepts a directory another target has just written into.
 - Kiro's adapter doc and `docs/user/targets.md` now note that `/docs/tools/` (2026-08-21) tables the agent `tools` category vocabulary differently from `/docs/custom-agents/configuration-reference/` (2026-08-04): `spec` and `context` replace `todo_list` and a standalone `knowledge`. This adapter still cites configuration-reference and only ever emits the four categories both pages agree on, so behavior is unchanged (#675).
 - Antigravity's adapter doc and `docs/user/targets.md` drop a stale "stays unconfirmed" note on whether the IDE executes its documented hooks. The vendor's own hook payload confirms it does; that no longer blocks adding the surface, tracked in #629 (#675).

--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -411,7 +411,17 @@ func mergeGlobalHooks(path, format string, entries []spec.Entry, previous map[st
 			next[event] = append(next[event], item)
 		}
 	}
-	doc["hooks"] = hooks
+	if len(hooks) > 0 {
+		doc["hooks"] = hooks
+	} else {
+		delete(doc, "hooks")
+	}
+	// Nothing of ours left and nothing of the user's either: drop the
+	// file rather than leave a `{"hooks": {}}` shell behind. The
+	// version key below is ours too, so it is not counted as content.
+	if len(doc) == 0 {
+		return nil, nil
+	}
 	if format == "cursor" {
 		doc["version"] = float64(1)
 	}

--- a/internal/cli/sync_global_test.go
+++ b/internal/cli/sync_global_test.go
@@ -321,3 +321,44 @@ func TestSyncGlobal_KeepsTheTrailingNewlineOfPreservedUserText(t *testing.T) {
 		t.Errorf("preserved user text = %q, want %q", got, "Personal notes.\n")
 	}
 }
+
+func TestSyncGlobal_DropsAHooksFileThatHasNothingLeftInIt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGNOSTIC_AI_HOME", filepath.Join(home, "source"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	hook := filepath.Join(home, "source", "hooks", "notify.yaml")
+	mustWriteGlobalTest(t, hook, "name: notify\nevent: SessionStart\ncommand: managed-command\n")
+	// A second target keeps unrelated content in its hooks file, so the
+	// same teardown must leave that one in place.
+	mustWriteGlobalTest(t, filepath.Join(home, ".gemini", "settings.json"), "{\n  \"theme\": \"dark\"\n}\n")
+
+	for _, pass := range []string{"create", "teardown"} {
+		if pass == "teardown" {
+			if err := os.Remove(hook); err != nil {
+				t.Fatal(err)
+			}
+		}
+		root := NewRootCmd("test")
+		root.SetArgs([]string{"sync", "--global", "--only", "claude,gemini"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("%s: %v", pass, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); !os.IsNotExist(err) {
+		data, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+		t.Errorf("empty hooks file left behind: %s", data)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".gemini", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings.json with unrelated keys was removed: %v", err)
+	}
+	if !strings.Contains(string(data), `"theme": "dark"`) {
+		t.Errorf("unrelated key lost:\n%s", data)
+	}
+	if strings.Contains(string(data), "managed-command") {
+		t.Errorf("managed hook survived its source:\n%s", data)
+	}
+}


### PR DESCRIPTION
## Summary

Last finding from the pre-release regression pass.

`sync --global` will not create a hooks file for a target with no hooks (#683). But once one existed, removing every hook spec left it behind as a shell:

```json
{
  "hooks": {}
}
```

Four files across `~/.claude/`, `~/.codex/`, `~/.cursor/`, and `~/.qoder/` in a full teardown. Harmless to the tools, inconsistent with the no-seed rule, and clutter in someone's home directory.

The file is now dropped when the merge leaves nothing in it. Cursor's `version` key is ours, so it does not count as content.

A file holding anything else keeps existing. Verified with a `settings.json` carrying `"theme": "dark"`: the file stays, the managed hook comes out, the theme is untouched.

## Test plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`, `gofmt -l .` clean, `git diff --check` clean
- [x] New `TestSyncGlobal_DropsAHooksFileThatHasNothingLeftInIt` covers both halves: the empty file goes, the one with an unrelated key stays
- [x] Re-ran the full-teardown scenario in a throwaway `HOME`: no leftover files