### PR TITLE
ci: decouple the npm publish from package-manager pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,12 @@ jobs:
   npm:
     name: npm
     # The wrapper downloads release assets on install, so it can only publish
-    # once GoReleaser has uploaded them.
+    # once GoReleaser has uploaded them. It runs even when the GoReleaser job
+    # failed: assets upload before the Homebrew, Scoop, and winget pushes, so
+    # a package-manager token going stale must not also hold back npm. The
+    # asset check below is the real gate, rather than the job result.
     needs: goreleaser
+    if: always() && needs.goreleaser.result != 'cancelled' && needs.goreleaser.result != 'skipped'
     runs-on: ubuntu-latest
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -62,15 +66,47 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Require the release archives the wrapper downloads
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          assets=$(gh release view "${GITHUB_REF_NAME}" --json assets --jq '.assets[].name')
+          echo "$assets"
+          for want in \
+            agnostic-ai_darwin_amd64.tar.gz agnostic-ai_darwin_arm64.tar.gz \
+            agnostic-ai_linux_amd64.tar.gz agnostic-ai_linux_arm64.tar.gz \
+            agnostic-ai_windows_amd64.zip agnostic-ai_windows_arm64.zip \
+            checksums.txt; do
+            if ! grep -qx "$want" <<<"$assets"; then
+              echo "::error::release ${GITHUB_REF_NAME} is missing $want; not publishing to npm"
+              exit 1
+            fi
+          done
+
       - name: Version the package from the tag
         working-directory: npm
         run: npm version --no-git-tag-version "${GITHUB_REF_NAME#v}"
+
+      - name: Skip when this version is already on the registry
+        id: published
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          # `npm view` exits non-zero for a package that has never been
+          # published, which is the first-release case, not an error.
+          if npm view "agnostic-ai@${version}" version >/dev/null 2>&1; then
+            echo "::notice::agnostic-ai@${version} is already published; nothing to do"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Publish
         # Skipped until NPM_TOKEN exists, so a release never fails over it.
         # setup-node replaces an empty NODE_AUTH_TOKEN with a placeholder, so
         # test the secret-presence flag captured before setup instead.
-        if: env.NPM_TOKEN_CONFIGURED == 'true'
+        if: env.NPM_TOKEN_CONFIGURED == 'true' && steps.published.outputs.exists == 'false'
         working-directory: npm
         run: npm publish --access public
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -124,11 +124,14 @@ homebrew_casks:
   - name: agnostic-ai
     binaries:
       - agnostic-ai
+    # Matches scoop and winget above: without a token the cask is still
+    # built, just never pushed, so a fork or a local run still releases.
+    skip_upload: '{{ if isEnvSet "HOMEBREW_TAP_TOKEN" }}false{{ else }}true{{ end }}'
     repository:
       owner: Chemaclass
       name: homebrew-tap
       branch: master
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      token: '{{ envOrDefault "HOMEBREW_TAP_TOKEN" "" }}'
     directory: Casks
     homepage: https://github.com/Chemaclass/agnostic-ai
     description: Sync agent prompts, skills, rules, and hooks across AI coding tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ## [Unreleased]
 
+### Changed
+
+- The npm publish no longer rides on every package-manager push succeeding. Release archives upload before the Homebrew, Scoop, and winget steps, so one stale tap token used to hold back the npm release too. The npm job now gates on the release archives actually being present, and skips cleanly when that version is already on the registry, so a re-run is safe.
+
 ## v0.52.0 - 2026-09-07
 
 ### Added


### PR DESCRIPTION
## Summary

The npm publish is already wired into the release pipeline, but it is not yet automation you can trust. v0.52.0 showed both weak points.

**A stale tap token stopped the npm release.** GoReleaser uploads the release archives, *then* pushes to Homebrew, Scoop, and winget. The npm job declared `needs: goreleaser`, so when the Homebrew push failed on a 401 the npm job skipped, even though every archive it needs had already been uploaded and the GitHub Release was published.

**A re-run would have failed anyway.** `npm publish` on a version that already exists is a hard error, so re-running a partially failed release could not have recovered.

## Changes

`.github/workflows/release.yml`:

- The npm job runs whenever GoReleaser ran, rather than only when it fully succeeded. The real gate is a new step that requires all six platform archives plus `checksums.txt` to be present on the release. A build failure still stops npm; a package-manager token going stale no longer does.
- A version already on the registry is detected and skipped with a notice, so re-running a release is safe. `npm view` exits non-zero for a package that has never been published, which is the first-release case and is handled as "publish", not as an error.

`.goreleaser.yml`:

- `homebrew_casks` gains the `skip_upload` guard that `scoops` and `winget` already carry. Without a token the cask is built but not pushed, so a fork or a local run still releases. This does not paper over an *invalid* token: a 401 still fails the GoReleaser job and stays visible. It only stops an *absent* one from failing the release.

Deliberately not done: making the tap push non-fatal. A tap that silently stopped updating is worse than a red check. The decoupling above is what protects npm, and a bad tap token stays loud.

## Test plan

- [x] `goreleaser check` validates the config
- [x] Asset gate run against the real v0.52.0 release: passes with all seven assets present
- [x] Already-published check verified both ways against the live registry: a published version is detected (skip), an absent one is not (publish). First run of the control used a version that never existed, which is why it needed a second pass
- [x] `agnostic-ai@0.52.0` correctly reports as not yet published
- [x] Packed the wrapper at 0.52.0 and installed it from the tarball: npm 11 blocks the postinstall by default, the bin shim recovers on first run, downloads the darwin/arm64 archive from the v0.52.0 release, and `agnostic-ai --version` prints `0.52.0`

## Follow-ups

`docs/user/getting-started.md` still marks the npm row "(not published yet)". That flips once the package is actually on the registry, not before.

This does not retroactively fix v0.52.0: a re-run uses the workflow file from the tagged commit. To get v0.52.0 onto npm, either publish it by hand once, or let the next tag pick this up.