### PR TITLE
docs(audit): fix Jules and Trae sources

### DIFF
--- a/.agnostic-ai/skills/target-audit/references/sources.md
+++ b/.agnostic-ai/skills/target-audit/references/sources.md
@@ -171,7 +171,7 @@ cost nobody again:
 ## trae
 
 - docs: https://docs.trae.ai/ide/rules · https://docs.trae.ai/ide/model-context-protocol · https://docs.trae.ai/ide/add-mcp-servers · https://docs.trae.ai/ide/skills · https://docs.trae.ai/ide/subagents · https://docs.trae.ai/ide/slash-commands · https://docs.trae.ai/ide/hook-configuration-reference · https://docs.trae.ai/ide/automate-actions-with-hooks · https://docs.trae.ai/ide/ignore-files
-- changelog: https://www.trae.ai/api/changelog (returns JSON; the docs site publishes no changelog page)
+- changelog: https://www.trae.ai/api/changelog (primary JSON feed, latest entry 2026-09-01) · https://docs.trae.ai/ide/changelog (documentation alternative, latest entry 2026-08-19; checked 2026-09-12)
 - watch: `docs.trae.ai/ide/mcp`, the old URL for the MCP page, now 302s
   to a marketing page; model-context-protocol (the MCP overview) and
   add-mcp-servers (the config how-to) are the two live ones. Confirm
@@ -231,7 +231,7 @@ cost nobody again:
 ## jules
 
 - docs: https://jules.google/docs
-- changelog: https://jules.google/docs (changelog section)
+- changelog: https://jules.google/docs/changelog/
 - watch: today AGENTS.md only; any per-file surface is new.
 
 ## goose

--- a/.github/skills/target-audit/references/sources.md
+++ b/.github/skills/target-audit/references/sources.md
@@ -171,7 +171,7 @@ cost nobody again:
 ## trae
 
 - docs: https://docs.trae.ai/ide/rules · https://docs.trae.ai/ide/model-context-protocol · https://docs.trae.ai/ide/add-mcp-servers · https://docs.trae.ai/ide/skills · https://docs.trae.ai/ide/subagents · https://docs.trae.ai/ide/slash-commands · https://docs.trae.ai/ide/hook-configuration-reference · https://docs.trae.ai/ide/automate-actions-with-hooks · https://docs.trae.ai/ide/ignore-files
-- changelog: https://www.trae.ai/api/changelog (returns JSON; the docs site publishes no changelog page)
+- changelog: https://www.trae.ai/api/changelog (primary JSON feed, latest entry 2026-09-01) · https://docs.trae.ai/ide/changelog (documentation alternative, latest entry 2026-08-19; checked 2026-09-12)
 - watch: `docs.trae.ai/ide/mcp`, the old URL for the MCP page, now 302s
   to a marketing page; model-context-protocol (the MCP overview) and
   add-mcp-servers (the config how-to) are the two live ones. Confirm
@@ -231,7 +231,7 @@ cost nobody again:
 ## jules
 
 - docs: https://jules.google/docs
-- changelog: https://jules.google/docs (changelog section)
+- changelog: https://jules.google/docs/changelog/
 - watch: today AGENTS.md only; any per-file surface is new.
 
 ## goose


### PR DESCRIPTION
Point Jules audits to its dated changelog and record Trae's documentation changelog as an alternative. Keep Trae's JSON API primary because its latest entry is newer.

[Jules's changelog](https://jules.google/docs/changelog/) is headed "Changelog"; `.agnostic-ai/skills/target-audit/references/sources.md:234` previously pointed to the documentation landing page. [Trae's changelog](https://docs.trae.ai/ide/changelog) has the same heading; line 174 incorrectly said that page did not exist.

Validation: `make preflight`, fresh-binary sync, and `sync --check` pass with Go 1.24.9. Generated skill references match their source.

Closes #776
