### PR TITLE
fix(sync): count Cursor's schema version as ours, not user content

### DIFF
--- a/internal/cli/sync_global.go
+++ b/internal/cli/sync_global.go
@@ -417,9 +417,15 @@ func mergeGlobalHooks(path, format string, entries []spec.Entry, previous map[st
 		delete(doc, "hooks")
 	}
 	// Nothing of ours left and nothing of the user's either: drop the
-	// file rather than leave a `{"hooks": {}}` shell behind. The
-	// version key below is ours too, so it is not counted as content.
-	if len(doc) == 0 {
+	// file rather than leave a shell behind. Cursor's schema version is
+	// ours as well, so an earlier run's copy of it is not user content.
+	remaining := len(doc)
+	if format == "cursor" {
+		if version, ok := doc["version"]; ok && version == float64(1) {
+			remaining--
+		}
+	}
+	if remaining == 0 {
 		return nil, nil
 	}
 	if format == "cursor" {

--- a/internal/cli/sync_global_test.go
+++ b/internal/cli/sync_global_test.go
@@ -341,15 +341,30 @@ func TestSyncGlobal_DropsAHooksFileThatHasNothingLeftInIt(t *testing.T) {
 			}
 		}
 		root := NewRootCmd("test")
-		root.SetArgs([]string{"sync", "--global", "--only", "claude,gemini"})
+		root.SetArgs([]string{"sync", "--global", "--only", "claude,cursor,gemini"})
 		if err := root.Execute(); err != nil {
 			t.Fatalf("%s: %v", pass, err)
 		}
 	}
 
-	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); !os.IsNotExist(err) {
-		data, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
-		t.Errorf("empty hooks file left behind: %s", data)
+	// Cursor keeps its bridge hook while instructions exist, so drop
+	// those too and sync once more to empty its file out.
+	if err := os.Remove(filepath.Join(home, "source", "AGNOSTIC_AI.md")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	root := NewRootCmd("test")
+	root.SetArgs([]string{"sync", "--global", "--only", "claude,cursor,gemini"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".claude", "settings.json"),
+		filepath.Join(home, ".cursor", "hooks.json"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			data, _ := os.ReadFile(path)
+			t.Errorf("%s left behind: %s", path, data)
+		}
 	}
 	data, err := os.ReadFile(filepath.Join(home, ".gemini", "settings.json"))
 	if err != nil {


### PR DESCRIPTION
## Summary

Follow-on to #688, caught re-running the teardown scenario against merged `main`.

#688 drops a global hooks file the merge leaves nothing in. Cursor's still survived:

```json
{
  "version": 1
}
```

The emptiness check ran against the file as read from disk, and `version` was already in there from the previous sync. agnostic-ai wrote that key itself, so it read as user content when it is not.

Cursor's `version: 1` is now excluded from the check. Any other key, and any other `version` value, still keeps the file.

A full teardown now leaves zero files: verified end to end in a throwaway `HOME` (22 targets, 40 files, then every source removed).

## Test plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`, `gofmt -l .` clean, `git diff --check` clean
- [x] `TestSyncGlobal_DropsAHooksFileThatHasNothingLeftInIt` extended to cursor, including the extra step its bridge hook needs (the bridge keeps a hook alive while instructions exist, so the instructions source has to go too)
- [x] Manual teardown against the built binary: 0 files left