### PR TITLE
fix(emit): retry a pruned parent on EINVAL as well as ENOENT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Entry style: one line per change. Lead with what changed, not how. State the use
 
 ### Fixed
 
+- `sync --jobs` no longer fails intermittently with `invalid argument` when two targets share a directory. The write path recreated a concurrently pruned parent only on `no such file or directory`, but the same race raises `EINVAL` just as readily on macOS, which the retry then skipped. Both errnos now trigger the single recreate-and-retry (#701).
 - The generated entry-point body no longer offers `.aiexclude` as an example ignore file. That file belongs to Gemini Code Assist and agnostic-ai stopped writing it in #625; the example is now `.geminiignore`, which Gemini CLI actually reads. Prose only, in every target's entry-point file (#651).
 - Warp: sync now warns when a hand-authored `WARP.md` sits next to the `AGENTS.md` it just wrote. Warp reads `WARP.md` first when both exist, so every synced rule was reaching nowhere with no signal (#691).
 - Cursor skills promote the vendor-documented `icon` and `color` frontmatter fields to first-class keys, alongside `paths`, `disable-model-invocation`, and `metadata`. Both reached `.cursor/skills/<name>/SKILL.md` before only through `x-cursor`, so setting either at the top level silently did nothing (#694).

--- a/internal/adapters/internal/emit/emit.go
+++ b/internal/adapters/internal/emit/emit.go
@@ -334,6 +334,21 @@ func mkdirAll(dir string, perm os.FileMode) error {
 	return err
 }
 
+// parentGone reports whether err is the failure a concurrent prune of the
+// parent directory produces.
+//
+// Both errnos count. macOS raises EINVAL as readily as ENOENT when a path
+// component is being created or removed underneath the call, which is the
+// same pairing mkdirAll above already absorbs. Checking only ENOENT left
+// the EINVAL half of one race unhandled and surfaced as an intermittent
+// `open .agents/agents/reviewer.md: invalid argument` from sync (#701).
+//
+// Widening this cannot swallow a genuinely invalid path: writeFileAt
+// retries the write once and a real EINVAL comes straight back.
+func parentGone(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.EINVAL)
+}
+
 // writeFileAt writes content to path, recreating the parent directory
 // when a concurrent prune removed it between mkdirAll and the write.
 //
@@ -341,13 +356,13 @@ func mkdirAll(dir string, perm os.FileMode) error {
 // another target's write into the same shared directory. Codex sweeps
 // its legacy `.agents/agents/*.toml` and prunes the directory once the
 // last one is gone, while antigravity writes `.agents/agents/<name>.md`
-// into it. Observed as `open .agents/agents/agent-0.md: no such file or
-// directory` on macOS. The prune is correct and the write is correct;
+// into it. Observed as both `no such file or directory` and `invalid
+// argument` on macOS. The prune is correct and the write is correct;
 // only their interleaving is wrong, and recreating the parent is the
 // cheap half of that fix. See removeEmptyDirs for the other half.
 func writeFileAt(path, content string, mode os.FileMode) error {
 	err := os.WriteFile(path, []byte(content), mode)
-	if err == nil || !errors.Is(err, fs.ErrNotExist) {
+	if err == nil || !parentGone(err) {
 		return err
 	}
 	if mkErr := mkdirAll(filepath.Dir(path), dirPerm); mkErr != nil {

--- a/internal/adapters/internal/emit/emit_test.go
+++ b/internal/adapters/internal/emit/emit_test.go
@@ -1,9 +1,11 @@
 package emit
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -455,5 +457,33 @@ func TestStopCounting_WithoutStart_ReturnsZero(t *testing.T) {
 	sess := NewSession()
 	if n := sess.StopCounting(); n != 0 {
 		t.Fatalf("want 0 when not counting, got %d", n)
+	}
+}
+
+// The prune race surfaces as two different errnos, and only ENOENT was
+// handled: sync failed intermittently with `invalid argument` instead
+// (#701). EACCES is in the table because widening the guard must not
+// start swallowing a permission failure as a missing parent.
+func TestParentGone_CoversBothPruneErrnosAndNothingElse(t *testing.T) {
+	pathErr := func(e error) error {
+		return &os.PathError{Op: "open", Path: "agents/agents/reviewer.md", Err: e}
+	}
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"enoent", pathErr(syscall.ENOENT), true},
+		{"einval", pathErr(syscall.EINVAL), true},
+		{"eacces", pathErr(syscall.EACCES), false},
+		{"unrelated", errors.New("boom"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parentGone(c.err); got != c.want {
+				t.Errorf("parentGone(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Found by a CI failure on #695, a PR that changes no Go code. Closes #701.

## The failure

```
--- FAIL: TestSync_CodexLegacySweepKeepsAntigravityAgents (0.01s)
    sync_shared_agents_dir_test.go:40: sync: antigravity: write .agents/agents/reviewer.md:
      open .agents/agents/reviewer.md: invalid argument
```

`Test (macos-latest)`, run 34317473904. That PR's diff is eight files of site HTML, `og.png`, `robots.txt`, `sitemap.xml`, `llms.txt`, the Pages workflow and CHANGELOG. `main` was green on the parent commit, and 60 local runs of the `internal/cli` sync tests passed clean. So it is the race, not the diff.

## The asymmetry

`mkdirAll` names both errnos this race produces, and absorbs both:

> When both try to create that parent, one can come back with **EINVAL or ENOENT** instead of the EEXIST that MkdirAll knows how to absorb

`writeFileAt`, forty lines below, recognised only one:

```go
if err == nil || !errors.Is(err, fs.ErrNotExist) {
    return err
}
```

Its own comment says "Observed as `... no such file or directory` on macOS", which is the ENOENT half. The EINVAL half reached the same line, returned early, and the parent was never recreated.

So this was not an unknown failure mode. It was a documented one, handled in one of the two places it lands.

## The change

A named predicate, used by `writeFileAt`:

```go
func parentGone(err error) bool {
	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.EINVAL)
}
```

**This cannot mask a real EINVAL.** The retry runs once. A path that is genuinely invalid fails the second `os.WriteFile` with the same error, and it surfaces exactly as before. The only new behavior is one recreate-and-retry on a transient failure, which is what `mkdirAll` already does for the same race.

## What I checked and deliberately did not change

- **`IsAbsent`** (`emit.go:499`) also reads `errors.Is(err, fs.ErrNotExist)`. It keeps that meaning. It answers "is this thing absent", not "did a parent vanish underneath me", and widening it to EINVAL would make removal logic treat an invalid path as a successful delete. The two-occurrence grep is why the patch is line-scoped rather than a replace-all.
- **`removeEmptyDirs`** (`emit.go:651`) tolerates absent plus `ENOTEMPTY`. #701 asked whether it has the same gap. It does not, for the platforms CI covers: a concurrent write makes `rmdir` report `ENOTEMPTY` on macOS and Linux, and the Windows message the existing comment already names. POSIX permits `EEXIST` as an alternative, but nothing observed reports it here, so adding it would be defensive code with no evidence behind it. Left alone on purpose.

## Test plan

- [x] New table test `TestParentGone_CoversBothPruneErrnosAndNothingElse`, covering `nil`, ENOENT, EINVAL, EACCES and an unrelated error.
- [x] **Verified it catches the regression**: narrowing the predicate back to ENOENT-only fails the `einval` subtest, and only that subtest. A test that passes either way would not be worth keeping.
- [x] EACCES is in the table on purpose. Widening the guard must not start reading a permission failure as a missing parent.
- [x] The existing `TestWriteFile_SurvivesAConcurrentPruneOfItsParent` still covers the ENOENT path end to end.
- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` all clean, `gofmt` clean.

The race itself is timing-dependent, so no test reproduces the EINVAL interleaving directly. The predicate is where the bug was, and that is what the new test pins.
